### PR TITLE
harden: UAC check, TLS 1.2, gitignore ~*, AGENTS conventions, batch lint

### DIFF
--- a/.github/workflows/batch-check.yml
+++ b/.github/workflows/batch-check.yml
@@ -34,7 +34,7 @@ jobs:
           - mode: real
           # conda-full: third lane - no fallbacks, proves real Miniconda path works
           - mode: conda-full
-          # justme-test: forces JustMe install path via HP_TEST_JUSTME_FALLBACK=1 (informational)
+          # justme-test: simulates non-elevated process via HP_TEST_NOT_ELEVATED=1 to cover fsutil branch (informational)
           - mode: justme-test
           # uv: explicit lane for uv env+dep installer path (no HP_FORCE_CONDA_ONLY)
           - mode: uv
@@ -90,12 +90,12 @@ jobs:
         run: |
           'HP_FORCE_CONDA_ONLY=1' | Out-File -FilePath $env:GITHUB_ENV -Encoding ascii -Append
 
-      # justme-test only: skips AllUsers install so the JustMe fallback path runs
-      - name: Force JustMe install path
+      # justme-test only: simulates non-elevated process so JustMe fallback path runs with CI coverage
+      - name: Force JustMe install path (simulate non-elevated)
         if: ${{ matrix.mode == 'justme-test' }}
         shell: pwsh
         run: |
-          'HP_TEST_JUSTME_FALLBACK=1' | Out-File -FilePath $env:GITHUB_ENV -Encoding ascii -Append
+          'HP_TEST_NOT_ELEVATED=1' | Out-File -FilePath $env:GITHUB_ENV -Encoding ascii -Append
 
       # justme-test only: also exercises download fallback by forcing primary URLs to fail
       - name: Force download fallback path (justme-test only)

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ actionlint_*.tar.gz
 
 # Dependency source diagnostics artifact (written by run_setup.bat)
 dependency_source.txt
+
+# Tilde-prefix runtime artifacts (bootstrapper writes these; see AGENTS.md)
+~*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,6 +151,25 @@ THEN stop and open/append a PR. One loop = one change set.
 - Core flow is non-admin (Miniconda + env under `%PUBLIC%\Documents`).
 - NI-VISA is optional and may require admin rights; treat as warn-only unless the app imports `pyvisa` or `visa`.
 
+## Windows Scripting Conventions
+
+### Batch path quoting
+- Assign with `set "VAR=value"` (quotes wrap the whole assignment, not the value).
+  Never use `set VAR="value"` -- the quotes become part of the string and cause double-quoting on expansion.
+- Execute with `"%VAR%"` at every file-system call site (`del`, `if exist`, `mkdir`, `move`, `copy`, `pushd`).
+- Exception: NSIS installer `/D=` parameter cannot be quoted -- leave as `/D=%VAR%` (NSIS restriction).
+
+### PowerShell 5.1 web requests (TLS)
+- Prepend `[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;`
+  to every `Invoke-WebRequest` call. PS 5.1 on older Windows defaults to TLS 1.0/1.1 which modern CDNs reject.
+- Keep `-UseBasicParsing` on all `Invoke-WebRequest` calls.
+
+### Admin awareness before system-wide installs
+- Before any system-wide install, check elevation silently:
+  `fsutil dirty query %systemdrive% >nul 2>&1`
+  If `errorlevel 1`, skip the system-wide path and fall back to per-user installation.
+  This avoids unexpected UAC prompts on non-elevated machines.
+
 ## Style and robustness
 - Keep ASCII plain text; avoid non-ASCII punctuation.
 - Prefer quoting/escaping and logic fixes over silencing errors.

--- a/run_setup.bat
+++ b/run_setup.bat
@@ -1779,15 +1779,20 @@ exit /b 0
 rem derived requirement: AllUsers install can fail when UAC rejects elevation even for admin accounts.
 rem JustMe is the non-admin fallback that installs under the user profile instead.
 rem Both attempts reuse the already-downloaded installer at %TEMP%\miniconda.exe (no re-download).
-if "%HP_TEST_JUSTME_FALLBACK%"=="1" (
-  call :log "[INFO] HP_TEST_JUSTME_FALLBACK: skipping AllUsers, forcing JustMe path."
-  goto :tci_justme
-)
 rem derived requirement: non-admin machines produce a UAC prompt when AllUsers install is attempted;
 rem skip directly to JustMe when the process is not elevated.
+rem HP_TEST_NOT_ELEVATED=1 simulates a non-admin environment for CI coverage of this branch.
+if "%HP_TEST_NOT_ELEVATED%"=="1" (
+  call :log "[INFO] Not elevated; skipping AllUsers Miniconda install."
+  goto :tci_justme
+)
 fsutil dirty query %systemdrive% >nul 2>&1
 if errorlevel 1 (
   call :log "[INFO] Not elevated; skipping AllUsers Miniconda install."
+  goto :tci_justme
+)
+if "%HP_TEST_JUSTME_FALLBACK%"=="1" (
+  call :log "[INFO] HP_TEST_JUSTME_FALLBACK: skipping AllUsers, forcing JustMe path."
   goto :tci_justme
 )
 start "" /wait "%TEMP%\miniconda.exe" /InstallationType=AllUsers /AddToPath=0 /RegisterPython=0 /S /D=%MINICONDA_ROOT%

--- a/run_setup.bat
+++ b/run_setup.bat
@@ -889,7 +889,7 @@ if errorlevel 1 (
   rem derived requirement: curl can leave a partial file on failure; delete before fallback
   rem so PowerShell does not find a corrupt file and skip its own download attempt.
   if exist "%NIVISA_INSTALLER%" del "%NIVISA_INSTALLER%" >nul 2>&1
-  powershell -Command "try { Invoke-WebRequest -Uri 'https://download.ni.com/support/nipkg/products/ni-v/ni-visa/24.0/runtime/ni-visa-runtime_24.0.0_windows.exe' -OutFile '%NIVISA_INSTALLER%' -UseBasicParsing -ErrorAction Stop } catch { exit 1 }" 2>> "%LOG%"
+  powershell -Command "try { [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; Invoke-WebRequest -Uri 'https://download.ni.com/support/nipkg/products/ni-v/ni-visa/24.0/runtime/ni-visa-runtime_24.0.0_windows.exe' -OutFile '%NIVISA_INSTALLER%' -UseBasicParsing -ErrorAction Stop } catch { exit 1 }" 2>> "%LOG%"
 )
 if not exist "%NIVISA_INSTALLER%" (
   call :log "[VISA] install_failed (download)"
@@ -1087,7 +1087,7 @@ call :log "[INFO] Downloading Miniconda from %HP_MINICONDA_ACTIVE_URL%..."
 curl --fail -L --retry 3 --retry-delay 5 --max-time 120 "%HP_MINICONDA_ACTIVE_URL%" -o "%TEMP%\miniconda.exe" >> "%LOG%" 2>&1
 if not errorlevel 1 if exist "%TEMP%\miniconda.exe" goto :eof
 echo *** curl download failed, trying PowerShell...
-powershell -NoProfile -ExecutionPolicy Bypass -Command "try { Invoke-WebRequest -Uri '%HP_MINICONDA_ACTIVE_URL%' -OutFile '%TEMP%\miniconda.exe' -UseBasicParsing } catch { exit 1 }" >> "%LOG%" 2>&1
+powershell -NoProfile -ExecutionPolicy Bypass -Command "try { [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; Invoke-WebRequest -Uri '%HP_MINICONDA_ACTIVE_URL%' -OutFile '%TEMP%\miniconda.exe' -UseBasicParsing } catch { exit 1 }" >> "%LOG%" 2>&1
 if not errorlevel 1 if exist "%TEMP%\miniconda.exe" goto :eof
 if exist "%TEMP%\miniconda.exe" del "%TEMP%\miniconda.exe" >nul 2>&1
 if defined HP_CONDA_DL_INJECTED (
@@ -1100,7 +1100,7 @@ if not errorlevel 1 if exist "%TEMP%\miniconda.exe" (
   call :log "[INFO] Miniconda download succeeded from fallback URL."
   goto :eof
 )
-powershell -NoProfile -ExecutionPolicy Bypass -Command "try { Invoke-WebRequest -Uri '%HP_MINICONDA_FALLBACK_URL%' -OutFile '%TEMP%\miniconda.exe' -UseBasicParsing } catch { exit 1 }" >> "%LOG%" 2>&1
+powershell -NoProfile -ExecutionPolicy Bypass -Command "try { [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; Invoke-WebRequest -Uri '%HP_MINICONDA_FALLBACK_URL%' -OutFile '%TEMP%\miniconda.exe' -UseBasicParsing } catch { exit 1 }" >> "%LOG%" 2>&1
 if not errorlevel 1 if exist "%TEMP%\miniconda.exe" (
   call :log "[INFO] Miniconda download succeeded from fallback URL."
   goto :eof
@@ -1781,6 +1781,13 @@ rem JustMe is the non-admin fallback that installs under the user profile instea
 rem Both attempts reuse the already-downloaded installer at %TEMP%\miniconda.exe (no re-download).
 if "%HP_TEST_JUSTME_FALLBACK%"=="1" (
   call :log "[INFO] HP_TEST_JUSTME_FALLBACK: skipping AllUsers, forcing JustMe path."
+  goto :tci_justme
+)
+rem derived requirement: non-admin machines produce a UAC prompt when AllUsers install is attempted;
+rem skip directly to JustMe when the process is not elevated.
+fsutil dirty query %systemdrive% >nul 2>&1
+if errorlevel 1 (
+  call :log "[INFO] Not elevated; skipping AllUsers Miniconda install."
   goto :tci_justme
 )
 start "" /wait "%TEMP%\miniconda.exe" /InstallationType=AllUsers /AddToPath=0 /RegisterPython=0 /S /D=%MINICONDA_ROOT%

--- a/tests/selfapps_justme.ps1
+++ b/tests/selfapps_justme.ps1
@@ -32,7 +32,7 @@ if (-not $IsWindows) {
     exit 0
 }
 
-# Read the envsmoke ~setup.log which is written by the bootstrap that ran with HP_TEST_JUSTME_FALLBACK=1.
+# Read the envsmoke ~setup.log which is written by the bootstrap that ran with HP_TEST_NOT_ELEVATED=1.
 # The justme-test lane runs selfapps_envsmoke.ps1 first (which executes run_setup.bat),
 # so the setup log is at tests/~envsmoke/~setup.log.
 $setupLogPath = Join-Path $here '~envsmoke\~setup.log'
@@ -51,22 +51,22 @@ if (Test-Path -LiteralPath $mainSetupPath) {
 $combinedText = $setupText + $mainSetupText
 
 # derived requirement: the JustMe path log line must appear to confirm the fallback ran.
-# HP_TEST_JUSTME_FALLBACK=1 causes run_setup.bat to goto :tci_justme,
+# HP_TEST_NOT_ELEVATED=1 simulates a non-admin process: run_setup.bat logs
+# "[INFO] Not elevated; skipping AllUsers Miniconda install." and then runs the JustMe install,
 # which logs "[INFO] Miniconda installed (JustMe fallback)."
-# The force-bypass log is "[INFO] HP_TEST_JUSTME_FALLBACK: skipping AllUsers, forcing JustMe path."
+$notElevatedSkip = $combinedText -match 'Not elevated; skipping AllUsers Miniconda install\.'
 $justmeInstalled = $combinedText -match 'Miniconda installed \(JustMe fallback\)'
-$justmeForced    = $combinedText -match 'HP_TEST_JUSTME_FALLBACK'
 
-$pass = $justmeInstalled -and $justmeForced
+$pass = $notElevatedSkip -and $justmeInstalled
 
 Write-NdjsonRow ([ordered]@{
     id      = 'conda.install.justme'
     req     = 'REQ-003'
     pass    = $pass
-    desc    = 'Miniconda JustMe install path executed successfully'
+    desc    = 'Miniconda JustMe install path executed (non-elevated simulation)'
     details = [ordered]@{
+        notElevatedSkip = $notElevatedSkip
         justmeInstalled = $justmeInstalled
-        justmeForced    = $justmeForced
         setupLog        = $setupLogPath
     }
 })

--- a/tools/check_delimiters.py
+++ b/tools/check_delimiters.py
@@ -357,6 +357,8 @@ class DelimiterChecker:
                     if scan_from is None and not line.rstrip().endswith("^"):
                         self._bat_in_backtick = False
                 self._check_bat_ps_like_brackets(line_no, line)
+                self._check_bat_set_quoting(line_no, line)
+                self._check_bat_unquoted_path_var(line_no, line)
 
         return self.issues
 
@@ -413,6 +415,42 @@ class DelimiterChecker:
                     "PS wildcard treats '[' as a character-class opener -- "
                     "use .StartsWith()/.EndsWith() or escape as '`[' instead.",
                 )
+
+    def _check_bat_set_quoting(self, line_no: int, line: str) -> None:
+        """Flag set assignments that store quotes inside the variable value.
+
+        Correct: set "VAR=value"  -- quotes wrap the entire assignment
+        Wrong:   set VAR="value"  -- quotes become part of the variable string
+        """
+        # derived requirement: set VAR="value" causes double-quoting on %VAR% expansion;
+        # enforce set "VAR=value" uniformly. Skip /a and /p variants (different syntax).
+        if re.match(
+            r'^\s*set\s+(?!/[aApP]\b)(?!")\w+\s*=\s*"',
+            line,
+            re.IGNORECASE,
+        ):
+            col = line.lower().find("set") + 1
+            self.add_issue(
+                line_no,
+                col,
+                'Batch: use set "VAR=value" not set VAR="value"; '
+                "quotes stored inside the variable cause double-quoting on expansion.",
+            )
+
+    def _check_bat_unquoted_path_var(self, line_no: int, line: str) -> None:
+        """Flag path-variable references in file-system commands without double-quote wrapping."""
+        # derived requirement: unquoted %VAR% in file-system commands breaks on paths with spaces.
+        FS_UNQUOTED = re.compile(
+            r'\b(?:del|if\s+(?:not\s+)?exist|mkdir|copy|move|pushd)\s+%[A-Za-z_]',
+            re.IGNORECASE,
+        )
+        for match in FS_UNQUOTED.finditer(line):
+            self.add_issue(
+                line_no,
+                match.start() + 1,
+                'Batch: path variable appears unquoted in a file-system command; '
+                'use "%VAR%" to handle paths containing spaces.',
+            )
 
     def _check_ps1_boolean_operators(self, line_no: int, line: str) -> None:
         # derived requirement: Windows runners surfaced "parameter name 'or'" faults whenever -or/-and sat


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Defensive hardening pass — no new features. Ensures `run_setup.bat` works robustly on non-standard Windows machines (non-admin users, older Windows 10 with PS 5.1) and prevents the same class of issues from recurring.

- **UAC elevation check before AllUsers Miniconda install** (`fsutil dirty query %systemdrive% >nul 2>&1`): non-elevated processes skip directly to the existing JustMe fallback instead of producing a silent UAC popup. No-op on admin CI runners (fsutil returns 0).
- **TLS 1.2 for all three `Invoke-WebRequest` calls** (NI-VISA + Miniconda primary + Miniconda fallback): PS 5.1 on older Windows defaults to TLS 1.0/1.1 which modern CDNs reject. Idempotent on modern systems.
- **`.gitignore ~*`**: bootstrapper runtime artifacts (`~setup.log`, `~bootstrap.status.json`, etc.) are now gitignored so they can never be accidentally committed.
- **`AGENTS.md` Windows Scripting Conventions section**: documents `set "VAR=value"` quoting rules, TLS 1.2 requirement, and elevation-check pattern so future agents don't regress on these same issues.
- **`tools/check_delimiters.py` batch lint checks**: two new methods (`_check_bat_set_quoting`, `_check_bat_unquoted_path_var`) enforce the quoting conventions at lint time. Zero new issues on existing codebase confirmed.

## Test plan

- [x] Part 1 (`run_setup.bat`): all three CI lanes green — cache 36/36, real 54/54, conda-full 60/60
- [x] Part 2 (`.gitignore`, `AGENTS.md`, `tools/check_delimiters.py`): `python -m compileall -q .`, `python -m pyflakes .`, `python tools/check_delimiters.py run_setup.bat` all clean; full-repo scan produces zero new issues from new checks
- [ ] Part 2 CI: wait for green on current push

https://claude.ai/code/session_0136PeKnbKExSQwkdwVnULnW
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_0136PeKnbKExSQwkdwVnULnW)_