### PR TITLE
feat: add EXE smokerun diagnostic hints and clarify iterate logs status

### DIFF
--- a/run_setup.bat
+++ b/run_setup.bat
@@ -1295,6 +1295,7 @@ if "%HP_EXE_EXIT%"=="0" (
   call :log "[INFO] EXE smokerun: exited 0 (ok)"
 ) else (
   call :log "[WARN] EXE smokerun: exited %HP_EXE_EXIT% (non-zero)"
+  call :exe_smokerun_hints
 )
 if defined HP_NDJSON (
   powershell -NoProfile -ExecutionPolicy Bypass -Command ^
@@ -1303,6 +1304,39 @@ if defined HP_NDJSON (
     "Add-Content -Path '%HP_NDJSON%' -Value $r -Encoding ASCII" >> "%LOG%" 2>&1
 )
 set "HP_EXE_EXIT="
+exit /b 0
+:exe_smokerun_hints
+rem derived requirement: re-run EXE briefly to capture stderr for pattern-based hints
+rem only. EXE exits immediately on ModuleNotFoundError/FileNotFoundError so no timeout
+rem is needed for hint capture. Existing success/failure logic is not changed.
+if not exist "dist\%ENVNAME%.exe" exit /b 0
+pushd dist
+"%ENVNAME%.exe" > "~exe_out.txt" 2>&1
+popd
+set "HP_HINT_FILE=dist\~exe_out.txt"
+set "HP_HINT_FILE_NAME=<file>"
+set "HP_HINT_MOD=<module>"
+findstr /i /c:"FileNotFoundError" /c:"No such file or directory" "%HP_HINT_FILE%" >nul 2>&1
+if not errorlevel 1 goto :hint_data_file
+goto :hint_check_mod
+:hint_data_file
+for /f "usebackq delims=" %%F in (`powershell -NoProfile -ExecutionPolicy Bypass -Command "$t=[IO.File]::ReadAllText('%HP_HINT_FILE%');$m=[regex]::Match($t,'No such file or directory: ''([^'']+)''');if($m.Success){$m.Groups[1].Value}else{'<file>'}"`) do set "HP_HINT_FILE_NAME=%%F"
+call :log "[HINT] Missing data file detected: %HP_HINT_FILE_NAME%"
+call :log "[HINT] Consider adding: --add-data %HP_HINT_FILE_NAME%;."
+:hint_check_mod
+findstr /i /c:"ModuleNotFoundError" /c:"No module named" "%HP_HINT_FILE%" >nul 2>&1
+if not errorlevel 1 goto :hint_hidden_import
+goto :hint_packaging
+:hint_hidden_import
+for /f "usebackq delims=" %%M in (`powershell -NoProfile -ExecutionPolicy Bypass -Command "$t=[IO.File]::ReadAllText('%HP_HINT_FILE%');$m=[regex]::Match($t,'No module named ''([^'']+)''');if($m.Success){$m.Groups[1].Value}else{'<module>'}"`) do set "HP_HINT_MOD=%%M"
+call :log "[HINT] Hidden import likely missing: %HP_HINT_MOD%"
+call :log "[HINT] Consider adding: --hidden-import=%HP_HINT_MOD%"
+:hint_packaging
+call :log "[HINT] EXE behavior differs from Python runtime (possible packaging issue)"
+if exist "%HP_HINT_FILE%" del "%HP_HINT_FILE%" >nul 2>&1
+set "HP_HINT_FILE="
+set "HP_HINT_FILE_NAME="
+set "HP_HINT_MOD="
 exit /b 0
 :write_pipreqs_summary
 if "%HP_JOB_SUMMARY%"=="" exit /b 0

--- a/tools/diag/publish_index.py
+++ b/tools/diag/publish_index.py
@@ -3283,7 +3283,7 @@ def _build_markdown(
         # derived requirement: Run 19201618363-1 exposed only discovery breadcrumbs; suppress the "found" badge until payload files land.
         iterate_found = False
     iterate_log_status = "found" if iterate_found else "missing"
-    iterate_hint = None if iterate_found else "see logs/iterate.MISSING.txt"
+    iterate_hint = None if iterate_found else "missing is OK on green CI (no failures = patcher did not run); see logs/iterate.MISSING.txt"
     diag_files = _diag_files(diag)
     artifact_count, artifact_missing = _artifact_stats(artifacts)
     if iterate_found and artifact_missing:
@@ -3635,7 +3635,7 @@ def _write_html(
     if iterate_found and iterate_file_status == "missing":
         iterate_found = False
     iterate_log_status = "found" if iterate_found else "missing"
-    iterate_hint = None if iterate_found else "see logs/iterate.MISSING.txt"
+    iterate_hint = None if iterate_found else "missing is OK on green CI (no failures = patcher did not run); see logs/iterate.MISSING.txt"
     batch_status = _batch_status(diag, context)
     diag_files = _diag_files(diag)
     gate_data = _load_iterate_gate(context)


### PR DESCRIPTION
## Summary

- **Part 1** (`run_setup.bat`): After EXE smokerun exits non-zero, a new `:exe_smokerun_hints` subroutine re-runs the EXE briefly to capture output, then emits `[HINT]` lines to the existing log stream:
  - `[HINT] Missing data file detected: <file>` + `[HINT] Consider adding: --add-data <file>;.` (triggered by `FileNotFoundError`/`No such file or directory`)
  - `[HINT] Hidden import likely missing: <module>` + `[HINT] Consider adding: --hidden-import=<module>` (triggered by `ModuleNotFoundError`/`No module named`)
  - `[HINT] EXE behavior differs from Python runtime (possible packaging issue)` (always emitted on EXE failure)
  - No existing success/failure logic, log labels, or tests changed.

- **Part 2** (`tools/diag/publish_index.py`): The `iterate_hint` note shown when iterate logs are absent now reads: *"missing is OK on green CI (no failures = patcher did not run); see logs/iterate.MISSING.txt"*. The parser-facing `* Iterate logs: missing` Markdown line is unchanged (required by `_validate_iterate_status_line`).

## Test plan

- [x] Part 1 CI run `24628880332` green: 54 rows, 0 failures (commit `db38aae`)
- [x] Part 2 CI run `24629434475` green: 54 rows, 0 failures (commit `25a5ae7`)
- [x] Iterate hint confirmed in published HTML: `"missing is OK on green CI (no failures = patcher did not run)"`
- [x] All pre-existing rows pass; no regressions
- [x] `python -m compileall -q .` passed; `python tools/check_delimiters.py run_setup.bat` passed; `yamllint` passed

https://claude.ai/code/session_01Et99CfvvW7hUBg3GLwVWrQ