### PR TITLE
Fix/ci batch tests

### DIFF
--- a/tests/harness.ps1
+++ b/tests/harness.ps1
@@ -56,7 +56,7 @@ Write-Result "batch.bang.scan" "No '!' in live batch code lines" ($bangHits.Coun
 $badConda = @()
 for ($i=0; $i -lt $Lines.Count; $i++) {
   $ln = $Lines[$i]
-  if ($ln -match "^\s*call\s+`"%CONDA_BAT%`"\s+(create|install)\b") {
+  if ($ln -match '^\s*call\s+(?:(?:"?%[^%\s]*conda[^%\s]*%"?)|(?:"[^"]*conda\.bat"|[^\s]*conda\.bat))\s+(create|install)\b') {
     $window = ($ln + " " + ($(if ($i+1 -lt $Lines.Count) { $Lines[$i+1] } else { "" })) + " " + ($(if ($i+2 -lt $Lines.Count) { $Lines[$i+2] } else { "" })))
     if ($window -notmatch "--override-channels" -or $window -notmatch "-c\s+conda-forge") {
       $badConda += ("line {0}: {1}" -f ($i+1), $ln.Trim())


### PR DESCRIPTION
## Summary
- ensure run_setup.bat installs Miniconda in a known path and enforces conda-forge channel policy
- broaden harness conda scan to catch variable-based conda.bat calls
- guard missing conda.bat check to avoid false channel-policy hit

## Testing
- ⚠️ `pwsh -NoProfile -ExecutionPolicy Bypass -File tests/harness.ps1` (missing `pwsh`)

------
https://chatgpt.com/codex/tasks/task_e_68c7453aa3ec832ab841431b19759f9a