### PR TITLE
harden: guardrails for long-path, OneDrive, empty ENVNAME, pip-install, req-copy failures

### DIFF
--- a/.github/workflows/batch-check.yml
+++ b/.github/workflows/batch-check.yml
@@ -806,6 +806,20 @@ jobs:
             tests\~pyproject_prec\~setup.log
             tests/~pyproject_prec/runtime.txt
             tests\~pyproject_prec\runtime.txt
+            tests/~selftest_pip_warn/~pip_warn_bootstrap.log
+            tests\~selftest_pip_warn\~pip_warn_bootstrap.log
+            tests/~selftest_pip_warn/~setup.log
+            tests\~selftest_pip_warn\~setup.log
+            tests/~selftest_pip_warn/~bootstrap.status.json
+            tests\~selftest_pip_warn\~bootstrap.status.json
+            tests/~selftest_OneDrive/~onedrive_bootstrap.log
+            tests\~selftest_OneDrive\~onedrive_bootstrap.log
+            tests/~selftest_OneDrive/~setup.log
+            tests\~selftest_OneDrive\~setup.log
+            tests/~selftest_OneDrive/~bootstrap.status.json
+            tests\~selftest_OneDrive\~bootstrap.status.json
+            tests/~selftest_longpath/
+            tests\~selftest_longpath\
             tests/~selftest-summary.txt
             tests\~selftest-summary.txt
             tests/~test-summary.txt

--- a/run_setup.bat
+++ b/run_setup.bat
@@ -27,6 +27,18 @@ set "LOG=~setup.log"
 set "LOGPREV=~setup.prev.log"
 set "STATUS_FILE=~bootstrap.status.json"
 if not exist "%LOG%" (type nul > "%LOG%")
+rem --- Path-length guard: warn if script root path approaches the 260-char cmd.exe limit ---
+for /f "usebackq delims=" %%L in (`powershell -NoProfile -ExecutionPolicy Bypass -Command "$env:HP_SCRIPT_ROOT.Length" 2^>nul`) do set "HP_PATH_LEN=%%L"
+if defined HP_PATH_LEN if %HP_PATH_LEN% GEQ 200 (
+  echo *** WARNING: Script path is %HP_PATH_LEN% chars. Paths near 260 chars may cause cmd.exe failures.
+  call :log "[WARN] Script path is %HP_PATH_LEN% chars; paths near 260 chars may cause failures."
+)
+set "HP_PATH_LEN="
+rem --- Synced-folder guard: warn when running from a OneDrive or similar sync folder ---
+if /I not "%HP_SCRIPT_ROOT:OneDrive=%"=="%HP_SCRIPT_ROOT%" (
+  echo *** WARNING: Script appears to be in a OneDrive folder. File locking may cause failures.
+  call :log "[WARN] OneDrive path detected; file locking may cause failures."
+)
 if exist "%STATUS_FILE%" del "%STATUS_FILE%"
 set "HP_BOOTSTRAP_STATE=ok"
 set "HP_ENV_MODE=conda"
@@ -229,6 +241,11 @@ if /I "%HP_ENV_STATE_RESULT%"=="skip" (
   goto :env_state_fast_path
 )
 :env_state_check_done
+rem --- ENVNAME guard: default to 'env' if sanitization yielded an empty name ---
+if "%ENVNAME%"=="" (
+  call :log "[WARN] Conda env name resolved to empty; defaulting to 'env'."
+  set "ENVNAME=env"
+)
 if "%PYSPEC%"=="" (
   call "%CONDA_BAT%" create -y -n "%ENVNAME%" "python<3.13" --override-channels -c conda-forge >> "%LOG%" 2>&1
 ) else (
@@ -482,7 +499,13 @@ if "%HP_PIPREQS_PHASE_RESULT%"=="ok" (
     call :die "[ERROR] pipreqs generation failed."
   )
 )
-if not exist "%REQ%" if exist "requirements.auto.txt" ( copy /y "requirements.auto.txt" "requirements.txt" >> "%LOG%" 2>&1 )
+if not exist "%REQ%" if exist "requirements.auto.txt" (
+  copy /y "requirements.auto.txt" "requirements.txt" >> "%LOG%" 2>&1
+  if errorlevel 1 (
+    echo *** Could not generate requirements.txt. Continuing without dependencies...
+    call :log "[WARN] Failed to copy requirements.auto.txt to requirements.txt; continuing without dependency installation."
+  )
+)
 if exist "requirements.txt" if exist "requirements.auto.txt" ( fc "requirements.txt" "requirements.auto.txt" > "~pipreqs.diff.txt" 2>&1 )
 rem --- Dep-check fast path: skip conda install when all pipreqs packages are in the lock ---
 rem derived requirement: skip the slow conda solver on repeat runs when the
@@ -519,8 +542,16 @@ if exist "requirements.txt" (
       )
     )
     "%HP_PY%" -m pip install -r requirements.txt >> "%LOG%" 2>&1
+    if errorlevel 1 (
+      echo *** Warning: Some requirements may have failed to install.
+      call :log "[WARN] pip install -r requirements.txt failed; some packages may be missing."
+    )
   ) else if "%HP_ENV_MODE%"=="venv" (
     "%HP_PY%" -m pip install -r requirements.txt >> "%LOG%" 2>&1
+    if errorlevel 1 (
+      echo *** Warning: Some requirements may have failed to install.
+      call :log "[WARN] pip install -r requirements.txt failed; some packages may be missing."
+    )
   ) else (
     call :log "[WARN] System fallback: skipping requirement installation."
   )

--- a/tests/selftest.ps1
+++ b/tests/selftest.ps1
@@ -232,4 +232,114 @@ Write-NdjsonRow ([ordered]@{
   }
 })
 if ($stateSkipFound) { $summary.Add('stub state skip: PASS') } else { $summary.Add('stub state skip: FAIL') }
+
+# --- pip-install warning test ---
+# Arrange: stub .py + a requirements.txt containing a nonexistent package so pip install fails.
+# Assert:  the "*** Warning: Some requirements..." line appears and bootstrap still exits 0.
+$pipWarnDir = Join-Path $TestsDir '~selftest_pip_warn'
+if (Test-Path $pipWarnDir) { Remove-Item -Recurse -Force $pipWarnDir }
+New-Item -ItemType Directory -Force -Path $pipWarnDir | Out-Null
+Copy-Item -Path $BatchPath -Destination $pipWarnDir -Force
+Set-Content -Path (Join-Path $pipWarnDir 'hello_stub.py') -Value 'print("hello-from-stub")' -Encoding ASCII
+Set-Content -Path (Join-Path $pipWarnDir 'requirements.txt') -Value '_fake_pkg_pipwarn_xyz_' -Encoding ASCII
+$pipWarnLogName = '~pip_warn_bootstrap.log'
+Push-Location $pipWarnDir
+try {
+  cmd /c "call run_setup.bat > $pipWarnLogName 2>&1"
+  $pipWarnExit = $LASTEXITCODE
+} finally {
+  Pop-Location
+}
+$pipWarnLogPath = Join-Path $pipWarnDir $pipWarnLogName
+$pipWarnLines = @()
+if (Test-Path $pipWarnLogPath) { $pipWarnLines = Get-Content -LiteralPath $pipWarnLogPath -Encoding ASCII }
+$pipWarnTag = '*** Warning: Some requirements may have failed to install.'
+$pipWarnFound = ($pipWarnLines | Where-Object { $_ -like "*$pipWarnTag*" }).Count -gt 0
+$pipWarnStatusPath = Join-Path $pipWarnDir '~bootstrap.status.json'
+$pipWarnContinued = $false
+if (Test-Path $pipWarnStatusPath) {
+  try {
+    $pipWarnStatus = Get-Content -LiteralPath $pipWarnStatusPath -Raw -Encoding ASCII | ConvertFrom-Json
+    $pipWarnContinued = ($pipWarnStatus.exitCode -eq 0)
+  } catch { }
+}
+Write-NdjsonRow ([ordered]@{
+  id = 'self.stub.pip_warn'
+  pass = ($pipWarnFound -and $pipWarnContinued)
+  desc = 'Bootstrap emits pip install warning and continues when a requirement fails to install'
+  details = [ordered]@{
+    warnFound = $pipWarnFound
+    continued = $pipWarnContinued
+  }
+})
+if ($pipWarnFound -and $pipWarnContinued) { $summary.Add('pip install warn + continue: PASS') } else { $summary.Add('pip install warn + continue: FAIL') }
+
+# --- OneDrive/synced-folder path warning test ---
+# Arrange: run from a directory whose name contains "OneDrive" so the guardrail fires.
+# Assert:  "[WARN] OneDrive path detected" appears in log and bootstrap exits 0.
+$oneDriveDir = Join-Path $TestsDir '~selftest_OneDrive'
+if (Test-Path $oneDriveDir) { Remove-Item -Recurse -Force $oneDriveDir }
+New-Item -ItemType Directory -Force -Path $oneDriveDir | Out-Null
+Copy-Item -Path $BatchPath -Destination $oneDriveDir -Force
+$odLogName = '~onedrive_bootstrap.log'
+Push-Location $oneDriveDir
+try {
+  cmd /c "call run_setup.bat > $odLogName 2>&1"
+  $odExit = $LASTEXITCODE
+} finally {
+  Pop-Location
+}
+$odLogPath = Join-Path $oneDriveDir $odLogName
+$odLines = @()
+if (Test-Path $odLogPath) { $odLines = Get-Content -LiteralPath $odLogPath -Encoding ASCII }
+$odWarnTag = 'OneDrive path detected'
+$odWarnFound = ($odLines | Where-Object { $_ -like "*$odWarnTag*" }).Count -gt 0
+Write-NdjsonRow ([ordered]@{
+  id = 'self.warn.onedrive'
+  pass = ($odWarnFound -and ($odExit -eq 0))
+  desc = 'Bootstrap emits OneDrive warning and exits 0 when script path contains OneDrive'
+  details = [ordered]@{
+    warnFound = $odWarnFound
+    exitCode = $odExit
+  }
+})
+if ($odWarnFound -and ($odExit -eq 0)) { $summary.Add('OneDrive path warning: PASS') } else { $summary.Add('OneDrive path warning: FAIL') }
+
+# --- Long-path (>=200 chars) warning test ---
+# Arrange: run from a directory whose full path exceeds the 200-char guardrail threshold.
+# Assert:  "[WARN] Script path is N chars" appears in log and bootstrap exits 0.
+$longBase = Join-Path $TestsDir '~selftest_longpath'
+$longSub  = 'pad_' + ('a' * 47)
+$longSub2 = 'b' * 50
+$longSub3 = 'c' * 50
+$longDir  = Join-Path $longBase "$longSub\$longSub2\$longSub3"
+if (Test-Path $longBase) { Remove-Item -Recurse -Force $longBase }
+New-Item -ItemType Directory -Force -Path $longDir | Out-Null
+Copy-Item -Path $BatchPath -Destination $longDir -Force
+$lpLogName = '~longpath_bootstrap.log'
+Push-Location $longDir
+try {
+  cmd /c "call run_setup.bat > $lpLogName 2>&1"
+  $lpExit = $LASTEXITCODE
+} finally {
+  Pop-Location
+}
+$lpLogPath = Join-Path $longDir $lpLogName
+$lpLines = @()
+if (Test-Path $lpLogPath) { $lpLines = Get-Content -LiteralPath $lpLogPath -Encoding ASCII }
+$lpWarnTag = 'Script path is'
+$lpWarnFound = ($lpLines | Where-Object { $_ -like "*$lpWarnTag*chars*" }).Count -gt 0
+$lpActualLen = $longDir.Length
+Write-NdjsonRow ([ordered]@{
+  id = 'self.warn.longpath'
+  pass = ($lpWarnFound -and ($lpExit -eq 0))
+  desc = 'Bootstrap emits long-path warning and exits 0 when script path is >=200 chars'
+  details = [ordered]@{
+    warnFound = $lpWarnFound
+    exitCode = $lpExit
+    pathLen = $lpActualLen
+  }
+})
+if ($lpWarnFound -and ($lpExit -eq 0)) { $summary.Add('Long-path warning: PASS') } else { $summary.Add("Long-path warning: FAIL (len=$lpActualLen, found=$lpWarnFound, exit=$lpExit)") }
+
 $summary | Set-Content -Path $summaryPath -Encoding ASCII

--- a/tests/selftests.ps1
+++ b/tests/selftests.ps1
@@ -134,6 +134,34 @@ if ($record.pass) {
         $summary.Add("Error: Expected console lines weren't found")
     }
 }
+
+# Assert: guardrail warning messages must NOT fire in an empty-repo (no .py files) bootstrap.
+# This ensures the new pip-install and requirements-copy guardrails don't emit spuriously.
+$noSpurious = $true
+$spuriousPatterns = @(
+    'Some requirements may have failed to install',
+    'Could not generate requirements.txt'
+)
+if ($record.details.logExists -and ($null -ne $logContent)) {
+    foreach ($pat in $spuriousPatterns) {
+        if ($logContent -match [regex]::Escape($pat)) {
+            $noSpurious = $false
+            $summary.Add("Unexpected warning in empty-repo log: $pat")
+        }
+    }
+}
+Write-NdjsonRow ([ordered]@{
+    id = 'self.empty_repo.no_spurious_warn'
+    pass = $noSpurious
+    desc = 'Empty-repo bootstrap does not emit spurious requirement-install warnings'
+    details = [ordered]@{ checked = $spuriousPatterns }
+})
+if ($noSpurious) {
+    $summary.Add('No spurious warnings in empty-repo: PASS')
+} else {
+    $summary.Add('No spurious warnings in empty-repo: FAIL')
+}
+
 $summary | Set-Content -LiteralPath $summaryPath -Encoding Ascii
 if ($record.pass) {
     exit 0


### PR DESCRIPTION
## Summary

- **run_setup.bat**: warn-and-continue guardrails for five real-world failure modes — paths ≥200 chars approaching the 260-char cmd.exe limit, OneDrive/synced-folder paths (file locking), empty ENVNAME after sanitization (default to `env`), `pip install -r requirements.txt` failures (both conda and venv modes), and `requirements.auto.txt → requirements.txt` copy failures
- **tests/selftest.ps1**: three new scenario tests — `self.stub.pip_warn` (fake package triggers pip warning + exit 0), `self.warn.onedrive` (path containing "OneDrive" triggers [WARN] + exit 0), `self.warn.longpath` (path ≥200 chars triggers [WARN] + exit 0)
- **tests/selftests.ps1**: new `self.empty_repo.no_spurious_warn` assertion — verifies the two new warning phrases do NOT fire in an empty-repo (no .py files) bootstrap
- **.github/workflows/batch-check.yml**: artifact upload paths for new test directories so CI diagnostics can display the logs

## Test plan

- [x] Pre-commit checks passed: `compileall`, `pyflakes`, `check_delimiters`, `yamllint`
- [x] Part 1 CI (guardrails only): green — 84 passes, 0 failures
- [x] Part 2 CI (tests added): green
- [ ] No review comments blocking merge