### PR TITLE
feat(warnfix): track repair-attempt failures without breaking fallback flow

### DIFF
--- a/run_setup.bat
+++ b/run_setup.bat
@@ -1434,20 +1434,31 @@ if "%HP_ENV_MODE%"=="system" (
     if exist "~parse_warn.py" del "~parse_warn.py" >nul 2>&1
     set "HP_WARNFIX_NEEDED="
     for /f "usebackq delims=" %%M in ("~missing_modules.txt") do set "HP_WARNFIX_NEEDED=1"
+    if exist "~warnfix_repair_failed.flag" del "~warnfix_repair_failed.flag" >nul 2>&1
     if defined HP_WARNFIX_NEEDED (
       call :log "[INFO] PyInstaller flagged missing modules; installing and rebuilding."
       if "%HP_ENV_MODE%"=="uv" (
         for /f "usebackq delims=" %%M in ("~missing_modules.txt") do (
           "%HP_UV_EXE%" pip install --python "%HP_PY%" %%M >> "%LOG%" 2>&1
+          if errorlevel 1 (
+            call :log "[WARN] Repair failed: %%M"
+            copy nul "~warnfix_repair_failed.flag" >nul 2>&1
+          )
         )
       ) else if defined CONDA_BAT (
         for /f "usebackq delims=" %%M in ("~missing_modules.txt") do (
           call "%CONDA_BAT%" install -y -n "%ENVNAME%" --override-channels -c conda-forge %%M >> "%LOG%" 2>&1
+          if errorlevel 1 (
+            call :log "[WARN] Repair failed: %%M"
+            copy nul "~warnfix_repair_failed.flag" >nul 2>&1
+          )
         )
       )
+      if exist "~warnfix_repair_failed.flag" call :log "[WARN] One or more repair attempts failed"
       "%HP_PY%" -m PyInstaller -y --onefile --clean --log-level WARN --name "%ENVNAME%" "%HP_ENTRY%" >> "%LOG%" 2>&1
       call :log "[INFO] PyInstaller rebuild after missing module install complete."
     )
+    if exist "~warnfix_repair_failed.flag" del "~warnfix_repair_failed.flag" >nul 2>&1
     if exist "~missing_modules.txt" del "~missing_modules.txt" >nul 2>&1
     set "HP_WARNFIX_NEEDED="
     if not defined HP_SPEC_PREEXIST if exist "%ENVNAME%.spec" del "%ENVNAME%.spec" >nul 2>&1

--- a/tests/selfapps_warnfix.ps1
+++ b/tests/selfapps_warnfix.ps1
@@ -113,6 +113,7 @@ $warnInstallPhrase = 'PyInstaller flagged missing modules; installing and rebuil
 $warnRebuildPhrase = 'PyInstaller rebuild after missing module install complete.'
 $warnInstallFired  = $combined -match [regex]::Escape($warnInstallPhrase)
 $warnRebuildFired  = $combined -match [regex]::Escape($warnRebuildPhrase)
+$repairFailuresDetected = $combined -match [regex]::Escape('[WARN] Repair failed:')
 
 # installPass: warnfix fired (exitCode not checked since smoke test is expected to fail)
 $installPass = $warnInstallFired -and $warnRebuildFired
@@ -151,10 +152,11 @@ Write-NdjsonRow ([ordered]@{
     pass    = $installPass
     desc    = 'PyInstaller warn file had missing modules; conda install ran'
     details = [ordered]@{
-        exitCode          = $run1Exit
-        warnInstallFired  = $warnInstallFired
-        warnRebuildFired  = $warnRebuildFired
-        log               = $bootstrapLog
+        exitCode               = $run1Exit
+        warnInstallFired       = $warnInstallFired
+        warnRebuildFired       = $warnRebuildFired
+        repairFailuresDetected = $repairFailuresDetected
+        log                    = $bootstrapLog
     }
 })
 


### PR DESCRIPTION
## Summary

- **`run_setup.bat`**: introduces a flag-file approach to detect when `uv pip install` or `conda install` returns non-zero during the warnfix repair loop — logs `[WARN] Repair failed: <module>` per failing attempt and `[WARN] One or more repair attempts failed` after all attempts complete. No `exit /b` added; fallback flow and control structure are unchanged.
- **`tests/selfapps_warnfix.ps1`**: adds `repairFailuresDetected` (boolean) to the `self.exe.warnfix.install` NDJSON details field by scanning the combined log for `[WARN] Repair failed:`. Field is additive only — `installPass` verdict logic is untouched.

## CI evidence

- **Run `25198692290-1`** (Part 1 — bat only): conda-full 56 rows / 0 failures, real 50 rows / 0 failures. Both warnfix rows pass.
- **Run `25199454280-1`** (Part 2 — both files): conda-full `repairFailuresDetected: false`, real `repairFailuresDetected: true` (uv attempted to install `'collections` — a quoted-name parse edge case — which correctly failed and was surfaced). EXE still succeeded in both lanes; all rows pass.

## Test plan

- [ ] `self.exe.warnfix.install` and `self.exe.warnfix.success` remain `pass: true` in conda-full and real lanes
- [ ] `repairFailuresDetected` field present in `self.exe.warnfix.install` details
- [ ] No new failing rows introduced
- [ ] Existing `installPass` logic unchanged (verified: same phrases, same conditions)

https://claude.ai/code/session_015XRTTyEhk3k3jm227bUt12

---
_Generated by [Claude Code](https://claude.ai/code/session_015XRTTyEhk3k3jm227bUt12)_