### PR TITLE
test(warnfix): exercise xlrd beyond bare import in real_warnfix scenarios

### DIFF
--- a/tests/selfapps_warnfix.ps1
+++ b/tests/selfapps_warnfix.ps1
@@ -213,6 +213,8 @@ print('wrote out.xlsx')
 import xlrd
 import os as _os
 import sys as _sys
+_ = xlrd.__version__
+assert callable(xlrd.open_workbook), 'xlrd.open_workbook not accessible'
 _here = _os.path.dirname(_os.path.abspath(_sys.argv[0]))
 with open(_os.path.join(_here, '~warnfix_token.txt'), 'w') as _f:
     _f.write('real-warnfix-ok\n')
@@ -228,6 +230,8 @@ import sys as _sys
 
 def do_work():
     import xlrd
+    _ = xlrd.__version__
+    assert callable(xlrd.open_workbook), 'xlrd.open_workbook not accessible'
     _here = _os.path.dirname(_os.path.abspath(_sys.argv[0]))
     with open(_os.path.join(_here, '~warnfix_token.txt'), 'w') as _f:
         _f.write('real-warnfix-delayed-ok\n')


### PR DESCRIPTION
## Summary

- In `real_warnfix` and `real_warnfix_delayed` scenarios, the test app previously only did `import xlrd` before writing the success token
- A bare import proves the module loads but not that its API is accessible — partial bundling or missing submodules could silently pass
- Adds two assertions before the token write in both scenarios:
  ```python
  _ = xlrd.__version__
  assert callable(xlrd.open_workbook), 'xlrd.open_workbook not accessible'
  ```
- Token is now written only after attribute resolution and function binding succeed, so CI fails if xlrd is imported but not fully functional inside the EXE

Contrast with `pass`/`real` scenarios which already exercised openpyxl beyond import (`Workbook()`, cell write, `save()`). This closes the equivalent gap for the xlrd warnfix scenarios.

## Test plan

- [ ] `real` and `conda-full` lanes green
- [ ] `self.exe.warnfix.real_warnfix` and `self.exe.warnfix.real_warnfix_delayed` pass with `pass=true`
- [ ] 4-line diff only — no other changes

https://claude.ai/code/session_01QMgxYNiTiaPzgANTdeHDCZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01QMgxYNiTiaPzgANTdeHDCZ)_