### PR TITLE
feat: add EXE smoke run after final PyInstaller build

### DIFF
--- a/run_setup.bat
+++ b/run_setup.bat
@@ -1272,12 +1272,37 @@ if "%HP_ENV_MODE%"=="system" (
     set "HP_SPEC_PREEXIST="
     if exist "build\%ENVNAME%" rd /s /q "build\%ENVNAME%" >nul 2>&1
     call :log "[INFO] PyInstaller build artifacts cleaned up."
+    call :run_exe_smokerun
   )
 )
 set "HP_FAST_EXE="
 set "HP_FAST_EXE_PATH="
 set "HP_FASTPATH_USED="
 set "HP_FASTPATH_TOKEN="
+exit /b 0
+:run_exe_smokerun
+if not exist "dist\%ENVNAME%.exe" (
+  call :log "[WARN] EXE smokerun: dist\%ENVNAME%.exe not found; skipping"
+  exit /b 0
+)
+call :log "[INFO] EXE smokerun: testing dist\%ENVNAME%.exe"
+set "HP_EXE_EXIT=-1"
+pushd dist
+for /f "usebackq delims=" %%X in (`powershell -NoProfile -ExecutionPolicy Bypass -Command "$si=New-Object System.Diagnostics.ProcessStartInfo;$si.FileName='%ENVNAME%.exe';$si.UseShellExecute=$false;$si.RedirectStandardOutput=$true;$si.RedirectStandardError=$true;$p=[System.Diagnostics.Process]::Start($si);$done=$p.WaitForExit(30000);if(-not $done){try{$p.Kill()}catch{}};if($done){$p.ExitCode}else{-1}"`) do set "HP_EXE_EXIT=%%X"
+popd
+if not defined HP_EXE_EXIT set "HP_EXE_EXIT=-1"
+if "%HP_EXE_EXIT%"=="0" (
+  call :log "[INFO] EXE smokerun: exited 0 (ok)"
+) else (
+  call :log "[WARN] EXE smokerun: exited %HP_EXE_EXIT% (non-zero)"
+)
+if defined HP_NDJSON (
+  powershell -NoProfile -ExecutionPolicy Bypass -Command ^
+    "$c=[int]'%HP_EXE_EXIT%';" ^
+    "$r=[ordered]@{id='self.exe.smokerun';pass=($c -eq 0);details=[ordered]@{exitCode=$c}}|ConvertTo-Json -Compress -Depth 8;" ^
+    "Add-Content -Path '%HP_NDJSON%' -Value $r -Encoding ASCII" >> "%LOG%" 2>&1
+)
+set "HP_EXE_EXIT="
 exit /b 0
 :write_pipreqs_summary
 if "%HP_JOB_SUMMARY%"=="" exit /b 0


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- After the final PyInstaller build (including post-warnfix rebuild), `run_setup.bat` now executes the built EXE via a new `:run_exe_smokerun` subroutine
- EXE is run from its `dist\` directory using `pushd`/`popd` so relative paths work correctly
- 30-second timeout guard via PowerShell `WaitForExit(30000)` — kills the process on timeout and returns -1
- Non-zero exit is logged as `[WARN]`; flow continues unchanged (no die on smokerun failure)
- Emits a `self.exe.smokerun` NDJSON row when `HP_NDJSON` is set; existing rows and log wording unchanged

## CI evidence (run 24593824485)

Warnfix bootstrap log confirms execution:
```
[INFO] PyInstaller rebuild after missing module install complete.
[INFO] PyInstaller build artifacts cleaned up.
[INFO] EXE smokerun: testing dist\_selftest_warnfix.exe
[INFO] EXE smokerun: exited 0 (ok)
```

All existing EXE rows pass: `self.exe.build`, `self.exe.run`, `self.exe.warnfix.install`, `self.exe.warnfix.success` — no regressions.

## Test plan

- [x] Delimiter check passes (`python tools/check_delimiters.py run_setup.bat`)
- [x] CI green on conda-full and real lanes (run 24593824485)
- [x] Warnfix bootstrap log shows smokerun executing and exiting 0
- [x] No existing tests or log wording changed

https://claude.ai/code/session_01Et99CfvvW7hUBg3GLwVWrQ
EOF
)