### PR TITLE
Fix requirements conversion in Windows setup script

### DIFF
--- a/run_setup.bat
+++ b/run_setup.bat
@@ -566,7 +566,7 @@ exit /b 0
 %PSH% "$in='%~1'; $out='%~2'; " ^
   "$lines=Get-Content $in | Where-Object { $_ -and $_ -notmatch '^\s*#' -and $_ -notmatch '^\s*-' }; " ^
   "$conv = foreach($l in $lines){ " ^
-  "  $m=$l -replace '\s*;.*$','' -replace '$begin:math:display$.*?$end:math:display$',''; " ^
+  "  $m=$l -replace '\s*;.*$','' -replace '\[.*?\]',''; " ^
   "  if($m -match '^\s*([A-Za-z0-9_.\-]+)\s*~=\s*([0-9]+)\.([0-9]+)(?:\.([0-9]+))?'){ " ^
   "    $pkg=$matches[1]; $maj=[int]$matches[2]; $min=[int]$matches[3]; $patch=$matches[4]; " ^
   "    $low= if($patch){\"$maj.$min.$patch\"} else {\"$maj.$min\"}; $up=\"$maj.\"+($min+1); " ^


### PR DESCRIPTION
## Summary
- fix regex placeholder in `:reqs_to_conda_specs` to strip extras like `[foo]` correctly

## Testing
- `cmd /c echo hi` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0d4750e0c832ab1d4962fc0fe8ec7