### PR TITLE
Use automerge token for PR failure commenter

### DIFF
--- a/.github/workflows/batch-check.yml
+++ b/.github/workflows/batch-check.yml
@@ -637,10 +637,12 @@ jobs:
           }
 
       - name: Distribute codex failure summary (PR comment)
-        if: failure() && github.event_name == 'pull_request' && secrets.AUTOMERGE_TOKEN
+        if: ${{ failure() && github.event_name == 'pull_request' && env.AUTOMERGE_TOKEN != '' }}
         uses: actions/github-script@v7
+        env:
+          AUTOMERGE_TOKEN: ${{ secrets.AUTOMERGE_TOKEN }}
         with:
-          github-token: ${{ secrets.AUTOMERGE_TOKEN }}
+          github-token: ${{ env.AUTOMERGE_TOKEN }}
           script: |
             const fs = require('fs');
             const path = 'codex_body.txt';


### PR DESCRIPTION
## Summary
- ensure the codex failure summary PR comment uses the maintainer PAT when available
- guard the commenter so it only runs on pull requests with the PAT configured

## Testing
- not run (workflow change only)

------
https://chatgpt.com/codex/tasks/task_e_68d824a1b108832aac5a637658c7dbda