### PR TITLE
harden: add G1/G2/G3 guardrail tests for variable/path safety and no-silent-failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ to fill remaining gaps quickly.
 
 ### Dependency strategy
 
-- `pipreqs` is used for discovery only -- it is not authoritative for versions or completeness.
+- `pipreqs` is used for discovery only -- it is not authoritative for versions or completeness. If pipreqs fails, bootstrap continues on available requirements rather than stopping; getting the code to run takes priority.
 - An existing `requirements.txt` is treated as input (hints), not as the authoritative specification.
 - conda performs final resolution from conda-forge; what it installs is the truth.
 - Implicit and plugin dependencies (for example, `pandas` needing `openpyxl` for `read_excel`) cannot be detected statically -- `pipreqs` only sees `import pandas`, not the runtime method call. These surface as `ImportError` at runtime.

--- a/run_setup.bat
+++ b/run_setup.bat
@@ -79,10 +79,16 @@ call :define_helper_payloads
 for %%I in ("%CD%") do set "ENVNAME=%%~nI"
 rem derived requirement: conda env names reject characters like '~'; self env smoke
 rem scenarios run from tests\~envsmoke so normalize to ASCII word chars/_/-.
+set "ENVNAME_ORIG=%ENVNAME%"
 set "ENVNAME_SANITIZED="
 for /f "usebackq delims=" %%I in (`powershell -NoProfile -ExecutionPolicy Bypass -Command "$name = $env:ENVNAME; if (-not $name) { $name = 'env'; } $san = ($name -replace '[^A-Za-z0-9_-]', '_'); if ([string]::IsNullOrWhiteSpace($san) -or ($san.Trim('_').Length -eq 0)) { $san = 'env'; } [Console]::Write($san)"` ) do set "ENVNAME_SANITIZED=%%I"
 if defined ENVNAME_SANITIZED set "ENVNAME=%ENVNAME_SANITIZED%"
 set "ENVNAME_SANITIZED="
+rem G1 guardrail: warn when folder name contained only non-word chars and defaulted to 'env'
+if "%ENVNAME%"=="env" if not "%ENVNAME_ORIG%"=="env" (
+  call :log "[WARN] Env name could not be derived from '%ENVNAME_ORIG%'; defaulting to 'env'."
+)
+set "ENVNAME_ORIG="
 
 
 set "PYCOUNT=0"
@@ -145,6 +151,8 @@ if "%HP_CONDA_PROBE_STATUS%"=="skipped" (
 if defined HP_CI_SKIP_ENV goto :ci_skip_entry
 
 rem === Miniconda location (non-admin) =========================================
+rem G2 guardrail: warn if PUBLIC is absent so path failures are observable
+if not defined PUBLIC call :log "[WARN] PUBLIC env var not defined; Miniconda path may be invalid."
 set "MC=%PUBLIC%\Documents\Miniconda3"
 set "CONDA_MAIN=%MC%\condabin\conda.bat"
 set "CONDA_ALT=%MC%\Scripts\conda.bat"
@@ -252,6 +260,8 @@ if "%ENVNAME%"=="" (
   call :log "[WARN] Conda env name resolved to empty; defaulting to 'env'."
   set "ENVNAME=env"
 )
+rem Recalculate ENV_PATH so it is always consistent with the guarded ENVNAME value
+set "ENV_PATH=%MINICONDA_ROOT%\envs\%ENVNAME%"
 if "%PYSPEC%"=="" (
   call "%CONDA_BAT%" create -y -n "%ENVNAME%" "python<3.13" --override-channels -c conda-forge >> "%LOG%" 2>&1
 ) else (
@@ -538,7 +548,8 @@ if "%HP_PIPREQS_PHASE_RESULT%"=="ok" (
     if not defined HP_PIPREQS_SUMMARY_NOTE set "HP_PIPREQS_SUMMARY_NOTE=(pipreqs run failed)"
     set "HP_PIPREQS_FAILURE_LOG=%HP_PIPREQS_LAST_LOG%"
     call :write_pipreqs_summary
-    call :die "[ERROR] pipreqs generation failed."
+    rem G3 guardrail: pipreqs is discovery only; a failed scan must not block bootstrap.
+    call :log "[WARN] pipreqs generation failed; continuing without auto-detected requirements."
   )
 )
 if not exist "%REQ%" if exist "requirements.auto.txt" (

--- a/tests/selftest.ps1
+++ b/tests/selftest.ps1
@@ -401,4 +401,65 @@ Write-NdjsonRow ([ordered]@{
 })
 if ($pnWarnFound -and $pnExitedOk) { $summary.Add('PATH-negative (minimal PATH): PASS') } else { $summary.Add('PATH-negative (minimal PATH): FAIL') }
 
+
+# --- G1 guardrail: ENVNAME derivation warns when folder name is all non-word chars ---
+# Arrange: dir named '~@~' so every char is outside [A-Za-z0-9_-]; sanitizes to '___'
+# which Trim('_') empties, forcing the default 'env' and triggering [WARN].
+$g1Base   = Join-Path $TestsDir '~selftest_guardrail_g1'
+$g1RunDir = Join-Path $g1Base   '~@~'
+if (Test-Path $g1Base) { Remove-Item -Recurse -Force $g1Base }
+New-Item -ItemType Directory -Force -Path $g1RunDir | Out-Null
+Copy-Item -Path $BatchPath -Destination $g1RunDir -Force
+$g1LogName = '~g1_bootstrap.log'
+Push-Location $g1RunDir
+try {
+  cmd /c "call run_setup.bat > $g1LogName 2>&1"
+  $g1Exit = $LASTEXITCODE
+} finally {
+  Pop-Location
+}
+$g1LogPath = Join-Path $g1RunDir $g1LogName
+$g1Lines   = @()
+if (Test-Path $g1LogPath) { $g1Lines = Get-Content -LiteralPath $g1LogPath -Encoding ASCII }
+$g1WarnTag   = 'Env name could not be derived from'
+$g1WarnFound = ($g1Lines | Where-Object { $_ -like "*$g1WarnTag*" }).Count -gt 0
+Write-NdjsonRow ([ordered]@{
+  id   = 'self.guardrail.g1'
+  pass = ($g1WarnFound -and ($g1Exit -eq 0))
+  desc = 'G1: all-non-word folder name emits [WARN] and exits 0 (no silent ENVNAME expansion)'
+  details = [ordered]@{ warnFound = $g1WarnFound; exitCode = $g1Exit }
+})
+if ($g1WarnFound -and ($g1Exit -eq 0)) { $summary.Add('G1 (ENVNAME guard warn): PASS') } else { $summary.Add('G1 (ENVNAME guard warn): FAIL') }
+
+# --- G2 guardrail: interpreter resolved to non-empty path (no empty-command expansion) ---
+# Assert: the stub bootstrap log contains 'Interpreter: <non-empty-path>' proving
+# HP_PY was guarded before use and no empty-string command was expanded.
+$g2LogPath   = Join-Path $stubDir $stubBootstrapLog
+$g2Lines     = @()
+if (Test-Path $g2LogPath) { $g2Lines = Get-Content -LiteralPath $g2LogPath -Encoding ASCII }
+$g2InterpLine = $g2Lines | Where-Object { $_ -like 'Interpreter: ?*' } | Select-Object -First 1
+$g2InterpOk   = $null -ne $g2InterpLine
+Write-NdjsonRow ([ordered]@{
+  id   = 'self.guardrail.g2'
+  pass = $g2InterpOk
+  desc = 'G2: interpreter resolved to non-empty path before execution (no empty-command expansion)'
+  details = [ordered]@{
+    found    = $g2InterpOk
+    interpLine = if ($g2InterpLine) { $g2InterpLine.Substring(0, [Math]::Min(80, $g2InterpLine.Length)) } else { '' }
+  }
+})
+if ($g2InterpOk) { $summary.Add('G2 (interpreter non-empty): PASS') } else { $summary.Add('G2 (interpreter non-empty): FAIL') }
+
+# --- G3 guardrail: dependency failure path is observable and non-fatal ---
+# Reuses pip-install-warn scenario: a bad requirements.txt causes pip install to fail;
+# bootstrap must emit [WARN] and continue (state=ok), not silently stop.
+$g3Pass = ($pipWarnFound -and $pipWarnContinued)
+Write-NdjsonRow ([ordered]@{
+  id   = 'self.guardrail.g3'
+  pass = $g3Pass
+  desc = 'G3: dependency install failure emits [WARN] and bootstrap exits 0 (no silent failure)'
+  details = [ordered]@{ warnInLog = $pipWarnFound; bootstrapContinued = $pipWarnContinued }
+})
+if ($g3Pass) { $summary.Add('G3 (no-silent-failure): PASS') } else { $summary.Add('G3 (no-silent-failure): FAIL') }
+
 $summary | Set-Content -Path $summaryPath -Encoding ASCII


### PR DESCRIPTION
## Summary

- **G1 (run_setup.bat)**: Warn when folder name contains only non-word chars and ENVNAME defaults to `env` — `[WARN] Env name could not be derived from '...'`. Recalculate `ENV_PATH` after the ENVNAME guard so the path is always consistent.
- **G2 (run_setup.bat)**: Warn when `PUBLIC` env var is absent before Miniconda path is constructed — `[WARN] PUBLIC env var not defined; Miniconda path may be invalid.`
- **G3 (run_setup.bat)**: pipreqs failure is now `[WARN]` + continue instead of `call :die`. pipreqs is discovery only; a failed scan must not block bootstrap.
- **G1 test (selftest.ps1)**: Run from `~@~` dir (all-non-word chars) — verifies ENVNAME guard emits `[WARN]` and exits 0. NDJSON row: `self.guardrail.g1`.
- **G2 test (selftest.ps1)**: Check stub bootstrap log contains a non-empty `Interpreter:` line — verifies HP_PY guard worked and no empty-string command was executed. NDJSON row: `self.guardrail.g2`.
- **G3 test (selftest.ps1)**: Reuse pip-install-warn scenario — verifies dependency install failure emits `[WARN]` and bootstrap exits 0. NDJSON row: `self.guardrail.g3`.
- **README**: One sentence added to the `pipreqs` dependency-strategy bullet making explicit that pipreqs failure is non-fatal.

## Test plan

- [x] `python tools/check_delimiters.py run_setup.bat` — no issues
- [x] `python -m compileall -q .` — clean
- [x] `python -m pyflakes .` — clean
- [x] CI run 24375775476-1 (commit 758ea92): 51 PASS, 0 FAIL (conda-full lane)
- [x] `self.guardrail.g1: pass=True`, `self.guardrail.g2: pass=True`, `self.guardrail.g3: pass=True` in real-lane test-logs NDJSON

https://claude.ai/code/session_011rCrhMd4T5seEej3VwP8Rs