### PR TITLE
feat: add PEP 723 inline script metadata support

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ to fill remaining gaps quickly.
 
 ### Dependency strategy
 
+- PEP 723 inline script metadata (`# /// script` blocks with a `dependencies` list) is supported as the highest-priority dependency source when `requirements.txt` is absent; a malformed or empty block logs `[WARN]` and falls through to the next source.
 - `pipreqs` is used for discovery only -- it is not authoritative for versions or completeness. If pipreqs fails, bootstrap continues on available requirements rather than stopping; getting the code to run takes priority.
 - An existing `requirements.txt` is treated as input (hints), not as the authoritative specification.
 - conda performs final resolution from conda-forge; what it installs is the truth.

--- a/run_setup.bat
+++ b/run_setup.bat
@@ -337,18 +337,27 @@ echo Interpreter: %HP_PY%
 call :append_env_mode_row
 "%HP_PY%" -c "print('py_ok')" 1>nul 2>nul || call :log "[WARN] Interpreter smoke test failed (continuing)."
 set "PEP723_ACTIVE="
+set "PEP723_BLOCK_FOUND="
 set "PEP723_REQ=~requirements.pep723.txt"
 if exist "%PEP723_REQ%" del "%PEP723_REQ%" >nul 2>&1
 call :determine_entry "%~1"
 if errorlevel 1 call :die "[ERROR] Could not determine entry point"
-if defined HP_ENTRY if exist "%HP_ENTRY%" (
-  findstr /c:"# /// script" "%HP_ENTRY%" >nul 2>&1
-  if not errorlevel 1 (
-    echo *** PEP 723 metadata detected
-    call :extract_pep723_requirements "%HP_ENTRY%" "%PEP723_REQ%"
-    if exist "%PEP723_REQ%" for %%S in ("%PEP723_REQ%") do if %%~zS GTR 0 set "PEP723_ACTIVE=1"
+if not "%DEP_SOURCE%"=="requirements.txt" (
+  if defined HP_ENTRY if exist "%HP_ENTRY%" (
+    findstr /c:"# /// script" "%HP_ENTRY%" >nul 2>&1
+    if not errorlevel 1 (
+      set "PEP723_BLOCK_FOUND=1"
+      echo *** PEP 723 metadata detected
+      call :extract_pep723_requirements "%HP_ENTRY%" "%PEP723_REQ%"
+      if exist "%PEP723_REQ%" for %%S in ("%PEP723_REQ%") do if %%~zS GTR 0 set "PEP723_ACTIVE=1"
+    )
+  )
+  if defined PEP723_BLOCK_FOUND if not defined PEP723_ACTIVE (
+    echo *** [WARN] PEP 723 block found but dependency list is empty or malformed; falling back
+    call :log "[WARN] PEP 723 block found but no valid dependencies extracted; pipreqs fallback."
   )
 )
+set "PEP723_BLOCK_FOUND="
 
 if not defined HP_SKIP_PIPREQS if not defined PEP723_ACTIVE (
   "%HP_PY%" -m pip install -q --disable-pip-version-check pipreqs==%HP_PIPREQS_VERSION% >> "%LOG%" 2>&1

--- a/run_setup.bat
+++ b/run_setup.bat
@@ -1067,7 +1067,7 @@ powershell -NoProfile -ExecutionPolicy Bypass -Command ^
   "  if ($line -eq '# ///') { $inside = $false; $deps = $false; return }" ^
   "  $trim = $line.Trim();" ^
   "  $compact = ($trim -replace '\s','');" ^
-  "  if ($compact -like '#dependencies=*[') { $deps = $true; return }" ^
+  "  if ($compact.StartsWith('#dependencies=') -and $compact.EndsWith('[')) { $deps = $true; return }" ^
   "  if ($deps -and $compact -eq '#]') { $deps = $false; return }" ^
   "  if ($deps -and $trim.StartsWith('# ""')) { $item = $trim.Substring(3).Trim(); if ($item.EndsWith('""')) { $item = $item.Substring(0, $item.Length - 1) }; $item }" ^
   "} | Set-Content -LiteralPath '%HP_PEP723_OUT%' -Encoding ASCII" >> "%LOG%" 2>&1

--- a/tests/selftest.ps1
+++ b/tests/selftest.ps1
@@ -462,4 +462,97 @@ Write-NdjsonRow ([ordered]@{
 })
 if ($g3Pass) { $summary.Add('G3 (no-silent-failure): PASS') } else { $summary.Add('G3 (no-silent-failure): FAIL') }
 
+# --- PEP 723 valid block test ---
+# Arrange: script with a well-formed PEP 723 inline dependency block.
+# Assert:  bootstrap log contains "Using PEP 723 inline dependency metadata" and exits 0.
+$pep723ValidDir = Join-Path $TestsDir '~selftest_pep723_valid'
+if (Test-Path $pep723ValidDir) { Remove-Item -Recurse -Force $pep723ValidDir }
+New-Item -ItemType Directory -Force -Path $pep723ValidDir | Out-Null
+Copy-Item -Path $BatchPath -Destination $pep723ValidDir -Force
+$pep723ValidScript = @'
+# /// script
+# dependencies = [
+# "packaging"
+# ]
+# ///
+print("pep723-valid")
+'@
+Set-Content -Path (Join-Path $pep723ValidDir 'app_pep723.py') -Value $pep723ValidScript -Encoding ASCII
+$pep723ValidLogName = '~pep723_valid_bootstrap.log'
+Push-Location $pep723ValidDir
+try {
+  cmd /c "call run_setup.bat > $pep723ValidLogName 2>&1"
+  $pep723ValidExit = $LASTEXITCODE
+} finally {
+  Pop-Location
+}
+$pep723ValidLogPath = Join-Path $pep723ValidDir $pep723ValidLogName
+$pep723ValidLines = @()
+if (Test-Path $pep723ValidLogPath) { $pep723ValidLines = Get-Content -LiteralPath $pep723ValidLogPath -Encoding ASCII }
+$pep723ValidTag = 'Using PEP 723 inline dependency metadata'
+$pep723ValidFound = ($pep723ValidLines | Where-Object { $_ -like "*$pep723ValidTag*" }).Count -gt 0
+$pep723ValidStatusPath = Join-Path $pep723ValidDir '~bootstrap.status.json'
+$pep723ValidContinued = $false
+if (Test-Path $pep723ValidStatusPath) {
+  try {
+    $pep723ValidStatus = Get-Content -LiteralPath $pep723ValidStatusPath -Raw -Encoding ASCII | ConvertFrom-Json
+    $pep723ValidContinued = ($pep723ValidStatus.exitCode -eq 0)
+  } catch { }
+}
+Write-NdjsonRow ([ordered]@{
+  id = 'self.pep723.valid'
+  pass = ($pep723ValidFound -and $pep723ValidContinued)
+  desc = 'PEP 723 valid block: bootstrap uses inline metadata as dep source and exits 0'
+  details = [ordered]@{
+    metadataFound = $pep723ValidFound
+    continued = $pep723ValidContinued
+  }
+})
+if ($pep723ValidFound -and $pep723ValidContinued) { $summary.Add('PEP 723 valid block: PASS') } else { $summary.Add('PEP 723 valid block: FAIL') }
+
+# --- PEP 723 malformed block test ---
+# Arrange: script with "# /// script" present but no valid dependencies block.
+# Assert:  bootstrap log contains "[WARN] PEP 723 block found but no valid" and exits 0 (pipreqs fallback).
+$pep723MalDir = Join-Path $TestsDir '~selftest_pep723_mal'
+if (Test-Path $pep723MalDir) { Remove-Item -Recurse -Force $pep723MalDir }
+New-Item -ItemType Directory -Force -Path $pep723MalDir | Out-Null
+Copy-Item -Path $BatchPath -Destination $pep723MalDir -Force
+$pep723MalScript = @'
+# /// script
+# malformed: missing dependencies array and no closing marker
+print("pep723-mal")
+'@
+Set-Content -Path (Join-Path $pep723MalDir 'app_pep723_mal.py') -Value $pep723MalScript -Encoding ASCII
+$pep723MalLogName = '~pep723_mal_bootstrap.log'
+Push-Location $pep723MalDir
+try {
+  cmd /c "call run_setup.bat > $pep723MalLogName 2>&1"
+  $pep723MalExit = $LASTEXITCODE
+} finally {
+  Pop-Location
+}
+$pep723MalLogPath = Join-Path $pep723MalDir $pep723MalLogName
+$pep723MalLines = @()
+if (Test-Path $pep723MalLogPath) { $pep723MalLines = Get-Content -LiteralPath $pep723MalLogPath -Encoding ASCII }
+$pep723MalWarnTag = 'PEP 723 block found but no valid dependencies extracted'
+$pep723MalWarnFound = ($pep723MalLines | Where-Object { $_ -like "*$pep723MalWarnTag*" }).Count -gt 0
+$pep723MalStatusPath = Join-Path $pep723MalDir '~bootstrap.status.json'
+$pep723MalContinued = $false
+if (Test-Path $pep723MalStatusPath) {
+  try {
+    $pep723MalStatus = Get-Content -LiteralPath $pep723MalStatusPath -Raw -Encoding ASCII | ConvertFrom-Json
+    $pep723MalContinued = ($pep723MalStatus.exitCode -eq 0)
+  } catch { }
+}
+Write-NdjsonRow ([ordered]@{
+  id = 'self.pep723.malformed'
+  pass = ($pep723MalWarnFound -and $pep723MalContinued)
+  desc = 'PEP 723 malformed block: bootstrap emits [WARN] and exits 0 (pipreqs fallback, no hard failure)'
+  details = [ordered]@{
+    warnFound = $pep723MalWarnFound
+    continued = $pep723MalContinued
+  }
+})
+if ($pep723MalWarnFound -and $pep723MalContinued) { $summary.Add('PEP 723 malformed block: PASS') } else { $summary.Add('PEP 723 malformed block: FAIL') }
+
 $summary | Set-Content -Path $summaryPath -Encoding ASCII

--- a/tools/check_delimiters.py
+++ b/tools/check_delimiters.py
@@ -356,6 +356,7 @@ class DelimiterChecker:
                     self._check_bat_forloop_pipes(line_no, segment)
                     if scan_from is None and not line.rstrip().endswith("^"):
                         self._bat_in_backtick = False
+                self._check_bat_ps_like_brackets(line_no, line)
 
         return self.issues
 
@@ -383,6 +384,35 @@ class DelimiterChecker:
                     "incorrect.' Use '^|' instead.",
                 )
             i += 1
+
+    def _check_bat_ps_like_brackets(self, line_no: int, line: str) -> None:
+        """Flag unmatched '[' inside PowerShell -like pattern strings embedded in .bat files.
+
+        PS wildcard patterns treat '[' as a character-class opener (like regex). An
+        unmatched '[' (no closing ']') causes the -like operator to silently return
+        False or throw, depending on the PS version. This is invisible to the outer
+        delimiter checker because the pattern sits inside a quoted batch string.
+        """
+        # derived requirement: the -like '#dependencies=*[' bug (unmatched bracket in
+        # PS wildcard pattern inside a batch double-quoted string) was undetectable by the
+        # standard delimiter pass. This targeted scan prevents the same class of regression.
+        for match in re.finditer(r"-like\s+'([^']*)'", line, re.IGNORECASE):
+            pattern = match.group(1)
+            depth = 0
+            for ch in pattern:
+                if ch == "[":
+                    depth += 1
+                elif ch == "]":
+                    depth -= 1
+            if depth != 0:
+                col = match.start(1) + 1
+                self.add_issue(
+                    line_no,
+                    col,
+                    f"Unmatched '[' in PowerShell -like pattern '{pattern}'; "
+                    "PS wildcard treats '[' as a character-class opener -- "
+                    "use .StartsWith()/.EndsWith() or escape as '`[' instead.",
+                )
 
     def _check_ps1_boolean_operators(self, line_no: int, line: str) -> None:
         # derived requirement: Windows runners surfaced "parameter name 'or'" faults whenever -or/-and sat


### PR DESCRIPTION
## Summary

- `run_setup.bat`: detect `# /// script` blocks in the entry .py file and use the `dependencies = [...]` list as the highest-priority dep source when `requirements.txt` is absent
- `requirements.txt` takes strict precedence — PEP 723 detection is skipped if `DEP_SOURCE` is already `requirements.txt`
- Malformed or empty blocks emit `[WARN]` and fall through to pipreqs (no hard failure; prime directive preserved)
- Fix: replaced `-like '#dependencies=*['` wildcard (unmatched `[` caused silent PS match failure) with `.StartsWith()/.EndsWith()` — this was the root cause of the `self.pep723.valid` CI failure
- `tests/selftest.ps1`: two new NDJSON rows — `self.pep723.valid` and `self.pep723.malformed`
- `README.md`: document PEP 723 as the highest-priority dep source in the Dependency strategy section

## Test plan

- [ ] `self.pep723.valid` PASS — bootstrap log contains "Using PEP 723 inline dependency metadata" and exits 0
- [ ] `self.pep723.malformed` PASS — bootstrap log contains "[WARN] PEP 723 block found but no valid dependencies extracted" and exits 0
- [ ] All existing static checks remain green (no regressions)
- [ ] `real` and `conda-full` CI lanes both green (gate lanes)

https://claude.ai/code/session_01Fn7LUx22S2bp9Cge7mymeB