### PR TITLE
fix(ci): stabilize batch test harness and surface errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,4 @@
+# AGENTS
+
+- Run tests via the PowerShell harness: `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/harness.ps1`.
+- Keep regex literals in PowerShell scripts single-quoted so `$` characters are treated literally.

--- a/tests/harness.ps1
+++ b/tests/harness.ps1
@@ -19,10 +19,18 @@ $Lines = Get-Content -LiteralPath $BatchPath -Encoding ASCII
 $AllText = [string]::Join("`n", $Lines)
 $sha = (Get-FileHash -Algorithm SHA256 -LiteralPath $BatchPath).Hash
 Write-Result "file.hash" "SHA256 of run_setup.bat" $true @{ sha256 = $sha }
-$psBlocks = [regex]::Matches($AllText, 'call\s+:write_ps_file\s+"[^"]*emit_[^"]*\.ps1"\s+"@''(?s).*?''@"') | ForEach-Object { $_.Value }
+$psBlocks = [regex]::Matches(
+  $AllText,
+  'call\s+:write_ps_file\s+"[^"]*emit_[^"]*\.ps1"\s+"@''.*?''@"',
+  [Text.RegularExpressions.RegexOptions]::Singleline
+) | ForEach-Object { $_.Value }
 function Extract-InnerHereString([string]$Block) {
-  $outFile = ([regex]::Match($Block, "\$(?:OutFile|TmpPy)\s*=\s*'([^']+\.py)'")).Groups[1].Value
-  $content = ([regex]::Match($Block, "\$(?:Content|code)\s*=\s*@'(?s)(.*?)'@")).Groups[1].Value
+  $outFile = ([regex]::Match($Block, '\$(?:OutFile|TmpPy)\s*=\s*''([^'']+\.py)''')).Groups[1].Value
+  $content = ([regex]::Match(
+    $Block,
+    '\$(?:Content|code)\s*=\s*@''(.*?)''@',
+    [Text.RegularExpressions.RegexOptions]::Singleline
+  )).Groups[1].Value
   return @{ OutFile=$outFile; Content=$content }
 }
 $emitted = @()


### PR DESCRIPTION
## Summary
- merge latest `main`
- document regex/test guidelines in AGENTS.md
- keep regex strings in `Extract-InnerHereString` single-quoted to avoid subexpression parsing
- use RegexOptions.Singleline for multi-line here-strings

## Testing
- ⚠️ `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/harness.ps1` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6259a5e40832ab0d420d1da3b4fcd