### PR TITLE
tests: assert envsmoke interpreter uses expected env

### DIFF
--- a/tests/selfapps_envsmoke.ps1
+++ b/tests/selfapps_envsmoke.ps1
@@ -177,7 +177,14 @@ $bootstrapText = @($setup, $bltxt) -join "`n"
 $hasEntryRun = ($bootstrapText -match 'Running entry script smoke test')
 $hasEntryExit = ($bootstrapText -match 'Entry smoke exit=0')
 $hasPyInstaller = ($bootstrapText -match 'PyInstaller produced')
-$bootstrapPass = (($exit -eq 0) -and $hasEntryRun -and $hasEntryExit -and $hasPyInstaller)
+$envLeaf = Split-Path $app -Leaf
+$condaEnvName = ($envLeaf -replace '[^A-Za-z0-9_-]', '_')
+if (-not $condaEnvName) { $condaEnvName = '_envsmoke' }
+$interpreterMatch = [regex]::Match($bootstrapText, '^Interpreter:\s*(.+)$', [System.Text.RegularExpressions.RegexOptions]::Multiline)
+$interpreterPath = if ($interpreterMatch.Success) { $interpreterMatch.Groups[1].Value.Trim() } else { '' }
+$hasInterpreter = [bool]$interpreterMatch.Success
+$hasExpectedEnv = ($hasInterpreter -and ($interpreterPath -match [regex]::Escape($condaEnvName)))
+$bootstrapPass = (($exit -eq 0) -and $hasEntryRun -and $hasEntryExit -and $hasPyInstaller -and $hasInterpreter -and $hasExpectedEnv)
 
 $smokeCommand = ''
 if ($setup) {
@@ -225,9 +232,6 @@ Check-PipreqsFailure -LogPath $setupLog -LogText $setup
 $haveRunOut = Test-Path -LiteralPath $runout
 
 # Derive env name and locate the conda bat that run_setup.bat installed.
-$envLeaf      = Split-Path $app -Leaf
-$condaEnvName = ($envLeaf -replace '[^A-Za-z0-9_-]', '_')
-if (-not $condaEnvName) { $condaEnvName = '_envsmoke' }
 $appPath = Join-Path $app 'app.py'
 $publicRoot   = [Environment]::GetEnvironmentVariable('PUBLIC')
 
@@ -352,6 +356,9 @@ Write-NdjsonRow ([ordered]@{
         hasEntryRun=$hasEntryRun
         hasEntryExit=$hasEntryExit
         hasPyInstaller=$hasPyInstaller
+        interpreterDetected=$hasInterpreter
+        expectedEnvUsed=$hasExpectedEnv
+        interpreterPath=$interpreterPath
     }
 })
 Write-NdjsonRow ([ordered]@{
@@ -365,6 +372,9 @@ Write-NdjsonRow ([ordered]@{
         hasEntryRun=$hasEntryRun
         hasEntryExit=$hasEntryExit
         hasPyInstaller=$hasPyInstaller
+        interpreterDetected=$hasInterpreter
+        expectedEnvUsed=$hasExpectedEnv
+        interpreterPath=$interpreterPath
     }
 })
 
@@ -573,6 +583,10 @@ $spaceCombinedBootstrapText = @($spaceSetupText, $spaceBootstrapText) -join "`n"
 $spaceHasEntryRun = ($spaceCombinedBootstrapText -match 'Running entry script smoke test')
 $spaceHasEntryExit = ($spaceCombinedBootstrapText -match 'Entry smoke exit=0')
 $spaceHasPyInstaller = ($spaceCombinedBootstrapText -match 'PyInstaller produced')
+$spaceInterpreterMatch = [regex]::Match($spaceCombinedBootstrapText, '^Interpreter:\s*(.+)$', [System.Text.RegularExpressions.RegexOptions]::Multiline)
+$spaceInterpreterPath = if ($spaceInterpreterMatch.Success) { $spaceInterpreterMatch.Groups[1].Value.Trim() } else { '' }
+$spaceHasInterpreter = [bool]$spaceInterpreterMatch.Success
+$spaceHasExpectedEnv = ($spaceHasInterpreter -and ($spaceInterpreterPath -match [regex]::Escape($spaceEnvName)))
 $spacePass = (
     ($spaceExit -eq 0) -and
     ($spaceTokenText -match 'space-path-ok') -and
@@ -580,7 +594,9 @@ $spacePass = (
     (-not $spaceHasPathErrors) -and
     $spaceHasEntryRun -and
     $spaceHasEntryExit -and
-    $spaceHasPyInstaller
+    $spaceHasPyInstaller -and
+    $spaceHasInterpreter -and
+    $spaceHasExpectedEnv
 )
 
 Write-NdjsonRow ([ordered]@{
@@ -597,6 +613,9 @@ Write-NdjsonRow ([ordered]@{
         hasEntryRun=$spaceHasEntryRun
         hasEntryExit=$spaceHasEntryExit
         hasPyInstaller=$spaceHasPyInstaller
+        interpreterDetected=$spaceHasInterpreter
+        expectedEnvUsed=$spaceHasExpectedEnv
+        interpreterPath=$spaceInterpreterPath
     }
 })
 Write-NdjsonRow ([ordered]@{
@@ -610,5 +629,8 @@ Write-NdjsonRow ([ordered]@{
         hasEntryRun=$spaceHasEntryRun
         hasEntryExit=$spaceHasEntryExit
         hasPyInstaller=$spaceHasPyInstaller
+        interpreterDetected=$spaceHasInterpreter
+        expectedEnvUsed=$spaceHasExpectedEnv
+        interpreterPath=$spaceInterpreterPath
     }
 })


### PR DESCRIPTION
### Motivation
- Prevent silent fallbacks to an unintended Python interpreter by asserting the bootstrap actually used the created environment rather than a system/venv fallback.
- The bootstrap emits an `Interpreter:` log line that can be parsed to verify the interpreter path, so tests should assert that line exists and contains the derived env name.

### Description
- Parse the `Interpreter:` line from the combined bootstrap logs and expose `interpreterPath`, `interpreterDetected`, and `expectedEnvUsed` booleans in `tests/selfapps_envsmoke.ps1`.
- Derive the expected conda env name from the test app directory and require the parsed interpreter path to contain that env name before considering the bootstrap a pass (applies to both normal and spaced-path flows).
- Add the new fields `interpreterDetected`, `expectedEnvUsed`, and `interpreterPath` to the NDJSON `details` for bootstrap-related rows so CI diagnostics clearly show interpreter selection behavior.
- Change scope is minimal and limited to `tests/selfapps_envsmoke.ps1` only.

### Testing
- Ran `python -m yamllint .github/workflows/batch-check.yml` which succeeded.
- Validated GitHub Actions YAML with `actionlint` by installing via `go install` and running `actionlint -oneline`, which succeeded.
- Ran Python checks `python -m compileall -q .` and `python -m pyflakes .` which succeeded with no new issues.
- Ran PowerShell syntax checks via `pwsh -NoLogo -NoProfile -File tools/ps-compileall.ps1` which reported `Syntax OK` and then executed `pwsh -NoLogo -NoProfile -File tests/selfapps_envsmoke.ps1` successfully.
- Ran `python tools/check_delimiters.py tests/selfapps_envsmoke.ps1` which found no delimiter issues for the modified file; a pre-existing delimiter remark was observed in `tools/ps-compileall.ps1` but is outside this change's scope.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5b6a232dc832a961a33d6c22cbb9a)