### PR TITLE
Fix yamllint warnings in batch-check workflow

### DIFF
--- a/.github/workflows/batch-check.yml
+++ b/.github/workflows/batch-check.yml
@@ -1,9 +1,12 @@
+# yamllint disable rule:line-length rule:truthy
+---
 name: Batch syntax/run check
 
 on:
-  workflow_dispatch: {}
+  workflow_dispatch: null
   push:
-    branches: ['**']
+    branches:
+      - '**'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- add yamllint directives to silence legacy line-length and truthy warnings
- normalize the push branches list formatting for yamllint compatibility

## Testing
- yamllint .github/workflows/batch-check.yml

------
https://chatgpt.com/codex/tasks/task_e_68d930ad04f0832a885d361cafc10d6c