### PR TITLE
fix(ci): stabilize batch test harness and surface errors

### DIFF
--- a/tests/harness.ps1
+++ b/tests/harness.ps1
@@ -21,8 +21,8 @@ $sha = (Get-FileHash -Algorithm SHA256 -LiteralPath $BatchPath).Hash
 Write-Result "file.hash" "SHA256 of run_setup.bat" $true @{ sha256 = $sha }
 $psBlocks = [regex]::Matches($AllText, 'call\s+:write_ps_file\s+"[^"]*emit_[^"]*\.ps1"\s+"@''(?s).*?''@"') | ForEach-Object { $_.Value }
 function Extract-InnerHereString([string]$Block) {
-  $outFile = ([regex]::Match($Block, '\$(?:OutFile|TmpPy)\s*=\s*''([^'']+\.py)''')).Groups[1].Value
-  $content = ([regex]::Match($Block, '\$(?:Content|code)\s*=\s*@''(?s)(.*?)''@')).Groups[1].Value
+  $outFile = ([regex]::Match($Block, "\$(?:OutFile|TmpPy)\s*=\s*'([^']+\.py)'")).Groups[1].Value
+  $content = ([regex]::Match($Block, "\$(?:Content|code)\s*=\s*@'(?s)(.*?)'@")).Groups[1].Value
   return @{ OutFile=$outFile; Content=$content }
 }
 $emitted = @()


### PR DESCRIPTION
## Summary
- adjust test harness regexes to properly extract helper scripts from batch here-strings
- relax/consolidate conda and VISA checks for stability
- remove trailing newline from tests/README_TESTS.txt per review feedback
- restore regex escaping in `Extract-InnerHereString` for correct helper extraction

## Testing
- `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/harness.ps1` *(fails: command not found)*
- `apt-get install -y powershell` *(fails: Unable to locate package powershell)*

------
https://chatgpt.com/codex/tasks/task_e_68c61d209d88832a8653b6085ed67350