### PR TITLE
test(warnfix): fail installPass only when repair failures break the runtime

### DIFF
--- a/tests/selfapps_warnfix.ps1
+++ b/tests/selfapps_warnfix.ps1
@@ -115,9 +115,6 @@ $warnInstallFired  = $combined -match [regex]::Escape($warnInstallPhrase)
 $warnRebuildFired  = $combined -match [regex]::Escape($warnRebuildPhrase)
 $repairFailuresDetected = $combined -match [regex]::Escape('[WARN] Repair failed:')
 
-# installPass: warnfix fired (exitCode not checked since smoke test is expected to fail)
-$installPass = $warnInstallFired -and $warnRebuildFired
-
 # EXE run: verify the rebuilt EXE has openpyxl bundled and succeeds
 $envLeaf  = Split-Path $workDir -Leaf
 $envName  = ($envLeaf -replace '[^A-Za-z0-9_-]', '_')
@@ -145,6 +142,9 @@ if ($exeExists) {
 }
 
 $successPass = $exeExists -and ($exeExit -eq 0) -and $tokenFound
+
+# installPass: warnfix fired; also fails if repair failures caused runtime breakage
+$installPass = $warnInstallFired -and $warnRebuildFired -and -not ($repairFailuresDetected -and -not $successPass)
 
 Write-NdjsonRow ([ordered]@{
     id      = 'self.exe.warnfix.install'


### PR DESCRIPTION
## Summary

Moves `$installPass` computation to after `$successPass` so the combined condition is available. `installPass` now also fails when `repairFailuresDetected` is true AND `successPass` is false (repair failure caused runtime breakage). When `repairFailuresDetected` is true but `successPass` is true, the row still passes — fallback behavior intact, no false failures.

**Truth table:**

| `repairFailuresDetected` | `successPass` | `installPass` | Meaning |
|---|---|---|---|
| `false` | `true` | `true` | Clean repair — no change |
| `true` | `true` | `true` | Repair partially failed but runtime OK — no false alarm |
| `true` | `false` | `false` | Repair failure broke the runtime — caught |
| `false` | `false` | `false` | Already caught by `successPass` row |

## CI evidence

Run `25200384930-1`:
- **conda-full**: `repairFailuresDetected=false`, `successPass=true` → `installPass=true` ✓ (56 rows, 0 failures)
- **real**: `repairFailuresDetected=true`, `successPass=true` → `installPass=true` ✓ (50 rows, 0 failures — repair of `'collections` quoted-name failed but EXE still succeeded)

## Test plan

- [ ] `self.exe.warnfix.install` remains `pass: true` when `repairFailuresDetected=false` (conda-full)
- [ ] `self.exe.warnfix.install` remains `pass: true` when `repairFailuresDetected=true` but EXE succeeds (real)
- [ ] `self.exe.warnfix.install` would fail when repair failure causes runtime breakage (enforced by new condition)
- [ ] No change to `run_setup.bat` or existing fallback behavior

https://claude.ai/code/session_015XRTTyEhk3k3jm227bUt12

---
_Generated by [Claude Code](https://claude.ai/code/session_015XRTTyEhk3k3jm227bUt12)_