### PR TITLE
Add CI self-test for single Python entry path

### DIFF
--- a/.github/workflows/batch-check.yml
+++ b/.github/workflows/batch-check.yml
@@ -91,7 +91,7 @@ jobs:
           & .\tests\selftests.ps1
           Get-Content -LiteralPath tests\~selftest_empty\~empty_bootstrap.log -Tail 60 -ErrorAction SilentlyContinue
 
-      - name: Self-test: single .py entry (CI-only)
+      - name: "Self-test: single .py entry (CI-only)"
         shell: pwsh
         run: |
           & tests\selfapps_single.ps1

--- a/tests/selfapps_single.ps1
+++ b/tests/selfapps_single.ps1
@@ -9,6 +9,10 @@ $resultsPath = Join-Path -Path $here -ChildPath '~test-results.ndjson'
 $entryRoot = Join-Path -Path $here -ChildPath '~entry1'
 $logName = '~entry1_bootstrap.log'
 $token = 'from-single'
+$repoRoot = Split-Path -Parent $here
+$bootstrapperName = 'run_setup.bat'
+$bootstrapperSrc = Join-Path -Path $repoRoot -ChildPath $bootstrapperName
+$bootstrapperDest = Join-Path -Path $entryRoot -ChildPath $bootstrapperName
 
 $record = [ordered]@{
     id = 'entry.single.direct'
@@ -32,6 +36,13 @@ try {
     ) -join "`n"
     Set-Content -LiteralPath $pyPath -Value $pySource -Encoding Ascii
 
+    if (Test-Path -LiteralPath $bootstrapperDest) {
+        Remove-Item -LiteralPath $bootstrapperDest -Force
+    }
+    if (Test-Path -LiteralPath $bootstrapperSrc) {
+        Copy-Item -LiteralPath $bootstrapperSrc -Destination $bootstrapperDest -Force
+    }
+
     $logPath = Join-Path -Path $entryRoot -ChildPath $logName
     if (Test-Path -LiteralPath $logPath) {
         Remove-Item -LiteralPath $logPath -Force
@@ -39,7 +50,7 @@ try {
 
     Push-Location -Path $entryRoot
     try {
-        cmd.exe /d /c "..\..\run_setup.bat *> $logName" | Out-Null
+        cmd.exe /d /c "run_setup.bat *> $logName" | Out-Null
     }
     finally {
         Pop-Location


### PR DESCRIPTION
## Summary
- add a CI-only PowerShell self-test that runs the bootstrapper against a single Python file
- record the result in the shared self-test NDJSON and reuse the existing summary step
- hook the new script into the batch-check workflow after the empty-repo self-test

## Testing
- not run (Windows-specific CI workflow)

------
https://chatgpt.com/codex/tasks/task_e_68d82af703f0832ab59c4e263b80e8a0