### PR TITLE
ci: surface dependency_source.txt in CI artifacts and public diagnostics UI

### DIFF
--- a/.github/workflows/batch-check.yml
+++ b/.github/workflows/batch-check.yml
@@ -1380,6 +1380,7 @@ jobs:
             'tests\~selftest_empty\~empty_bootstrap.log',
             'tests\~selftest_stub\~setup.log',
             'dynamic_tests.log',
+            'dependency_source.txt',
             'tests\~test-summary.txt',
             'iterate_gate.json',
             'iterate_auth.json',
@@ -1814,6 +1815,7 @@ jobs:
             @{ Source = (Join-Path 'tests' '~test-results.ndjson'); Destination = (Join-Path $testsDir '~test-results.ndjson') }
             @{ Source = (Join-Path 'tests' '~test-summary.txt');    Destination = (Join-Path $testsDir '~test-summary.txt') }
             @{ Source = 'dynamic_tests.log';                        Destination = (Join-Path $stage 'dynamic_tests.log') }
+            @{ Source = 'dependency_source.txt';                    Destination = (Join-Path $stage 'dependency_source.txt') }
           )
 
           foreach ($pair in $pairs) {

--- a/.github/workflows/batch-check.yml
+++ b/.github/workflows/batch-check.yml
@@ -728,6 +728,7 @@ jobs:
             bootstrap.log
             ~setup.log
             runtime.txt
+            dependency_source.txt
             tests/~dynamic-run.log
             tests/~entry1/~entry1_bootstrap.log
             tests\~entry1\~entry1_bootstrap.log


### PR DESCRIPTION
## Summary

- Add `dependency_source.txt` to the `Upload test logs` artifact path list so the file written by `run_setup.bat` is captured in the CI artifact bundle for all 4 lanes (cache, real, conda-full, justme-test)
- Add `dependency_source.txt` to the `Stage self-test diagnostics payload` `$pairs` array so it is included in the selftest artifact bundle
- Add `dependency_source.txt` to `$wantLogs` in `Build public diagnostics tree` so it is copied into the published logs directory

No changes to `run_setup.bat` logic or any existing wording/behavior.

## Test plan

- [x] Pre-commit checks passed: `compileall`, `pyflakes`, `check_delimiters`, `yamllint`, `actionlint` (pre-existing `if: false` warning only)
- [x] Part 1 CI run `24340576865`: cache 35/35 pass, real 51/51 pass, `batchcheck_failing.txt = none`
- [x] Part 2 CI run `24343164880`: cache 35/35 pass, real 51/51 pass, `batchcheck_failing.txt = none`
- [x] `dependency_source.txt` (27 bytes) confirmed in diagnostics inventory for all 4 lanes: `_artifacts/batch-check/test-logs/test-logs-selftest-{cache,real,conda-full,justme-test}-*/dependency_source.txt`
- [x] Public diagnostics site: https://mixmansoundude.github.io/Python_vs_Windows/diag/24343164880-1/index.html

https://claude.ai/code/session_01DTm5VK6USGEwPs1DgVJAHz