### PR TITLE
ci: cover fix branches and ignore bang in helper blocks

### DIFF
--- a/.github/workflows/batch-check.yml
+++ b/.github/workflows/batch-check.yml
@@ -2,7 +2,9 @@ name: Batch syntax/run check
 on:
   workflow_dispatch: {}
   push:
-    branches: [ main ]
+    branches: [ 'main', 'fix/**', 'feature/**' ]
+  pull_request:
+    branches: [ 'main' ]
 
 jobs:
   check:

--- a/tests/harness.ps1
+++ b/tests/harness.ps1
@@ -41,8 +41,14 @@ Write-Result "batch.delayed.off" "DisableDelayedExpansion present" $hasDisable @
 $hasEnable = ($Lines | Select-String -SimpleMatch "EnableDelayedExpansion").Count -gt 0
 Write-Result "batch.delayed.enable_absent" "EnableDelayedExpansion not present" (-not $hasEnable) @{}
 $bangHits = @()
+$inHere = $false
 for ($i=0; $i -lt $Lines.Count; $i++) {
   $ln = $Lines[$i]
+  if (-not $inHere -and $ln -match "@'") { $inHere = $true; continue }
+  if ($inHere) {
+    if ($ln -match "'@") { $inHere = $false }
+    continue
+  }
   if ($ln -match '^\s*(rem|echo)\b') { continue }
   if ($ln -like "*!*") { $bangHits += ("line {0}: {1}" -f ($i+1), $ln.Trim()) }
 }


### PR DESCRIPTION
## Summary
- trigger batch check on feature/fix branches and main PRs
- ignore exclamation marks inside generated helper scripts during static test

## Testing
- `pwsh tests/harness.ps1`
- `pwsh tests/harness.ps1`

------
https://chatgpt.com/codex/tasks/task_e_68c396bba18c832abd8dfee49b0cdd7d