### PR TITLE
Display human-friendly iterate-log status and adjust diagnostics output

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ A branch with zero Python files still counts as healthy when:
 ### Diagnostics and Iterate gate snapshots
 - The diagnostics run-summary page shows a **pre-flight Iterate gate** entry that snapshots the NDJSON inputs before iterate runs. That snapshot is expected to report `has_failures: true` while `tests~test-results.ndjson` and `ci_test_results.ndjson` are still empty so blank inputs cannot pass silently.
 - The later Iterate gate summary (after iterate has produced NDJSON rows) is the real gate verdict; use it to judge pass/fail once results exist.
+- Diagnostics keeps a parser-facing machine line `* Iterate logs: found|missing` in the markdown source, but the human-facing status now reports either `available`, `not needed (all checks passing)`, or `not produced yet (check batch-check run)` to avoid false alarms from the raw word `missing` alone.
 
 The only CI auto-patching agent is the **Model quick-fix (inline)** job in `.github/workflows/batch-check.yml`, which invokes `tools/inline_model_fix.py` against the `gpt-codex-5` model. It only runs when the NDJSON harness reports failures and must respect the git hygiene rules that forbid committing artifacts (tilde-prefixed logs, NDJSON outputs, etc.). See **AGENTS.md** for the full agent policy.
 

--- a/tests/test_publish_index_regex.py
+++ b/tests/test_publish_index_regex.py
@@ -15,6 +15,7 @@ from tools.diag.publish_index import (
     _ensure_diag_log_placeholders,
     _ensure_iterate_log_archive,
     _ensure_repo_index,
+    _iterate_status_display,
     _validate_iterate_status_line,
     _write_global_txt_mirrors,
     _write_html,
@@ -96,6 +97,61 @@ class IterateStatusLineTest(unittest.TestCase):
             )
 
             self.assertIn("Pre-flight iterate gate intentionally fails", markdown)
+
+    def test_markdown_reassures_when_iterate_logs_are_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            diag_root = Path(tmp) / "diag"
+            diag_root.mkdir(parents=True, exist_ok=True)
+
+            context = Context(
+                diag=diag_root,
+                artifacts=diag_root / "_artifacts",
+                artifacts_override=None,
+                downloaded_iter_root=None,
+                repo="owner/repo",
+                branch="main",
+                sha="abc123",
+                run_id="555",
+                run_attempt="1",
+                run_url="https://example.invalid/run",
+                short_sha="abc1234",
+                inventory_b64=None,
+                batch_run_id=None,
+                batch_run_attempt=None,
+                site=None,
+            )
+
+            markdown = _build_markdown(
+                context,
+                None,
+                None,
+                "2025-01-02T03:04:05Z",
+                "2025-01-01T21:04:05-06:00",
+                None,
+                None,
+                None,
+            )
+
+            self.assertIn("* Iterate logs: missing", markdown)
+            self.assertIn("- Iterate logs (human): not produced yet (check batch-check run)", markdown)
+            self.assertIn("if CI is green, iterate logs were not needed", markdown)
+
+
+class IterateStatusDisplayTest(unittest.TestCase):
+    def test_found_status_is_available(self) -> None:
+        self.assertEqual(_iterate_status_display("found", "no failures (success)"), "available")
+
+    def test_missing_status_with_green_batch_is_not_needed(self) -> None:
+        self.assertEqual(
+            _iterate_status_display("missing", "no failures (success)"),
+            "not needed (all checks passing)",
+        )
+
+    def test_missing_status_without_green_batch_is_not_produced(self) -> None:
+        self.assertEqual(
+            _iterate_status_display("missing", "missing"),
+            "not produced yet (check batch-check run)",
+        )
 
 
 class ReloadLinkTest(unittest.TestCase):

--- a/tests/test_publish_index_regex.py
+++ b/tests/test_publish_index_regex.py
@@ -147,6 +147,12 @@ class IterateStatusDisplayTest(unittest.TestCase):
             "not needed (all checks passing)",
         )
 
+    def test_missing_status_with_run_id_batch_is_not_needed(self) -> None:
+        self.assertEqual(
+            _iterate_status_display("missing", "1234 (attempt 1)"),
+            "not needed (all checks passing)",
+        )
+
     def test_missing_status_without_green_batch_is_not_produced(self) -> None:
         self.assertEqual(
             _iterate_status_display("missing", "missing"),

--- a/tools/diag/publish_index.py
+++ b/tools/diag/publish_index.py
@@ -1592,6 +1592,21 @@ def _gate_summary_line(status_data: Optional[dict]) -> str:
     return "n/a"
 
 
+def _iterate_status_display(iterate_log_status: str, batch_status: str) -> str:
+    if iterate_log_status == "found":
+        return "available"
+
+    lowered = (batch_status or "").strip().lower()
+    if "no failures (success)" in lowered or lowered.endswith("/ success"):
+        # derived requirement: people and agents routinely escalated on the word
+        # "missing" when CI was actually green and iterate intentionally skipped.
+        # Keep parser-facing found|missing intact, but show a human-facing status
+        # that spells out the "nothing needed" path.
+        return "not needed (all checks passing)"
+
+    return "not produced yet (check batch-check run)"
+
+
 def _normalize_link(value: Optional[str]) -> Optional[str]:
     if not value:
         return value
@@ -3282,8 +3297,10 @@ def _build_markdown(
     if iterate_found and iterate_file_status == "missing":
         # derived requirement: Run 19201618363-1 exposed only discovery breadcrumbs; suppress the "found" badge until payload files land.
         iterate_found = False
+    batch_status = _batch_status(diag, context)
     iterate_log_status = "found" if iterate_found else "missing"
-    iterate_hint = None if iterate_found else "missing is OK on green CI (no failures = patcher did not run); see logs/iterate.MISSING.txt"
+    iterate_status_display = _iterate_status_display(iterate_log_status, batch_status)
+    iterate_hint = None if iterate_found else "if CI is green, iterate logs were not needed; see logs/iterate.MISSING.txt"
     diag_files = _diag_files(diag)
     artifact_count, artifact_missing = _artifact_stats(artifacts)
     if iterate_found and artifact_missing:
@@ -3295,7 +3312,6 @@ def _build_markdown(
             # stops claiming the artifact is missing. Likewise, treat historical
             # "no completed run" sentinels as stale once iterate evidence is available.
             artifact_missing = None
-    batch_status = _batch_status(diag, context)
     gate_data = _load_iterate_gate(context)
     inputs_info = _iterate_inputs_info(context)
     lines: List[str] = []
@@ -3320,6 +3336,7 @@ def _build_markdown(
             "",
             "## Status",
             f"* Iterate logs: {iterate_log_status}",
+            f"- Iterate logs (human): {iterate_status_display}",
             f"- Batch-check run id: {batch_status}",
             f"- Artifact files enumerated: {artifact_count}",
         ]
@@ -3634,9 +3651,10 @@ def _write_html(
     iterate_file_status, iterate_key_files = _summarize_iterate_files(context)
     if iterate_found and iterate_file_status == "missing":
         iterate_found = False
-    iterate_log_status = "found" if iterate_found else "missing"
-    iterate_hint = None if iterate_found else "missing is OK on green CI (no failures = patcher did not run); see logs/iterate.MISSING.txt"
     batch_status = _batch_status(diag, context)
+    iterate_log_status = "found" if iterate_found else "missing"
+    iterate_status_display = _iterate_status_display(iterate_log_status, batch_status)
+    iterate_hint = None if iterate_found else "if CI is green, iterate logs were not needed; see logs/iterate.MISSING.txt"
     diag_files = _diag_files(diag)
     gate_data = _load_iterate_gate(context)
 
@@ -3655,7 +3673,7 @@ def _write_html(
     ]
 
     status_pairs = [
-        {"label": "Iterate logs", "value": iterate_log_status},
+        {"label": "Iterate logs", "value": iterate_status_display},
         {"label": "Batch-check run id", "value": batch_status},
         {"label": "Artifact files enumerated", "value": str(artifact_count)},
     ]

--- a/tools/diag/publish_index.py
+++ b/tools/diag/publish_index.py
@@ -1596,8 +1596,14 @@ def _iterate_status_display(iterate_log_status: str, batch_status: str) -> str:
     if iterate_log_status == "found":
         return "available"
 
-    lowered = (batch_status or "").strip().lower()
-    if "no failures (success)" in lowered or lowered.endswith("/ success"):
+    normalized = (batch_status or "").strip()
+    lowered = normalized.lower()
+    green_batch = (
+        "no failures (success)" in lowered
+        or lowered.endswith("/ success")
+        or bool(re.fullmatch(r"\d+(?:\s*\(attempt\s*\d+\))?", normalized))
+    )
+    if green_batch:
         # derived requirement: people and agents routinely escalated on the word
         # "missing" when CI was actually green and iterate intentionally skipped.
         # Keep parser-facing found|missing intact, but show a human-facing status


### PR DESCRIPTION
### Motivation
- The diagnostics page should preserve the parser-friendly `found|missing` marker but present a clearer human-facing status to avoid false alarms when CI is green and iterate was intentionally skipped.
- Provide a single place to map raw iterate presence and batch-check results into readable labels for both Markdown and HTML outputs.

### Description
- Add `_iterate_status_display(iterate_log_status, batch_status)` to map `found`/`missing` plus batch status into `available`, `not needed (all checks passing)`, or `not produced yet (check batch-check run)`.
- Use the new `_iterate_status_display` in the Markdown and HTML builders so the human-facing diagnostics show the new labels while preserving the raw `Iterate logs: found|missing` line for parsers.
- Adjust the iterate hint text to read `if CI is green, iterate logs were not needed; see logs/iterate.MISSING.txt` and ensure `batch_status` is computed before deriving the display string.
- Add unit tests in `tests/test_publish_index_regex.py` to cover the new display logic and to assert the Markdown includes the reassuring explanatory lines when iterate logs are missing.

### Testing
- Ran the new unit tests with `python -m unittest tests.test_publish_index_regex` and the test cases in that file all passed.
- The repository unit test run for the updated file validated `test_markdown_reassures_when_iterate_logs_are_missing` and the `IterateStatusDisplayTest` scenarios, and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed7c3632f0832ab10b3d67bdcb10bb)