### PR TITLE
Add non-blocking UNC path warning to run_setup.bat

### DIFF
--- a/run_setup.bat
+++ b/run_setup.bat
@@ -3,6 +3,8 @@ setlocal DisableDelayedExpansion
 set "DEP_SOURCE=unknown"
 rem Boot strap renamed to run_setup.bat
 set "HP_SCRIPT_LAUNCH_DIR=%~dp0"
+echo %~dp0 | findstr /C:"\\\\" >nul
+if not errorlevel 1 echo [WARN] UNC paths not supported
 if "%HP_SCRIPT_LAUNCH_DIR:~0,2%"=="\\" (
   rem derived requirement: parentheses must be escaped inside IF (...) blocks in CMD or parsing breaks.
   echo *** WARNING: UNC/network paths detected ^(\\server\share^).


### PR DESCRIPTION
### Motivation
- Emit a clear, non-blocking warning when the bootstrapper is launched from a UNC/network path so users and CI see that UNC paths are unsupported while preserving existing behavior.

### Description
- Inserted two lines immediately after `set "HP_SCRIPT_LAUNCH_DIR=%~dp0"` that run `echo %~dp0 | findstr /C:"\\" >nul` and `if not errorlevel 1 echo [WARN] UNC paths not supported`, leaving all existing UNC checks and control flow unchanged.

### Testing
- Ran `python -m compileall -q .`, `python -m pyflakes .`, `python -m yamllint .github/workflows/*.yml`, `python tools/check_delimiters.py run_setup.bat`, and `actionlint -oneline` (installed via `go install`), and these checks completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df026460e0832a93d75dc34032ff05)