### PR TITLE
feat(uv): enforce uv contract — logging, diag visibility, contract test lanes

### DIFF
--- a/.github/workflows/batch-check.yml
+++ b/.github/workflows/batch-check.yml
@@ -38,7 +38,11 @@ jobs:
           - mode: justme-test
           # uv: explicit lane for uv env+dep installer path (no HP_FORCE_CONDA_ONLY)
           - mode: uv
-    continue-on-error: ${{ matrix.mode == 'cache' || matrix.mode == 'justme-test' || matrix.mode == 'uv' }}
+          # contract-uv: enforces uv contract on the happy path (informational while shaking out)
+          - mode: contract-uv
+          # contract-uv-fail: HP_TEST_UV_FAIL=1 forces uv venv to fail; asserts explicit conda fallback
+          - mode: contract-uv-fail
+    continue-on-error: ${{ matrix.mode == 'cache' || matrix.mode == 'justme-test' || matrix.mode == 'uv' || matrix.mode == 'contract-uv' || matrix.mode == 'contract-uv-fail' }}
     runs-on: windows-latest
 
     outputs:
@@ -63,12 +67,21 @@ jobs:
           restore-keys: |
             win-${{ runner.os }}-py311-conda-
 
-      # probe fires in real, conda-full, and uv; cache lane skips it intentionally
-      - name: Enable Miniconda probe (real/conda-full/uv mode)
-        if: ${{ matrix.mode == 'real' || matrix.mode == 'conda-full' || matrix.mode == 'uv' }}
+      # probe fires in real, conda-full, uv, and contract-uv* lanes; cache lane skips it intentionally
+      - name: Enable Miniconda probe (real/conda-full/uv/contract-uv mode)
+        if: ${{ matrix.mode == 'real' || matrix.mode == 'conda-full' || matrix.mode == 'uv' || matrix.mode == 'contract-uv' || matrix.mode == 'contract-uv-fail' }}
         shell: pwsh
         run: |
           'HP_CI_TEST_CONDA_DL=1' | Out-File -FilePath $env:GITHUB_ENV -Encoding ascii -Append
+
+      # contract-uv-fail only: HP_TEST_UV_FAIL=1 forces uv venv creation to fail so the
+      # bootstrapper takes the existing conda fallback path. The contract assertion then
+      # verifies UV_FALLBACK reason=venv_create_failed and HP_ENV_MODE=conda were logged.
+      - name: Force uv failure (contract-uv-fail only)
+        if: ${{ matrix.mode == 'contract-uv-fail' }}
+        shell: pwsh
+        run: |
+          'HP_TEST_UV_FAIL=1' | Out-File -FilePath $env:GITHUB_ENV -Encoding ascii -Append
 
       # conda-full only: clears venv/system fallbacks so a conda failure can't hide as a venv pass
       - name: Force conda-only bootstrap
@@ -194,6 +207,12 @@ jobs:
         shell: pwsh
         run: |
           & tests\selfapps_envsmoke.ps1
+
+      - name: "Self-test: uv contract assertions (contract-uv* only)"
+        if: ${{ matrix.mode == 'contract-uv' || matrix.mode == 'contract-uv-fail' }}
+        shell: pwsh
+        run: |
+          & tests\selfapps_contract_uv.ps1
 
       - name: "Self-test: JustMe install path (justme-test only)"
         if: ${{ matrix.mode == 'justme-test' }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,6 +263,18 @@ justme-test lane rows (subset, flag-triggered):
 conda.install.justme
 ```
 
+contract-uv lane rows (flag-triggered):
+
+```
+self.contract.uv
+```
+
+contract-uv-fail lane rows (HP_TEST_UV_FAIL=1, flag-triggered):
+
+```
+self.contract.uv.fail
+```
+
 Test-logs NDJSON (from harness/selftest, additional rows):
 
 ```

--- a/run_setup.bat
+++ b/run_setup.bat
@@ -303,6 +303,10 @@ rem folder, short-circuiting conda create. On failure, :try_conda_create runs th
 rem existing conda path unchanged. Python version from PYSPEC is not yet forwarded
 rem to uv (version-pinning deferred; uv picks the system default Python).
 if not defined HP_UV_EXE goto :try_conda_create
+if "%HP_TEST_UV_FAIL%"=="1" (
+  call :log "[TEST] Injecting uv failure"
+  goto :uv_venv_fail
+)
 set "HP_UV_ENV_PATH=%HP_SCRIPT_ROOT%.uv_env"
 if exist "%HP_UV_ENV_PATH%\Scripts\python.exe" (
   "%HP_UV_ENV_PATH%\Scripts\python.exe" -c "import pip;exit(0)" >nul 2>&1

--- a/run_setup.bat
+++ b/run_setup.bat
@@ -751,6 +751,8 @@ if exist "requirements.txt" (
       if errorlevel 1 (
         echo *** Warning: Some requirements may have failed to install.
         call :log "[WARN] uv pip install -r requirements.txt failed; some packages may be missing."
+        set "UV_FALLBACK_REASON=dep_install_failed"
+        call :log "[WARN] UV_FALLBACK reason=dep_install_failed"
       )
     )
     call :log "[INFO] UV_USED=1"
@@ -783,6 +785,10 @@ if "%HP_ENV_MODE%"=="uv" (
   rem already captured in ~dependency_installed.txt to avoid a second freeze call.
   if exist "~dependency_installed.txt" copy /y "~dependency_installed.txt" "~environment.lock.txt" >nul 2>&1
   if exist "~environment.lock.txt" call :log "[INFO] Environment snapshot written: ~environment.lock.txt"
+  if not exist "~environment.lock.txt" (
+    set "UV_FALLBACK_REASON=lock_failed"
+    call :log "[WARN] UV_FALLBACK reason=lock_failed"
+  )
   goto :lock_done
 )
 if not "%HP_ENV_MODE%"=="conda" goto :lock_done

--- a/run_setup.bat
+++ b/run_setup.bat
@@ -238,6 +238,8 @@ if exist "%HP_UV_BIN%\uv.exe" (
   call :log "[INFO] uv: acquired at ~uv_bin\uv.exe"
 ) else (
   call :log "[WARN] uv: acquisition failed; will use conda for env creation."
+  set "UV_FALLBACK_REASON=acquire_failed"
+  call :log "[WARN] UV_FALLBACK reason=acquire_failed"
 )
 :uv_acquire_done
 
@@ -331,8 +333,11 @@ if not errorlevel 1 (
 goto :after_env_mode_selection
 :uv_venv_fail
 call :log "[WARN] uv: venv creation failed; falling back to conda create."
+set "UV_FALLBACK_REASON=venv_create_failed"
+call :log "[WARN] UV_FALLBACK reason=venv_create_failed"
 set "HP_UV_EXE="
 :try_conda_create
+call :log "[INFO] HP_ENV_MODE=conda"
 if "%PYSPEC%"=="" (
   call "%CONDA_BAT%" create -y -n "%ENVNAME%" "python<3.13" --override-channels -c conda-forge >> "%LOG%" 2>&1
 ) else (

--- a/tests/selfapps_contract_uv.ps1
+++ b/tests/selfapps_contract_uv.ps1
@@ -1,0 +1,98 @@
+$ErrorActionPreference = 'Continue'
+$here = $PSScriptRoot
+$repo = Split-Path -Path $here -Parent
+$nd   = Join-Path $here '~test-results.ndjson'
+$ciNd = Join-Path $repo 'ci_test_results.ndjson'
+if (-not (Test-Path $nd)) { New-Item -ItemType File -Path $nd -Force | Out-Null }
+if (-not (Test-Path $ciNd)) { New-Item -ItemType File -Path $ciNd -Force | Out-Null }
+
+function Write-NdjsonRow {
+    param([hashtable]$Row)
+    $json = $Row | ConvertTo-Json -Compress -Depth 8
+    Add-Content -LiteralPath $nd   -Value $json -Encoding Ascii
+    Add-Content -LiteralPath $ciNd -Value $json -Encoding Ascii
+}
+
+# derived requirement: this script asserts the uv contract using only artifacts
+# left behind by the envsmoke run. It does not invoke run_setup.bat itself.
+$envsmoke = Join-Path $here '~envsmoke'
+$setupLog = Join-Path $envsmoke '~setup.log'
+$lockFile = Join-Path $envsmoke '~environment.lock.txt'
+$runtimeTxt = Join-Path $envsmoke 'runtime.txt'
+
+$logText = ''
+if (Test-Path -LiteralPath $setupLog) {
+    $logText = Get-Content -LiteralPath $setupLog -Raw -ErrorAction SilentlyContinue
+    if (-not $logText) { $logText = '' }
+}
+
+$lane = [Environment]::GetEnvironmentVariable('HP_CI_LANE')
+$fallbackInjected = ($logText -match '\[TEST\] Injecting uv failure')
+$fallbackLogged = ($logText -match '\[WARN\] UV_FALLBACK reason=(\w+)')
+$fallbackReason = if ($fallbackLogged) { $matches[1] } else { '' }
+$envModeLines = [regex]::Matches($logText, 'HP_ENV_MODE=(\w+)')
+$lastEnvMode = if ($envModeLines.Count -gt 0) { $envModeLines[$envModeLines.Count - 1].Groups[1].Value } else { 'unknown' }
+$uvUsedSignal = ($logText -match '\[INFO\] UV_USED=1')
+
+$lockExists = Test-Path -LiteralPath $lockFile
+$lockNonEmpty = $false
+if ($lockExists) {
+    try { $lockNonEmpty = ((Get-Item -LiteralPath $lockFile).Length -gt 0) } catch { $lockNonEmpty = $false }
+}
+
+$runtimeExists = Test-Path -LiteralPath $runtimeTxt
+$runtimeValid = $false
+if ($runtimeExists) {
+    $runtimeContent = (Get-Content -LiteralPath $runtimeTxt -Raw -ErrorAction SilentlyContinue) -replace '\s', ''
+    $runtimeValid = ($runtimeContent -match '^python-3\.\d+')
+}
+
+if ($lane -eq 'contract-uv-fail') {
+    # Failure-injection contract: HP_TEST_UV_FAIL=1 was set; assert explicit fallback to conda
+    $assertions = [ordered]@{
+        injectionLogged   = $fallbackInjected
+        fallbackLogged    = $fallbackLogged
+        fallbackReason    = $fallbackReason
+        finalEnvMode      = $lastEnvMode
+        finalEnvModeIsConda = ($lastEnvMode -eq 'conda')
+        lockExists        = $lockExists
+        lockNonEmpty      = $lockNonEmpty
+        runtimeExists     = $runtimeExists
+        runtimeValid      = $runtimeValid
+    }
+    $pass = $fallbackInjected -and $fallbackLogged -and `
+            ($fallbackReason -eq 'venv_create_failed') -and `
+            ($lastEnvMode -eq 'conda') -and `
+            $lockNonEmpty -and $runtimeValid
+    Write-NdjsonRow ([ordered]@{
+        id      = 'self.contract.uv.fail'
+        req     = 'REQ-003'
+        pass    = [bool]$pass
+        desc    = 'Forced uv failure must produce explicit conda fallback'
+        details = $assertions
+        lane    = $lane
+    })
+} else {
+    # Happy contract: assert uv-as-authority end-to-end
+    $assertions = [ordered]@{
+        envModeIsUv      = ($lastEnvMode -eq 'uv')
+        finalEnvMode     = $lastEnvMode
+        uvUsedSignal     = $uvUsedSignal
+        lockExists       = $lockExists
+        lockNonEmpty     = $lockNonEmpty
+        runtimeExists    = $runtimeExists
+        runtimeValid     = $runtimeValid
+        noFallbackLogged = (-not $fallbackLogged)
+        fallbackReason   = $fallbackReason
+    }
+    $pass = ($lastEnvMode -eq 'uv') -and $uvUsedSignal -and `
+            $lockNonEmpty -and $runtimeValid -and (-not $fallbackLogged)
+    Write-NdjsonRow ([ordered]@{
+        id      = 'self.contract.uv'
+        req     = 'REQ-003'
+        pass    = [bool]$pass
+        desc    = 'uv must be authoritative end-to-end on happy path'
+        details = $assertions
+        lane    = $lane
+    })
+}

--- a/tests/selfapps_contract_uv.ps1
+++ b/tests/selfapps_contract_uv.ps1
@@ -85,7 +85,7 @@ if ($lane -eq 'contract-uv-fail') {
         noFallbackLogged = (-not $fallbackLogged)
         fallbackReason   = $fallbackReason
     }
-    $pass = ($lastEnvMode -eq 'uv') -and $uvUsedSignal -and `
+    $pass = ($lastEnvMode -eq 'uv') -and `
             $lockNonEmpty -and $runtimeValid -and (-not $fallbackLogged)
     Write-NdjsonRow ([ordered]@{
         id      = 'self.contract.uv'

--- a/tests/selfapps_envsmoke.ps1
+++ b/tests/selfapps_envsmoke.ps1
@@ -427,13 +427,13 @@ $uvSmokePass = if ($uvSmokeForceSkip) { $true }
                elseif (-not $isUvMode) { $true }
                else { $bootstrapPass -and $errorSignalPass }
 $uvSmokeDetails = if ($uvSmokeForceSkip) {
-    [ordered]@{ skip=$true; reason='HP_FORCE_CONDA_ONLY' }
+    [ordered]@{ state='force-skip'; skip=$true; reason='HP_FORCE_CONDA_ONLY' }
 } elseif (-not $uvAcquired) {
-    [ordered]@{ skip=$true; reason='uv-not-acquired'; bootstrapPass=$bootstrapPass }
+    [ordered]@{ state='not-acquired'; skip=$true; reason='uv-not-acquired'; bootstrapPass=$bootstrapPass }
 } elseif (-not $isUvMode) {
-    [ordered]@{ skip=$true; reason='uv-acquired-but-fell-back'; uvAcquired=$uvAcquired; bootstrapPass=$bootstrapPass }
+    [ordered]@{ state='acquired-but-fell-back'; skip=$true; reason='uv-acquired-but-fell-back'; uvAcquired=$uvAcquired; bootstrapPass=$bootstrapPass }
 } else {
-    [ordered]@{ isUvMode=$isUvMode; uvAcquired=$uvAcquired; bootstrapPass=$bootstrapPass; interpreterPath=$interpreterPath }
+    [ordered]@{ state='acquired-used'; isUvMode=$isUvMode; uvAcquired=$uvAcquired; bootstrapPass=$bootstrapPass; interpreterPath=$interpreterPath }
 }
 Write-NdjsonRow ([ordered]@{
     id='self.env.smoke.uv'

--- a/tests/test_publish_index_regex.py
+++ b/tests/test_publish_index_regex.py
@@ -15,6 +15,7 @@ from tools.diag.publish_index import (
     _ensure_diag_log_placeholders,
     _ensure_iterate_log_archive,
     _ensure_repo_index,
+    _extract_uv_signals,
     _validate_iterate_status_line,
     _write_global_txt_mirrors,
     _write_html,
@@ -795,6 +796,59 @@ class QuickLinksRenderingTest(unittest.TestCase):
         self.assertIn("  reason1", index_txt)
         self.assertIn("Prompt (head):", index_txt)
         self.assertIn("  line1", index_txt)
+
+
+class ExtractUvSignalsTest(unittest.TestCase):
+    def _make_setup_log(self, tmpdir: Path, lane: str, log_text: str, *, lock_text: str = "") -> Path:
+        diag = tmpdir / "diag"
+        scenario = (
+            diag
+            / "_artifacts"
+            / "batch-check"
+            / "test-logs"
+            / f"test-logs-selftest-{lane}-1234-1"
+            / "tests"
+            / "~envsmoke"
+        )
+        scenario.mkdir(parents=True)
+        (scenario / "~setup.log").write_text(log_text, encoding="utf-8")
+        if lock_text:
+            (scenario / "~environment.lock.txt").write_text(lock_text, encoding="utf-8")
+        return diag
+
+    def test_returns_default_when_diag_missing(self) -> None:
+        sig = _extract_uv_signals(None)
+        self.assertEqual(sig["env_provider"], "unknown")
+        self.assertEqual(sig["uv_used"], "0")
+        self.assertEqual(sig["uv_fallback_reason"], "none")
+        self.assertEqual(sig["lock_present"], "no")
+
+    def test_acquired_used_signals(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            diag = self._make_setup_log(
+                Path(tmp),
+                "real",
+                "[INFO] HP_ENV_MODE=uv\n[INFO] UV_USED=1\n",
+                lock_text="pkg==1.0\n",
+            )
+            sig = _extract_uv_signals(diag)
+            self.assertEqual(sig["env_provider"], "uv")
+            self.assertEqual(sig["uv_used"], "1")
+            self.assertEqual(sig["uv_fallback_reason"], "none")
+            self.assertEqual(sig["lock_present"], "yes")
+
+    def test_fallback_reason_captured(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            diag = self._make_setup_log(
+                Path(tmp),
+                "real",
+                "[INFO] HP_ENV_MODE=uv\n[WARN] UV_FALLBACK reason=venv_create_failed\n[INFO] HP_ENV_MODE=conda\n",
+            )
+            sig = _extract_uv_signals(diag)
+            self.assertEqual(sig["env_provider"], "conda")
+            self.assertEqual(sig["uv_fallback_reason"], "venv_create_failed")
+            self.assertEqual(sig["lock_present"], "no")
+            self.assertEqual(sig["uv_used"], "0")
 
 
 if __name__ == "__main__":

--- a/tests/test_publish_index_regex.py
+++ b/tests/test_publish_index_regex.py
@@ -850,6 +850,26 @@ class ExtractUvSignalsTest(unittest.TestCase):
             self.assertEqual(sig["lock_present"], "no")
             self.assertEqual(sig["uv_used"], "0")
 
+    def test_uv_used_reflects_env_provider_when_no_install_logged(self) -> None:
+        # Stub apps with no requirements.txt take uv end-to-end (HP_ENV_MODE=uv,
+        # .uv_env created) but the [INFO] UV_USED=1 line never fires because the
+        # requirements.txt install path is skipped. The diag display must still
+        # report UV_USED=1 so it matches user intent ("uv was used").
+        with tempfile.TemporaryDirectory() as tmp:
+            diag = self._make_setup_log(
+                Path(tmp),
+                "real",
+                "[INFO] uv: acquired at ~uv_bin\\uv.exe\n"
+                "[INFO] uv: venv created at .uv_env\n"
+                "[INFO] HP_ENV_MODE=uv\n",
+                lock_text="pkg==1.0\n",
+            )
+            sig = _extract_uv_signals(diag)
+            self.assertEqual(sig["env_provider"], "uv")
+            self.assertEqual(sig["uv_used"], "1")
+            self.assertEqual(sig["uv_fallback_reason"], "none")
+            self.assertEqual(sig["lock_present"], "yes")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_publish_index_regex.py
+++ b/tests/test_publish_index_regex.py
@@ -850,6 +850,42 @@ class ExtractUvSignalsTest(unittest.TestCase):
             self.assertEqual(sig["lock_present"], "no")
             self.assertEqual(sig["uv_used"], "0")
 
+    def test_contract_lanes_do_not_stomp_real_lane(self) -> None:
+        # Regression: contract-uv and contract-uv-fail artifact dirs must be
+        # classified separately so they cannot be picked when the chooser
+        # prefers "real". Reproduce by giving the contract lane a sentinel
+        # value (UV_FALLBACK reason=acquire_failed) and the real lane the
+        # canonical happy-path log; the helper must return the real lane data.
+        with tempfile.TemporaryDirectory() as tmp:
+            diag = Path(tmp) / "diag"
+            test_logs = diag / "_artifacts" / "batch-check" / "test-logs"
+            for lane_dir, log_text, lock_text in [
+                (
+                    "test-logs-selftest-contract-uv-1234-1",
+                    "[INFO] HP_ENV_MODE=conda\n[WARN] UV_FALLBACK reason=acquire_failed\n",
+                    "",
+                ),
+                (
+                    "test-logs-selftest-contract-uv-fail-1234-1",
+                    "[INFO] HP_ENV_MODE=conda\n[WARN] UV_FALLBACK reason=venv_create_failed\n",
+                    "",
+                ),
+                (
+                    "test-logs-selftest-real-1234-1",
+                    "[INFO] uv: venv created at .uv_env\n[INFO] HP_ENV_MODE=uv\n",
+                    "pkg==1.0\n",
+                ),
+            ]:
+                scenario = test_logs / lane_dir / "tests" / "~envsmoke"
+                scenario.mkdir(parents=True)
+                (scenario / "~setup.log").write_text(log_text, encoding="utf-8")
+                if lock_text:
+                    (scenario / "~environment.lock.txt").write_text(lock_text, encoding="utf-8")
+            sig = _extract_uv_signals(diag)
+            self.assertEqual(sig["env_provider"], "uv")
+            self.assertEqual(sig["uv_fallback_reason"], "none")
+            self.assertEqual(sig["lock_present"], "yes")
+
     def test_uv_used_reflects_env_provider_when_no_install_logged(self) -> None:
         # Stub apps with no requirements.txt take uv end-to-end (HP_ENV_MODE=uv,
         # .uv_env created) but the [INFO] UV_USED=1 line never fires because the

--- a/tools/diag/publish_index.py
+++ b/tools/diag/publish_index.py
@@ -2415,10 +2415,26 @@ def _extract_uv_signals(diag: Optional[Path]) -> dict:
             lane = "conda-full"
         elif "cache" in dir_name:
             lane = "cache"
-        elif "uv" in dir_name and "selftest-uv" in dir_name:
+        # derived requirement: more-specific lane names must be tested before
+        # broader ones. The contract-uv* names contain "uv" and would otherwise
+        # match the bare "uv" lane (or fall through to "real") and stomp on the
+        # canonical real-lane signals on the diag page.
+        elif "contract-uv-fail" in dir_name:
+            lane = "contract-uv-fail"
+        elif "contract-uv" in dir_name:
+            lane = "contract-uv"
+        elif "justme-test" in dir_name:
+            lane = "justme-test"
+        elif "selftest-uv-" in dir_name:
             lane = "uv"
-        else:
+        elif "real" in dir_name:
             lane = "real"
+        else:
+            # Unknown lane name; do not silently bucket as "real" -- record the
+            # artifact dir name so the chooser cannot pick it and so any
+            # mislabeling is visible in the (rare) downstream consumer that
+            # iterates raw lane values.
+            lane = f"unknown:{artifact_dir.name}"
         scenario_dir = artifact_dir / "tests" / "~envsmoke"
         log_path = scenario_dir / "~setup.log"
         if log_path.exists():

--- a/tools/diag/publish_index.py
+++ b/tools/diag/publish_index.py
@@ -2387,6 +2387,76 @@ def _collect_batch_ndjson_links(diag: Optional[Path]) -> List[dict]:
     return results
 
 
+def _extract_uv_signals(diag: Optional[Path]) -> dict:
+    """Extract uv-related signals from the most informative ~setup.log.
+
+    Returns a dict with: env_provider, uv_used, uv_fallback_reason, lock_present.
+    Prefers the real lane's ~envsmoke setup log; falls back to whichever lane is found.
+    """
+    default = {
+        "env_provider": "unknown",
+        "uv_used": "0",
+        "uv_fallback_reason": "none",
+        "lock_present": "no",
+    }
+    if not diag:
+        return default
+    test_logs_root = diag / "_artifacts" / "batch-check" / "test-logs"
+    if not test_logs_root.exists():
+        return default
+    candidates: List[Tuple[str, Path, Path]] = []
+    try:
+        artifact_dirs = sorted(p for p in test_logs_root.iterdir() if p.is_dir())
+    except OSError:
+        return default
+    for artifact_dir in artifact_dirs:
+        dir_name = artifact_dir.name.lower()
+        if "conda-full" in dir_name:
+            lane = "conda-full"
+        elif "cache" in dir_name:
+            lane = "cache"
+        elif "uv" in dir_name and "selftest-uv" in dir_name:
+            lane = "uv"
+        else:
+            lane = "real"
+        scenario_dir = artifact_dir / "tests" / "~envsmoke"
+        log_path = scenario_dir / "~setup.log"
+        if log_path.exists():
+            candidates.append((lane, log_path, scenario_dir))
+    if not candidates:
+        return default
+    chosen: Optional[Tuple[str, Path, Path]] = None
+    for preferred in ("real", "uv", "conda-full", "cache"):
+        for entry in candidates:
+            if entry[0] == preferred:
+                chosen = entry
+                break
+        if chosen:
+            break
+    if not chosen:
+        chosen = candidates[0]
+    _, log_path, scenario_dir = chosen
+    try:
+        text = log_path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return default
+    env_provider = "unknown"
+    for match in re.finditer(r"HP_ENV_MODE=(\w+)", text):
+        env_provider = match.group(1)
+    uv_used = "1" if "UV_USED=1" in text else "0"
+    fallback_reason = "none"
+    for match in re.finditer(r"UV_FALLBACK reason=(\w+)", text):
+        fallback_reason = match.group(1)
+    lock_path = scenario_dir / "~environment.lock.txt"
+    lock_present = "yes" if lock_path.exists() and _nonempty_file(lock_path) else "no"
+    return {
+        "env_provider": env_provider,
+        "uv_used": uv_used,
+        "uv_fallback_reason": fallback_reason,
+        "lock_present": lock_present,
+    }
+
+
 def _collect_setup_log_links(diag: Optional[Path]) -> List[dict]:
     """Return quick-link entries for ~setup.log files from each test scenario and lane.
 
@@ -3324,6 +3394,11 @@ def _build_markdown(
             f"- Artifact files enumerated: {artifact_count}",
         ]
     )
+    uv_signals = _extract_uv_signals(diag)
+    lines.append(f"- ENV_PROVIDER: {uv_signals['env_provider']}")
+    lines.append(f"- UV_USED: {uv_signals['uv_used']}")
+    lines.append(f"- UV_FALLBACK_REASON: {uv_signals['uv_fallback_reason']}")
+    lines.append(f"- environment.lock.txt: {uv_signals['lock_present']}")
     if gate_data:
         stage_value = gate_data.get("stage", "n/a")
         lines.append(f"- Gate stage: {stage_value}")
@@ -3659,6 +3734,11 @@ def _write_html(
         {"label": "Batch-check run id", "value": batch_status},
         {"label": "Artifact files enumerated", "value": str(artifact_count)},
     ]
+    uv_signals = _extract_uv_signals(diag)
+    status_pairs.append({"label": "ENV_PROVIDER", "value": uv_signals["env_provider"]})
+    status_pairs.append({"label": "UV_USED", "value": uv_signals["uv_used"]})
+    status_pairs.append({"label": "UV_FALLBACK_REASON", "value": uv_signals["uv_fallback_reason"]})
+    status_pairs.append({"label": "environment.lock.txt", "value": uv_signals["lock_present"]})
     if gate_data:
         status_pairs.append({"label": "Gate stage", "value": gate_data.get("stage", "n/a")})
         status_pairs.append({"label": "Gate proceed", "value": str(gate_data.get("proceed", True)).lower()})

--- a/tools/diag/publish_index.py
+++ b/tools/diag/publish_index.py
@@ -2443,7 +2443,20 @@ def _extract_uv_signals(diag: Optional[Path]) -> dict:
     env_provider = "unknown"
     for match in re.finditer(r"HP_ENV_MODE=(\w+)", text):
         env_provider = match.group(1)
-    uv_used = "1" if "UV_USED=1" in text else "0"
+    # derived requirement: UV_USED=1 in run_setup.bat only fires from inside the
+    # requirements.txt install path; stub apps with no requirements.txt still take
+    # uv end-to-end (env_provider=uv) but never emit UV_USED=1. Treat env_provider
+    # uv OR the explicit log line OR the venv-created/reused signal as evidence
+    # that uv was used so the diag display matches user intent.
+    uv_used = (
+        "1"
+        if (
+            env_provider == "uv"
+            or "UV_USED=1" in text
+            or re.search(r"\[INFO\] uv: (venv created|reusing existing)", text)
+        )
+        else "0"
+    )
     fallback_reason = "none"
     for match in re.finditer(r"UV_FALLBACK reason=(\w+)", text):
         fallback_reason = match.group(1)


### PR DESCRIPTION
## Summary

Five-commit series that turns the just-landed uv installer path from "works" into a **provable, regression-protected contract**, and surfaces uv state directly in the diagnostics site.

- **`feat(uv): standardized fallback reason logging and smoke state field` (1b92e1c)** — Adds `UV_FALLBACK_REASON` env var + `[WARN] UV_FALLBACK reason=<x>` log lines at the existing `acquire_failed` / `venv_create_failed` fallback points. Mirrors the existing `[INFO] HP_ENV_MODE=uv` line with `[INFO] HP_ENV_MODE=conda` at the conda branch entry. Adds an explicit `state` field to `self.env.smoke.uv` NDJSON details (`force-skip` / `not-acquired` / `acquired-but-fell-back` / `acquired-used`). Existing keys preserved — additive only.
- **`feat(uv): record dep_install_failed and lock_failed fallback reasons` (8f175bd)** — Records (no enforcement) two more reason strings: `dep_install_failed` (uv pip install -r requirements.txt errored) and `lock_failed` (~environment.lock.txt write failed in uv mode).
- **`feat(diag): surface ENV_PROVIDER, UV_USED, UV_FALLBACK_REASON, lock present` (8bfba4e)** — `tools/diag/publish_index.py` now extracts these signals from `~setup.log` and renders them in the per-run Status section (markdown + HTML). 3 unit tests added. Pure read-side; no NDJSON or run_setup behavior changes.
- **`feat(uv): contract test lanes (happy + failure injection)` (d9f7a0f)** — Two new CI matrix lanes:
  - **`contract-uv`** asserts uv was authoritative end-to-end (HP_ENV_MODE=uv final, lock non-empty, runtime.txt valid, no UV_FALLBACK reason). Emits `self.contract.uv` NDJSON row.
  - **`contract-uv-fail`** sets `HP_TEST_UV_FAIL=1` which forces uv venv creation to take the existing `:uv_venv_fail` fallback path; asserts `[TEST] Injecting uv failure`, `UV_FALLBACK reason=venv_create_failed`, final HP_ENV_MODE=conda, runtime.txt still valid. Emits `self.contract.uv.fail` row. The 4-line failure-injection hook in run_setup.bat is gated on `HP_TEST_UV_FAIL=1`; production behavior is unchanged when the flag is unset.
- **`fix(uv): relax self.contract.uv to not require [INFO] UV_USED=1` (36ec419)** — `UV_USED=1` only fires when run_setup.bat reaches the requirements.txt install path. Stub apps with no requirements.txt still take uv end-to-end but never emit it. Drop `uvUsedSignal` from the pass criteria; `envModeIsUv` (final HP_ENV_MODE=uv) is the authoritative signal.

CI verification — all 7 lanes green on the final commit:

| Lane | Rows | Failed |
|------|------|--------|
| cache | 36 | 0 |
| real | 50 | 0 |
| conda-full | 56 | 0 |
| justme-test | 37 | 0 |
| uv | 36 | 0 |
| contract-uv | 37 | 0 (`self.contract.uv` pass=true) |
| contract-uv-fail | 37 | 0 (`self.contract.uv.fail` pass=true) |

Diag site now shows `ENV_PROVIDER`, `UV_USED`, `UV_FALLBACK_REASON`, `environment.lock.txt: yes/no` in the Status section of every run.

`CLAUDE.md` updated with the two new NDJSON ids.

## Test plan
- [x] All 5 existing lanes (cache, real, conda-full, justme-test, uv) remain green
- [x] New `contract-uv` lane passes — `self.contract.uv` NDJSON row pass=true
- [x] New `contract-uv-fail` lane passes — `HP_TEST_UV_FAIL=1` triggers existing fallback, `self.contract.uv.fail` row pass=true with `fallbackReason=venv_create_failed` and `finalEnvMode=conda`
- [x] Diag site Status section shows the new `ENV_PROVIDER` / `UV_USED` / `UV_FALLBACK_REASON` / `environment.lock.txt` bullets
- [x] Pre-commit checks (compileall, pyflakes, check_delimiters, yamllint) clean on each push
- [x] `python -m pytest tests/test_publish_index_regex.py` — 3 new `_extract_uv_signals` tests pass; one pre-existing failure (`test_site_overview_emits_one_line_per_entry`) is unrelated to this change

https://claude.ai/code/session_01EYcd1ZnzbUtkgqvuJnDhxK

---
_Generated by [Claude Code](https://claude.ai/code/session_01EYcd1ZnzbUtkgqvuJnDhxK)_