### PR TITLE
feat(req-008): full NI-VISA runtime handling with tightened test signals

### DIFF
--- a/run_setup.bat
+++ b/run_setup.bat
@@ -838,6 +838,37 @@ if "%NEED_VISA%"=="1" (
 )
 if exist "~visa.flag" del "~visa.flag"
 
+rem --- NI-VISA presence check and install (REQ-008) ---
+rem derived requirement: NEED_VISA must be exactly "1"; any other value (0, empty, error)
+rem skips install to avoid hanging CI on non-visa projects.
+if not "%NEED_VISA%"=="1" (
+  call :log "[VISA] skipped (not_required)"
+  goto visa_done
+)
+reg query "HKLM\SOFTWARE\National Instruments\NI-VISA" /v "CurrentVersion" >nul 2>&1
+if not errorlevel 1 (
+  call :log "[VISA] present"
+  goto visa_done
+)
+set "NIVISA_INSTALLER=~ni-visa-runtime.exe"
+curl -L --silent --fail -o "%NIVISA_INSTALLER%" "https://download.ni.com/support/nipkg/products/ni-v/ni-visa/21.5/online/ni-visa_21.5_online.exe" 2>> "%LOG%"
+if not exist "%NIVISA_INSTALLER%" (
+  powershell -Command "try { Invoke-WebRequest -Uri 'https://download.ni.com/support/nipkg/products/ni-v/ni-visa/24.0/runtime/ni-visa-runtime_24.0.0_windows.exe' -OutFile '%NIVISA_INSTALLER%' -UseBasicParsing -ErrorAction Stop } catch { exit 1 }" 2>> "%LOG%"
+)
+if not exist "%NIVISA_INSTALLER%" (
+  call :log "[VISA] install_failed (download)"
+  goto visa_done
+)
+start /wait "" "%NIVISA_INSTALLER%" --quiet --accept-eulas --prevent-reboot --prevent-activation
+reg query "HKLM\SOFTWARE\National Instruments\NI-VISA" /v "CurrentVersion" >nul 2>&1
+if not errorlevel 1 (
+  call :log "[VISA] install_success"
+) else (
+  call :log "[VISA] install_failed (post_check)"
+)
+if exist "%NIVISA_INSTALLER%" del "%NIVISA_INSTALLER%" >nul 2>&1
+:visa_done
+
 rem --- Write env state for fast path on next run ---
 rem derived requirement: goto avoids %errorlevel% parse-time expansion inside
 rem parenthesized if-blocks; same pattern as dep-check and lock-capture blocks.

--- a/run_setup.bat
+++ b/run_setup.bat
@@ -852,7 +852,10 @@ if not errorlevel 1 (
 )
 set "NIVISA_INSTALLER=~ni-visa-runtime.exe"
 curl -L --silent --fail -o "%NIVISA_INSTALLER%" "https://download.ni.com/support/nipkg/products/ni-v/ni-visa/21.5/online/ni-visa_21.5_online.exe" 2>> "%LOG%"
-if not exist "%NIVISA_INSTALLER%" (
+if errorlevel 1 (
+  rem derived requirement: curl can leave a partial file on failure; delete before fallback
+  rem so PowerShell does not find a corrupt file and skip its own download attempt.
+  if exist "%NIVISA_INSTALLER%" del "%NIVISA_INSTALLER%" >nul 2>&1
   powershell -Command "try { Invoke-WebRequest -Uri 'https://download.ni.com/support/nipkg/products/ni-v/ni-visa/24.0/runtime/ni-visa-runtime_24.0.0_windows.exe' -OutFile '%NIVISA_INSTALLER%' -UseBasicParsing -ErrorAction Stop } catch { exit 1 }" 2>> "%LOG%"
 )
 if not exist "%NIVISA_INSTALLER%" (
@@ -860,12 +863,22 @@ if not exist "%NIVISA_INSTALLER%" (
   goto visa_done
 )
 start /wait "" "%NIVISA_INSTALLER%" --quiet --accept-eulas --prevent-reboot --prevent-activation
+rem derived requirement: NI installers may spawn child processes; retry registry check
+rem up to 3 times (approx 5 s each) before declaring post-install failure.
+set "HP_VISA_RETRY=0"
+:visa_post_check
 reg query "HKLM\SOFTWARE\National Instruments\NI-VISA" /v "CurrentVersion" >nul 2>&1
 if not errorlevel 1 (
   call :log "[VISA] install_success"
-) else (
-  call :log "[VISA] install_failed (post_check)"
+  goto visa_cleanup
 )
+set /a HP_VISA_RETRY+=1
+if %HP_VISA_RETRY% lss 3 (
+  ping -n 6 127.0.0.1 >nul 2>&1
+  goto visa_post_check
+)
+call :log "[VISA] install_failed (post_check)"
+:visa_cleanup
 if exist "%NIVISA_INSTALLER%" del "%NIVISA_INSTALLER%" >nul 2>&1
 :visa_done
 

--- a/tests/selfapps_pyvisa.ps1
+++ b/tests/selfapps_pyvisa.ps1
@@ -59,8 +59,10 @@ try {
 }
 
 $detectPass      = ($log -match 'Detected pyvisa')
-$nisaPass        = ($log -match 'NI-VISA')
-$nisaOutcomePass = ($log -match 'NI-VISA install may be required') -or ($log -match 'NI-VISA already installed') -or ($log -match 'Installing NI-VISA') -or ($log -match 'Skipping NI-VISA')
+# derived requirement: branch and outcome require explicit [VISA] terminal signals, not indirect log substrings.
+# Old fuzzy matches ('NI-VISA', 'NI-VISA install may be required', etc.) allowed false-green when no action was taken.
+$nisaPass        = ($log -match '\[VISA\]')
+$nisaOutcomePass = ($log -match '\[VISA\] present') -or ($log -match '\[VISA\] install_success') -or ($log -match '\[VISA\] skipped') -or ($log -match '\[VISA\] install_failed')
 
 $detectDetails = [ordered]@{ exitCode = $exitCode; detectFound = $detectPass }
 if (-not $log)      { $detectDetails.logMissing = $true }
@@ -82,7 +84,7 @@ Write-NdjsonRow ([ordered]@{
     id      = 'pyvisa.nivisa.branch'
     req     = 'REQ-008'
     pass    = $nisaPass
-    desc    = 'NI-VISA branch taken when pyvisa import detected'
+    desc    = 'NI-VISA branch taken when pyvisa import detected (requires [VISA] terminal signal)'
     details = $nisaDetails
 })
 
@@ -90,10 +92,14 @@ Write-NdjsonRow ([ordered]@{
     id      = 'pyvisa.nivisa.outcome'
     req     = 'REQ-008'
     pass    = $nisaOutcomePass
-    desc    = 'NI-VISA branch outcome logged (install required / already installed / installing / skipping)'
+    desc    = 'NI-VISA terminal signal present ([VISA] present / install_success / skipped / install_failed)'
     details = [ordered]@{ exitCode = $exitCode; outcomeFound = $nisaOutcomePass }
 })
 
+if (-not $nisaPass) {
+    Write-Host "[VISA] terminal signal not present in log"
+    exit 1
+}
 if (-not $nisaOutcomePass) {
     Write-Host "NI-VISA branch outcome not detected"
     exit 1


### PR DESCRIPTION
## Summary

- **Tighten REQ-008 tests** (`tests/selfapps_pyvisa.ps1`): replace fuzzy log substring matching with explicit `[VISA]` terminal signal requirements — prevents false-green where REQ-008 was marked passing before any registry check or install attempt occurred
- **Implement NI-VISA runtime handling** (`run_setup.bat`): add presence check (registry), download attempt (curl + PowerShell fallback), silent install, post-install verification, and terminal signal logging for all outcomes

## Terminal signals produced

| Condition | Log line |
|-----------|----------|
| pyvisa not detected | `[VISA] skipped (not_required)` |
| NI-VISA already installed | `[VISA] present` |
| Install succeeds | `[VISA] install_success` |
| Download fails | `[VISA] install_failed (download)` |
| Install runs but post-check fails | `[VISA] install_failed (post_check)` |

## Test plan

- [x] Part 1 push confirmed RED on CI (run `25355021326`): `pyvisa.nivisa.branch` and `pyvisa.nivisa.outcome` both `pass=false` — tightened signals working as intended
- [ ] Part 2 push: expect GREEN — download will fail on CI runners → `[VISA] install_failed (download)` is the expected terminal signal, satisfying both NDJSON rows
- [ ] `pyvisa.detect` row unaffected (still checks for "Detected pyvisa")
- [ ] Non-pyvisa projects get `[VISA] skipped (not_required)` — no regression

## Sanity checks run

- `python tools/check_delimiters.py run_setup.bat` — no issues
- `python -m compileall -q .` — clean
- `python -m pyflakes .` — clean

https://claude.ai/code/session_01BMSUA67TCjs1yg7mCXz8dz

---
_Generated by [Claude Code](https://claude.ai/code/session_01BMSUA67TCjs1yg7mCXz8dz)_