### PR TITLE
fix: strip quotes from PyInstaller 6.x module token in parse_warn

### DIFF
--- a/tests/test_parse_warn.py
+++ b/tests/test_parse_warn.py
@@ -168,6 +168,13 @@ class ParseWarnFileEdgeCasesTest(unittest.TestCase):
         ])
         self.assertEqual(result, ["opencv"])
 
+    def test_pyi6_quoted_module_name_strips_quotes(self):
+        # PyInstaller 6.x may quote the module name; quotes must not appear in output
+        result = _parse_lines([
+            "missing module named 'collections' - imported by app (top-level)"
+        ])
+        self.assertEqual(result, ["collections"])
+
     def test_submodule_resolves_to_root(self):
         # PIL.Image.open -> root PIL -> pillow
         result = _parse_lines(["W: no module named 'PIL.Image'"])

--- a/tools/parse_warn.py
+++ b/tools/parse_warn.py
@@ -91,7 +91,7 @@ def parse_warn_file(warn_path):
                     continue
                 if "top-level" not in line:
                     continue
-                mod = m.group(1).split(".")[0]
+                mod = m.group(1).strip("'\"").split(".")[0]
             if mod.startswith("_"):
                 continue
             if mod in SKIP:


### PR DESCRIPTION
## Summary

- Adds a regression test (`test_pyi6_quoted_module_name_strips_quotes`) that exposes PyInstaller 6.x quoted-module parsing bug — input `missing module named 'collections' - imported by app (top-level)` was producing `"'collections'"` instead of `"collections"`
- Fixes the bug with a one-character change: `.strip("'\"")` applied to the extracted token before the dot-split in the 6.x parse path (`tools/parse_warn.py` line 94)
- 5.x parse path (`W: no module named 'foo'`) is unaffected — its regex already uses `'([^']+)'` which never captures quotes

## Test plan

- [ ] `test_pyi6_quoted_module_name_strips_quotes` — previously failing, now passing
- [ ] All 34 `tests/test_parse_warn.py` tests pass (`python -m unittest tests.test_parse_warn`)
- [ ] CI green (run 25162691218): 36 pass cache lane, 56 pass real lane, 0 failures

https://claude.ai/code/session_01HHuqfDYooHcCsdNiSWyNBa

---
_Generated by [Claude Code](https://claude.ai/code/session_01HHuqfDYooHcCsdNiSWyNBa)_