### PR TITLE
feat: Nomad defensive refactor — identity header & PVW_ super-user override hooks

### DIFF
--- a/run_setup.bat
+++ b/run_setup.bat
@@ -1,8 +1,14 @@
+:: run_setup.bat -- Python vs Windows
+:: Project Home: https://github.com/mixmansoundude/Python_vs_Windows
+:: Description: Automated, zero-config Python environment management for Windows. Standalone and portable.
 :: [VERSION_METADATA]
 :: Last Verified Date: 2026-05-10
 :: Verified Windows: Windows 10/11
 :: Verified PowerShell: 5.1+
 :: Verified Python: 3.14 (CI Latest)
+:: RECOVERY: If a future Python version breaks auto-detection, install a Python version matching the
+::   'Last Verified' metadata above, then run 'set PVW_PYTHON_EXE=C:\path\to\python.exe' in your
+::   terminal before running this script to bypass the broken detection.
 @echo off
 setlocal DisableDelayedExpansion
 set "DEP_SOURCE=unknown"

--- a/run_setup.bat
+++ b/run_setup.bat
@@ -41,6 +41,28 @@ set "LOG=~setup.log"
 set "LOGPREV=~setup.prev.log"
 set "STATUS_FILE=~bootstrap.status.json"
 if not exist "%LOG%" (type nul > "%LOG%")
+rem --- PVW_ super-user overrides (inherit from calling terminal; logged before detection runs) ---
+rem derived requirement: PVW_ variables let a super-user pre-set values to bypass auto-detection.
+if defined PVW_PYTHON_EXE (
+  echo [DEBUG] Using super-user override for PVW_PYTHON_EXE: %PVW_PYTHON_EXE%
+  call :log "[DEBUG] Using super-user override for PVW_PYTHON_EXE: %PVW_PYTHON_EXE%"
+)
+if defined PVW_UV_EXE (
+  echo [DEBUG] Using super-user override for PVW_UV_EXE: %PVW_UV_EXE%
+  call :log "[DEBUG] Using super-user override for PVW_UV_EXE: %PVW_UV_EXE%"
+)
+if defined PVW_CONDA_EXE (
+  echo [DEBUG] Using super-user override for PVW_CONDA_EXE: %PVW_CONDA_EXE%
+  call :log "[DEBUG] Using super-user override for PVW_CONDA_EXE: %PVW_CONDA_EXE%"
+)
+if defined PVW_TARGET_PY (
+  echo [DEBUG] Using super-user override for PVW_TARGET_PY: %PVW_TARGET_PY%
+  call :log "[DEBUG] Using super-user override for PVW_TARGET_PY: %PVW_TARGET_PY%"
+)
+if defined PVW_WORKSPACE (
+  echo [DEBUG] Using super-user override for PVW_WORKSPACE: %PVW_WORKSPACE%
+  call :log "[DEBUG] Using super-user override for PVW_WORKSPACE: %PVW_WORKSPACE%"
+)
 rem --- Path-length guard: warn if script root path approaches the 260-char cmd.exe limit ---
 for /f "usebackq delims=" %%L in (`powershell -NoProfile -ExecutionPolicy Bypass -Command "$env:HP_SCRIPT_ROOT.Length" 2^>nul`) do set "HP_PATH_LEN=%%L"
 if defined HP_PATH_LEN if %HP_PATH_LEN% GEQ 200 (
@@ -185,6 +207,7 @@ set "MINICONDA_ROOT=%MC%"
 set "CONDA_BASE_PY=%MINICONDA_ROOT%\python.exe"
 
 call :select_conda_bat
+if defined PVW_CONDA_EXE set "CONDA_BAT=%PVW_CONDA_EXE%"
 
 rem Install Miniconda if conda.bat is missing
 set "HP_CONDA_JUST_INSTALLED="
@@ -231,6 +254,11 @@ rem === uv acquisition (preferred env+dep installer; falls back to conda) ======
 rem derived requirement: uv is gated by HP_FORCE_CONDA_ONLY (same gate used for
 rem venv/system fallbacks) so the conda-full CI lane exercises the pure conda path.
 rem The binary is cached under ~uv_bin\ (tilde-prefix keeps it gitignored).
+if defined PVW_UV_EXE (
+  set "HP_UV_EXE=%PVW_UV_EXE%"
+  call :log "[INFO] uv: using super-user override PVW_UV_EXE=%PVW_UV_EXE%."
+  goto :uv_acquire_done
+)
 set "HP_UV_EXE="
 set "HP_UV_BIN=%HP_SCRIPT_ROOT%~uv_bin"
 set "HP_UV_ZIP=%TEMP%\~uv_setup.zip"
@@ -312,6 +340,10 @@ if exist "%CONDA_BASE_PY%" (
 )
 set "PYSPEC="
 for /f "usebackq delims=" %%A in ("~py_spec.txt") do set "PYSPEC=%%A"
+if defined PVW_TARGET_PY (
+  set "PYSPEC=%PVW_TARGET_PY%"
+  call :log "[INFO] Python version: using super-user override PVW_TARGET_PY=%PVW_TARGET_PY%."
+)
 
 rem --- Env-state fast path: skip conda create+install if env is still valid ---
 rem derived requirement: ~env.state.json records envMode/envName/envPath/pySpec/lockSize
@@ -346,7 +378,11 @@ rem folder, short-circuiting conda create. On failure, :try_conda_create runs th
 rem existing conda path unchanged. Python version from PYSPEC is not yet forwarded
 rem to uv (version-pinning deferred; uv picks the system default Python).
 if not defined HP_UV_EXE goto :try_conda_create
-set "HP_UV_ENV_PATH=%HP_SCRIPT_ROOT%.uv_env"
+if defined PVW_WORKSPACE (
+  set "HP_UV_ENV_PATH=%PVW_WORKSPACE%"
+) else (
+  set "HP_UV_ENV_PATH=%HP_SCRIPT_ROOT%.uv_env"
+)
 if exist "%HP_UV_ENV_PATH%\Scripts\python.exe" (
   "%HP_UV_ENV_PATH%\Scripts\python.exe" -c "import pip;exit(0)" >nul 2>&1
   if not errorlevel 1 (
@@ -457,6 +493,10 @@ if not errorlevel 1 (
 )
 
 :after_env_mode_selection
+if defined PVW_PYTHON_EXE (
+  set "HP_PY=%PVW_PYTHON_EXE%"
+  call :log "[INFO] Python host: using super-user override PVW_PYTHON_EXE=%PVW_PYTHON_EXE%."
+)
 rem === Conda base periodic update (~30 days) ====================================
 rem derived requirement: README.md requires periodic conda base update; skip on
 rem first install (timestamp seeded) and when uv env is in use.

--- a/run_setup.bat
+++ b/run_setup.bat
@@ -43,8 +43,8 @@ set "STATUS_FILE=~bootstrap.status.json"
 if not exist "%LOG%" (type nul > "%LOG%")
 rem --- PVW_ super-user overrides (inherit from calling terminal; logged before detection runs) ---
 rem derived requirement: PVW_ variables let a super-user pre-set values to bypass auto-detection.
-rem Single-line if form avoids parse-time parenthesis expansion breaking the block on paths like
-rem C:\Program Files (x86)\... -- the ) in (x86) would terminate a parenthesized if block early.
+rem Single-line if form avoids parse-time expansion issues in block-form if-statements when a
+rem variable value contains parentheses, such as a path under "C:\Program Files (x86)\...".
 if defined PVW_PYTHON_EXE echo [DEBUG] Using super-user override for PVW_PYTHON_EXE: %PVW_PYTHON_EXE%
 if defined PVW_PYTHON_EXE call :log "[DEBUG] Using super-user override for PVW_PYTHON_EXE: %PVW_PYTHON_EXE%"
 if defined PVW_UV_EXE echo [DEBUG] Using super-user override for PVW_UV_EXE: %PVW_UV_EXE%

--- a/run_setup.bat
+++ b/run_setup.bat
@@ -43,26 +43,18 @@ set "STATUS_FILE=~bootstrap.status.json"
 if not exist "%LOG%" (type nul > "%LOG%")
 rem --- PVW_ super-user overrides (inherit from calling terminal; logged before detection runs) ---
 rem derived requirement: PVW_ variables let a super-user pre-set values to bypass auto-detection.
-if defined PVW_PYTHON_EXE (
-  echo [DEBUG] Using super-user override for PVW_PYTHON_EXE: %PVW_PYTHON_EXE%
-  call :log "[DEBUG] Using super-user override for PVW_PYTHON_EXE: %PVW_PYTHON_EXE%"
-)
-if defined PVW_UV_EXE (
-  echo [DEBUG] Using super-user override for PVW_UV_EXE: %PVW_UV_EXE%
-  call :log "[DEBUG] Using super-user override for PVW_UV_EXE: %PVW_UV_EXE%"
-)
-if defined PVW_CONDA_EXE (
-  echo [DEBUG] Using super-user override for PVW_CONDA_EXE: %PVW_CONDA_EXE%
-  call :log "[DEBUG] Using super-user override for PVW_CONDA_EXE: %PVW_CONDA_EXE%"
-)
-if defined PVW_TARGET_PY (
-  echo [DEBUG] Using super-user override for PVW_TARGET_PY: %PVW_TARGET_PY%
-  call :log "[DEBUG] Using super-user override for PVW_TARGET_PY: %PVW_TARGET_PY%"
-)
-if defined PVW_WORKSPACE (
-  echo [DEBUG] Using super-user override for PVW_WORKSPACE: %PVW_WORKSPACE%
-  call :log "[DEBUG] Using super-user override for PVW_WORKSPACE: %PVW_WORKSPACE%"
-)
+rem Single-line if form avoids parse-time parenthesis expansion breaking the block on paths like
+rem C:\Program Files (x86)\... -- the ) in (x86) would terminate a parenthesized if block early.
+if defined PVW_PYTHON_EXE echo [DEBUG] Using super-user override for PVW_PYTHON_EXE: %PVW_PYTHON_EXE%
+if defined PVW_PYTHON_EXE call :log "[DEBUG] Using super-user override for PVW_PYTHON_EXE: %PVW_PYTHON_EXE%"
+if defined PVW_UV_EXE echo [DEBUG] Using super-user override for PVW_UV_EXE: %PVW_UV_EXE%
+if defined PVW_UV_EXE call :log "[DEBUG] Using super-user override for PVW_UV_EXE: %PVW_UV_EXE%"
+if defined PVW_CONDA_EXE echo [DEBUG] Using super-user override for PVW_CONDA_EXE: %PVW_CONDA_EXE%
+if defined PVW_CONDA_EXE call :log "[DEBUG] Using super-user override for PVW_CONDA_EXE: %PVW_CONDA_EXE%"
+if defined PVW_TARGET_PY echo [DEBUG] Using super-user override for PVW_TARGET_PY: %PVW_TARGET_PY%
+if defined PVW_TARGET_PY call :log "[DEBUG] Using super-user override for PVW_TARGET_PY: %PVW_TARGET_PY%"
+if defined PVW_WORKSPACE echo [DEBUG] Using super-user override for PVW_WORKSPACE: %PVW_WORKSPACE%
+if defined PVW_WORKSPACE call :log "[DEBUG] Using super-user override for PVW_WORKSPACE: %PVW_WORKSPACE%"
 rem --- Path-length guard: warn if script root path approaches the 260-char cmd.exe limit ---
 for /f "usebackq delims=" %%L in (`powershell -NoProfile -ExecutionPolicy Bypass -Command "$env:HP_SCRIPT_ROOT.Length" 2^>nul`) do set "HP_PATH_LEN=%%L"
 if defined HP_PATH_LEN if %HP_PATH_LEN% GEQ 200 (
@@ -207,6 +199,9 @@ set "MINICONDA_ROOT=%MC%"
 set "CONDA_BASE_PY=%MINICONDA_ROOT%\python.exe"
 
 call :select_conda_bat
+rem PVW_CONDA_EXE: super-user override for the conda batch file path. When set, Miniconda
+rem installation is skipped. Requires conda to already be on PATH (the 'where conda' probe
+rem below will fail gracefully if not). Typical usage: pointing at a system-wide conda install.
 if defined PVW_CONDA_EXE set "CONDA_BAT=%PVW_CONDA_EXE%"
 
 rem Install Miniconda if conda.bat is missing
@@ -254,11 +249,11 @@ rem === uv acquisition (preferred env+dep installer; falls back to conda) ======
 rem derived requirement: uv is gated by HP_FORCE_CONDA_ONLY (same gate used for
 rem venv/system fallbacks) so the conda-full CI lane exercises the pure conda path.
 rem The binary is cached under ~uv_bin\ (tilde-prefix keeps it gitignored).
-if defined PVW_UV_EXE (
-  set "HP_UV_EXE=%PVW_UV_EXE%"
-  call :log "[INFO] uv: using super-user override PVW_UV_EXE=%PVW_UV_EXE%."
-  goto :uv_acquire_done
-)
+if not defined PVW_UV_EXE goto :pvw_uv_exe_skip
+set "HP_UV_EXE=%PVW_UV_EXE%"
+call :log "[INFO] uv: using super-user override PVW_UV_EXE."
+goto :uv_acquire_done
+:pvw_uv_exe_skip
 set "HP_UV_EXE="
 set "HP_UV_BIN=%HP_SCRIPT_ROOT%~uv_bin"
 set "HP_UV_ZIP=%TEMP%\~uv_setup.zip"
@@ -340,10 +335,8 @@ if exist "%CONDA_BASE_PY%" (
 )
 set "PYSPEC="
 for /f "usebackq delims=" %%A in ("~py_spec.txt") do set "PYSPEC=%%A"
-if defined PVW_TARGET_PY (
-  set "PYSPEC=%PVW_TARGET_PY%"
-  call :log "[INFO] Python version: using super-user override PVW_TARGET_PY=%PVW_TARGET_PY%."
-)
+if defined PVW_TARGET_PY set "PYSPEC=%PVW_TARGET_PY%"
+if defined PVW_TARGET_PY call :log "[INFO] Python version: using super-user override PVW_TARGET_PY."
 
 rem --- Env-state fast path: skip conda create+install if env is still valid ---
 rem derived requirement: ~env.state.json records envMode/envName/envPath/pySpec/lockSize
@@ -378,11 +371,8 @@ rem folder, short-circuiting conda create. On failure, :try_conda_create runs th
 rem existing conda path unchanged. Python version from PYSPEC is not yet forwarded
 rem to uv (version-pinning deferred; uv picks the system default Python).
 if not defined HP_UV_EXE goto :try_conda_create
-if defined PVW_WORKSPACE (
-  set "HP_UV_ENV_PATH=%PVW_WORKSPACE%"
-) else (
-  set "HP_UV_ENV_PATH=%HP_SCRIPT_ROOT%.uv_env"
-)
+set "HP_UV_ENV_PATH=%HP_SCRIPT_ROOT%.uv_env"
+if defined PVW_WORKSPACE set "HP_UV_ENV_PATH=%PVW_WORKSPACE%"
 if exist "%HP_UV_ENV_PATH%\Scripts\python.exe" (
   "%HP_UV_ENV_PATH%\Scripts\python.exe" -c "import pip;exit(0)" >nul 2>&1
   if not errorlevel 1 (
@@ -493,10 +483,8 @@ if not errorlevel 1 (
 )
 
 :after_env_mode_selection
-if defined PVW_PYTHON_EXE (
-  set "HP_PY=%PVW_PYTHON_EXE%"
-  call :log "[INFO] Python host: using super-user override PVW_PYTHON_EXE=%PVW_PYTHON_EXE%."
-)
+if defined PVW_PYTHON_EXE set "HP_PY=%PVW_PYTHON_EXE%"
+if defined PVW_PYTHON_EXE call :log "[INFO] Python host: using super-user override PVW_PYTHON_EXE."
 rem === Conda base periodic update (~30 days) ====================================
 rem derived requirement: README.md requires periodic conda base update; skip on
 rem first install (timestamp seeded) and when uv env is in use.


### PR DESCRIPTION
## Summary

- **Identity header**: adds project home URL, description, and emergency recovery comment to the top of `run_setup.bat` so the file is self-documenting when separated from the repo (visible within first 11 lines).
- **PVW_ backdoor hooks**: adds five `if defined` hook points that let a super-user pre-set override variables in their terminal before calling the script, bypassing auto-detection without altering the normal code flow:

| Variable | Overrides | Purpose |
|---|---|---|
| `PVW_PYTHON_EXE` | `HP_PY` | Python host for helper operations |
| `PVW_UV_EXE` | `HP_UV_EXE` | uv executable path; skips acquisition |
| `PVW_CONDA_EXE` | `CONDA_BAT` | conda bat path; skips Miniconda install |
| `PVW_TARGET_PY` | `PYSPEC` | Python version spec for env creation |
| `PVW_WORKSPACE` | `HP_UV_ENV_PATH` | uv venv directory |

- **Override diagnostics**: `[DEBUG]` line echoed to console and written to `~setup.log` for each PVW_ variable that is pre-defined.

## Design notes

- `setlocal DisableDelayedExpansion` is preserved (CI has explicit `batch.delayed.off` / `batch.delayed.enable_absent` assertions).
- In normal CI runs, no PVW_ variables are set → all hooks are no-ops → zero change to NDJSON output or behavior.
- All `if defined PVW_*` blocks use standard `%var%` expansion; no delayed expansion needed.

## Test plan

- [x] `python tools/check_delimiters.py run_setup.bat` — clean
- [x] `python -m compileall -q .` and `python -m pyflakes .` — clean
- [x] Part 1 CI (header commit): conda-full 55/55 harness + 60/60 selfapps, real 54/54, cache 36/36 — all green
- [ ] Part 2 CI (PVW_ hooks commit): await same green signal including `batch.delayed.off=True` and `batch.delayed.enable_absent=True`

https://claude.ai/code/session_01LS37zsDUEVEZnL13dBnzLW

---
_Generated by [Claude Code](https://claude.ai/code/session_01LS37zsDUEVEZnL13dBnzLW)_