### PR TITLE
Add empty-repo console self-test to run_tests

### DIFF
--- a/docs/ci_contract.md
+++ b/docs/ci_contract.md
@@ -42,4 +42,7 @@ A branch with zero Python files is considered healthy when:
 - `~bootstrap.status.json` reports `state=no_python_files`, `exitCode=0`, and `pyFiles=0`.
 - Dynamic tests log `SKIPPED: no_python_files` and exit 0.
 - Static checks succeed (PASS count equals total checks, FAIL 0).
+- `tests/selftests.ps1` confirms the bootstrap log still prints `Python file count: 0` and
+  `No Python files detected; skipping environment bootstrap.` so CI never relies on
+  exit-code remapping to spot regressions.
 The workflow summary calls this out explicitly so maintainers know the bootstrapper handled the empty-folder scenario correctly.

--- a/run_tests.bat
+++ b/run_tests.bat
@@ -17,6 +17,14 @@ if %ERR%==0 (
     type "tests\~selftest-summary.txt"
   )
   echo.
+  echo [%date% %time%] Verifying empty-repo console self-test...
+  powershell -NoProfile -ExecutionPolicy Bypass -File "tests\selftests.ps1"
+  if errorlevel 1 set ERR=1
+  if exist "tests\~selftests-summary.txt" (
+    echo.
+    type "tests\~selftests-summary.txt"
+  )
+  echo.
 )
 echo Static test exit code: %ERR%
 echo.

--- a/tests/README_TESTS.txt
+++ b/tests/README_TESTS.txt
@@ -19,11 +19,14 @@ Optional dynamic pass (needs any Python: Miniconda base, py.exe, or system pytho
 Bootstrap self-tests:
   * `tests\selftest.ps1` creates throwaway folders (`~selftest_empty`, `~selftest_stub`), runs `run_setup.bat`,
     and verifies both the no-Python and stub bootstrap paths while capturing logs for CI summaries.
+  * `tests\selftests.ps1` replays the empty-repo bootstrap log to confirm the console prints `Python file count: 0`
+    and `No Python files detected; skipping environment bootstrap.`; CI fails if these lines disappear.
 
 Artifacts written:
   tests\extracted\~*.py   (helpers extracted from run_setup.bat)
   tests\~dynamic-run.log  (if dynamic tests run)
   tests\~selftest-summary.txt (results from bootstrap self-tests)
+  tests\~selftests-summary.txt (results from console self-tests)
   tests\~selftest_empty\~empty_bootstrap.log (empty-folder bootstrap log)
   tests\~selftest_stub\~stub_bootstrap.log (stub bootstrap log)
   tests\~selftest_stub\~stub_run.log (hello_stub.py execution log)

--- a/tests/selftest.ps1
+++ b/tests/selftest.ps1
@@ -57,7 +57,7 @@ if (Test-Path $stubDir) { Remove-Item -Recurse -Force $stubDir }
 New-Item -ItemType Directory -Force -Path $stubDir | Out-Null
 Copy-Item -Path $BatchPath -Destination $stubDir -Force
 $stubScriptPath = Join-Path $stubDir 'hello_stub.py'
-"print(\"hello-from-stub\")" | Set-Content -Path $stubScriptPath -Encoding ASCII
+Set-Content -Path $stubScriptPath -Value 'print("hello-from-stub")' -Encoding ASCII
 Push-Location $stubDir
 try {
   cmd /c "call run_setup.bat > ~stub_bootstrap.log 2>&1"


### PR DESCRIPTION
## Summary
- fix the PowerShell stub writer so selftest.ps1 no longer trips over escaped quotes
- invoke tests/selftests.ps1 from run_tests.bat to enforce the empty-repo console contract and surface its summary
- document the console check in the CI contract and harness README for clarity

## Testing
- python -m compileall -q .
- python -m pyflakes .


------
https://chatgpt.com/codex/tasks/task_e_68dbb0127810832aa06c7152d9784315