### PR TITLE
nomad: hardening - VERSION_METADATA header, host env diagnostics, README TL;DR isolation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -239,3 +239,16 @@ Schema for `~env.state.json` (schema=1):
  "req_hash": "...", "runtime_hash": "...", "lock_hash": "..."}
 ```
 Unknown schema is treated as stale (triggers full rebuild, not error).
+
+## Version Metadata Maintenance
+
+The `[VERSION_METADATA]` block at the top of `run_setup.bat` records the last verified execution environment.
+
+**Maintenance Rule:** If a CI run passes on a version of Windows, PowerShell, or Python newer than
+what is listed in the `[VERSION_METADATA]` block, update that block to reflect the latest verified
+environment. Fields to keep current:
+
+- `Last Verified Date` -- date of the confirming CI run (YYYY-MM-DD)
+- `Verified Windows` -- Windows version(s) confirmed passing
+- `Verified PowerShell` -- PowerShell version confirmed present on the runner
+- `Verified Python` -- Python version(s) used in CI (CI Default / Latest)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -301,6 +301,7 @@ visa.detect, emit.helpers, env.state.write, dep.check.parse_lock,
 dp.compat, prep.multi.constraint, batch.paren.balance, env.foldername,
 conda.path,
 version.metadata,
+host.env.os, host.env.ps, host.env.python,
 self.stub.fastpath, self.stub.rebuild, self.stub.state_skip
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -300,6 +300,7 @@ conda.channels, pipreqs.flags, pyi.onefile, log.rotate, tilde.naming,
 visa.detect, emit.helpers, env.state.write, dep.check.parse_lock,
 dp.compat, prep.multi.constraint, batch.paren.balance, env.foldername,
 conda.path,
+version.metadata,
 self.stub.fastpath, self.stub.rebuild, self.stub.state_skip
 ```
 

--- a/README.md
+++ b/README.md
@@ -29,12 +29,11 @@ This repository serves as a proof of concept of this new approach.
 
 ## TL;DR (Quickstart)
 
-1. Windows 10 (1809+) or newer.
-2. Put your `.py` app files in a folder.
-3. Put `run_setup.bat` in the same folder.
-4. Double-click `run_setup.bat`.
-   - Core flow targets **non-admin** install under `%PUBLIC%\Documents` using Miniconda.
-   - **NI-VISA** (optional) may require admin rights. If non-admin is blocked by policy, use an elevated shell.
+- **Windows 10 (1809+)** or newer.
+- **One Folder per Program:** Create a unique folder for your project (e.g., `universal_paperclip_optimizer` or `solve_world_hunger_v2`).
+- **Avoid Conflicts:** To ensure environment integrity, do not mix independent programs in the same folder. Each program should have its own dedicated folder and its own copy of `run_setup.bat`.
+- **Setup:** Put your `.py` files and `run_setup.bat` in that folder, then double-click the `.bat`.
+- **Environment Locking:** On the first run, `run_setup.bat` creates or respects a `runtime.txt` to "pin" the Python version. It applies similar logic for dependencies found in `requirements.txt`, `pyproject.toml`, or PEP 723 headers.
 
 ---
 

--- a/run_setup.bat
+++ b/run_setup.bat
@@ -106,7 +106,9 @@ if "%ENVNAME%"=="env" if not "%ENVNAME_ORIG%"=="env" (
   call :log "[WARN] Env name could not be derived from '%ENVNAME_ORIG%'; defaulting to 'env'."
 )
 set "ENVNAME_ORIG="
-
+rem --- Host environment diagnostics (confirm runner OS/PS version for every CI run) ---
+for /f "tokens=*" %%V in ('ver') do call :log "[INFO] Host OS: %%V"
+for /f "usebackq delims=" %%P in (`powershell -NoProfile -ExecutionPolicy Bypass -Command "$PSVersionTable.PSVersion.ToString()" 2^>nul`) do call :log "[INFO] Host PowerShell: %%P"
 
 set "PYCOUNT=0"
 for /f "delims=" %%F in ('dir /b /a-d *.py 2^>nul') do call :count_python "%%F"
@@ -476,6 +478,9 @@ echo Interpreter: %HP_PY%
 >> "%LOG%" echo Interpreter: %HP_PY%
 call :append_env_mode_row
 "%HP_PY%" -c "print('py_ok')" 1>nul 2>nul || call :log "[WARN] Interpreter smoke test failed (continuing)."
+"%HP_PY%" -c "import sys;print(sys.version.split()[0])" > "~pyver_host.tmp" 2>nul
+if exist "~pyver_host.tmp" for /f "usebackq delims=" %%Y in ("~pyver_host.tmp") do call :log "[INFO] Host Python: %%Y"
+if exist "~pyver_host.tmp" del "~pyver_host.tmp" >nul 2>&1
 set "PEP723_ACTIVE="
 set "PEP723_BLOCK_FOUND="
 set "PEP723_REQ=~requirements.pep723.txt"

--- a/run_setup.bat
+++ b/run_setup.bat
@@ -1,8 +1,8 @@
 :: [VERSION_METADATA]
-:: Last Verified Date: 2026-05-09
+:: Last Verified Date: 2026-05-10
 :: Verified Windows: Windows 10/11
 :: Verified PowerShell: 5.1+
-:: Verified Python: 3.12 (CI Default) / 3.13 (Latest)
+:: Verified Python: 3.14 (CI Latest)
 @echo off
 setlocal DisableDelayedExpansion
 set "DEP_SOURCE=unknown"

--- a/run_setup.bat
+++ b/run_setup.bat
@@ -1,3 +1,8 @@
+:: [VERSION_METADATA]
+:: Last Verified Date: 2026-05-09
+:: Verified Windows: Windows 10/11
+:: Verified PowerShell: 5.1+
+:: Verified Python: 3.12 (CI Default) / 3.13 (Latest)
 @echo off
 setlocal DisableDelayedExpansion
 set "DEP_SOURCE=unknown"

--- a/tests/harness.ps1
+++ b/tests/harness.ps1
@@ -258,6 +258,12 @@ $instPathOk = ($AllText -match "%PUBLIC%\\Documents\\Miniconda3")
 Write-Result "conda.path" "Miniconda path is %PUBLIC%\Documents\Miniconda3" $instPathOk @{}
 $hasVersionMetadata = ($AllText -match '\[VERSION_METADATA\]')
 Write-Result "version.metadata" "VERSION_METADATA block present in run_setup.bat" $hasVersionMetadata @{}
+$hasHostOS = ($AllText -match 'Host OS:')
+Write-Result "host.env.os" "Host OS diagnostic print present" $hasHostOS @{}
+$hasHostPS = ($AllText -match 'Host PowerShell:')
+Write-Result "host.env.ps" "Host PowerShell diagnostic print present" $hasHostPS @{}
+$hasHostPython = ($AllText -match 'Host Python:')
+Write-Result "host.env.python" "Host Python diagnostic print present" $hasHostPython @{}
 $results = Get-Content -LiteralPath $ResultsPath -Encoding ASCII | ForEach-Object { $_ | ConvertFrom-Json }
 $fail = @($results | Where-Object { -not $_.pass })
 $pass = @($results | Where-Object { $_.pass })

--- a/tests/harness.ps1
+++ b/tests/harness.ps1
@@ -255,7 +255,9 @@ Write-Result "batch.paren.balance" "No negative parenthesis balance while scanni
 $envLine = ($AllText -match 'for %%I in \("%CD%"\) do set "ENVNAME=%%~nI"')
 Write-Result "env.foldername" "Env name equals folder name" $envLine @{} 
 $instPathOk = ($AllText -match "%PUBLIC%\\Documents\\Miniconda3")
-Write-Result "conda.path" "Miniconda path is %PUBLIC%\Documents\Miniconda3" $instPathOk @{} 
+Write-Result "conda.path" "Miniconda path is %PUBLIC%\Documents\Miniconda3" $instPathOk @{}
+$hasVersionMetadata = ($AllText -match '\[VERSION_METADATA\]')
+Write-Result "version.metadata" "VERSION_METADATA block present in run_setup.bat" $hasVersionMetadata @{}
 $results = Get-Content -LiteralPath $ResultsPath -Encoding ASCII | ForEach-Object { $_ | ConvertFrom-Json }
 $fail = @($results | Where-Object { -not $_.pass })
 $pass = @($results | Where-Object { $_.pass })


### PR DESCRIPTION
## Summary

- **VERSION_METADATA block**: adds a `[VERSION_METADATA]` comment at the top of `run_setup.bat` recording the last verified Windows/PowerShell/Python environment; includes maintenance rule in `AGENTS.md` for keeping it current after CI confirms newer versions
- **Host environment diagnostics**: three `[INFO]` log lines emitted on every run to confirm the runner environment — `Host OS:`, `Host PowerShell:`, `Host Python:` (X.Y.Z); each backed by a static-analysis NDJSON row in `harness.ps1`
- **README TL;DR rewrite**: "Quickstart" section rewritten to emphasize the standalone Nomad use case — one-folder-per-program isolation, avoid mixing apps, environment locking via `runtime.txt`/`requirements.txt`/`pyproject.toml`
- **VERSION_METADATA updated**: per the new maintenance rule, `Last Verified Date` and `Verified Python` refreshed to match CI run 25618060042 (Python 3.14.4, Windows 11 10.0.26100, PowerShell 5.1)

## Test plan

- [x] `python tools/check_delimiters.py run_setup.bat` — no issues
- [x] `python -m compileall -q .` + `python -m pyflakes .` — clean
- [x] CI run 25618060042: 55/55 test-log rows PASS in conda-full, cache, and real lanes
- [x] `version.metadata`, `host.env.os`, `host.env.ps`, `host.env.python` NDJSON rows confirmed passing
- [x] Setup log confirmed: `[INFO] Host OS: Microsoft Windows [Version 10.0.26100.32690]`, `[INFO] Host PowerShell: 5.1.26100.32684`, `[INFO] Host Python: 3.14.4`

https://claude.ai/code/session_013gJupzLqTuY4XC1v84WNqS

---
_Generated by [Claude Code](https://claude.ai/code/session_013gJupzLqTuY4XC1v84WNqS)_