### PR TITLE
tests: require entry-smoke and PyInstaller markers in envsmoke pass criteria

### DIFF
--- a/tests/selfapps_envsmoke.ps1
+++ b/tests/selfapps_envsmoke.ps1
@@ -173,6 +173,11 @@ $bltxt  = (Test-Path $blog)   ? (Get-Content -LiteralPath $blog   -Raw -Encoding
 $outxt  = (Test-Path $runout) ? (Get-Content -LiteralPath $runout -Raw -Encoding Ascii) : ''
 $runerr = Join-Path $app '~run.err.txt'
 $errtxt = (Test-Path $runerr) ? (Get-Content -LiteralPath $runerr -Raw -Encoding Ascii) : ''
+$bootstrapText = @($setup, $bltxt) -join "`n"
+$hasEntryRun = ($bootstrapText -match 'Running entry script smoke test')
+$hasEntryExit = ($bootstrapText -match 'Entry smoke exit=0')
+$hasPyInstaller = ($bootstrapText -match 'PyInstaller produced')
+$bootstrapPass = (($exit -eq 0) -and $hasEntryRun -and $hasEntryExit -and $hasPyInstaller)
 
 $smokeCommand = ''
 if ($setup) {
@@ -339,19 +344,31 @@ try {
 Write-NdjsonRow ([ordered]@{
     id='self.env.smoke.conda'
     req='REQ-003'
-    pass=($exit -eq 0)
+    pass=$bootstrapPass
     desc='Miniconda bootstrap + environment creation'
-    details=[ordered]@{ exitCode=$exit; command=$displayCommand }
+    details=[ordered]@{
+        exitCode=$exit
+        command=$displayCommand
+        hasEntryRun=$hasEntryRun
+        hasEntryExit=$hasEntryExit
+        hasPyInstaller=$hasPyInstaller
+    }
 })
 Write-NdjsonRow ([ordered]@{
     id='self.prime.bootstrap'
     req='REQ-001'
-    pass=($exit -eq 0)
+    pass=$bootstrapPass
     desc='Prime directive: batch file bootstraps Python environment from scratch'
-    details=[ordered]@{ exitCode=$exit; command=$displayCommand }
+    details=[ordered]@{
+        exitCode=$exit
+        command=$displayCommand
+        hasEntryRun=$hasEntryRun
+        hasEntryExit=$hasEntryExit
+        hasPyInstaller=$hasPyInstaller
+    }
 })
 
-$passRun = ($exit -eq 0) -and $tokenFound
+$passRun = $bootstrapPass -and $tokenFound
 Write-NdjsonRow ([ordered]@{
     id='self.env.smoke.run'
     req='REQ-003'
@@ -552,7 +569,19 @@ $spaceExePath = Join-Path $spaceApp ("dist\\$spaceEnvName.exe")
 
 $spacePathErrorPattern = 'The system cannot find the path specified|is not recognized as an internal or external command'
 $spaceHasPathErrors = (($spaceSetupText -match $spacePathErrorPattern) -or ($spaceBootstrapText -match $spacePathErrorPattern))
-$spacePass = (($spaceExit -eq 0) -and ($spaceTokenText -match 'space-path-ok') -and (Test-Path -LiteralPath $spaceExePath) -and (-not $spaceHasPathErrors))
+$spaceCombinedBootstrapText = @($spaceSetupText, $spaceBootstrapText) -join "`n"
+$spaceHasEntryRun = ($spaceCombinedBootstrapText -match 'Running entry script smoke test')
+$spaceHasEntryExit = ($spaceCombinedBootstrapText -match 'Entry smoke exit=0')
+$spaceHasPyInstaller = ($spaceCombinedBootstrapText -match 'PyInstaller produced')
+$spacePass = (
+    ($spaceExit -eq 0) -and
+    ($spaceTokenText -match 'space-path-ok') -and
+    (Test-Path -LiteralPath $spaceExePath) -and
+    (-not $spaceHasPathErrors) -and
+    $spaceHasEntryRun -and
+    $spaceHasEntryExit -and
+    $spaceHasPyInstaller
+)
 
 Write-NdjsonRow ([ordered]@{
     id='self.prime.spaced-path'
@@ -565,6 +594,9 @@ Write-NdjsonRow ([ordered]@{
         tokenFound=($spaceTokenText -match 'space-path-ok')
         exeExists=(Test-Path -LiteralPath $spaceExePath)
         noPathErrors=(-not $spaceHasPathErrors)
+        hasEntryRun=$spaceHasEntryRun
+        hasEntryExit=$spaceHasEntryExit
+        hasPyInstaller=$spaceHasPyInstaller
     }
 })
 Write-NdjsonRow ([ordered]@{
@@ -575,5 +607,8 @@ Write-NdjsonRow ([ordered]@{
     details=[ordered]@{
         workspace=$spaceApp
         tokenFound=($spaceTokenText -match 'space-path-ok')
+        hasEntryRun=$spaceHasEntryRun
+        hasEntryExit=$spaceHasEntryExit
+        hasPyInstaller=$spaceHasPyInstaller
     }
 })


### PR DESCRIPTION
### Motivation
- Batch bootstrappers can exit 0 while silently skipping critical steps, so envsmoke must assert that the bootstrap actually performed entry-script smoke and packaging stages.  
- Existing logs already contain markers (`Running entry script smoke test`, `Entry smoke exit=0`, `PyInstaller produced`) that can be checked without changing `run_setup.bat`.  
- Change scope limited to test diagnostics and pass gating to avoid altering bootstrap behavior or existing assertions.

### Description
- Updated `tests/selfapps_envsmoke.ps1` to combine existing bootstrap logs and set marker booleans: `$hasEntryRun`, `$hasEntryExit`, `$hasPyInstaller` and a consolidated `$bootstrapPass` that requires exit code 0 plus all three markers.  
- Changed bootstrap NDJSON rows (`self.env.smoke.conda`, `self.prime.bootstrap`) to use `$bootstrapPass` and added the marker booleans into their `details` for diagnostics visibility.  
- Extended the spaced-path scenario to detect the same three markers (`$spaceHasEntryRun`, `$spaceHasEntryExit`, `$spaceHasPyInstaller`), require them in `$spacePass` while preserving existing checks (`token`, `exe`, `noPathErrors`), and expose marker booleans in NDJSON details.

### Testing
- Ran `python -m compileall -q .` which completed successfully.  
- Ran `python -m pyflakes .` and `python -m yamllint .github/workflows/batch-check.yml` which returned no errors.  
- Ran `actionlint -oneline` and PowerShell syntax checks (`tools/ps-compileall.ps1` and `[System.Management.Automation.Language.Parser]::ParseFile`) which parsed `tests/selfapps_envsmoke.ps1` OK.  
- Executed the modified test script with `pwsh -NoLogo -NoProfile -File tests/selfapps_envsmoke.ps1`, which ran without parser/runtime errors (exit 0).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d46896a800832a952f076274ecab00)