### PR TITLE
ci: wire heuristics tests into CI, NDJSON, and diagnostic site

### DIFF
--- a/.github/workflows/batch-check.yml
+++ b/.github/workflows/batch-check.yml
@@ -342,6 +342,34 @@ jobs:
           })
           if (-not $pass) { Write-Host $outStr; exit 1 }
 
+      - name: "Self-test: heuristics unittest (test_heuristics.py)"
+        shell: pwsh
+        run: |
+          $nd   = "tests\~test-results.ndjson"
+          $ciNd = "ci_test_results.ndjson"
+          if (-not (Test-Path $nd))   { New-Item -ItemType File -Path $nd   -Force | Out-Null }
+          if (-not (Test-Path $ciNd)) { New-Item -ItemType File -Path $ciNd -Force | Out-Null }
+          function Write-NdjsonRow { param([hashtable]$Row)
+            $lane = [Environment]::GetEnvironmentVariable('HP_CI_LANE')
+            if ($lane -and -not $Row.ContainsKey('lane')) { $Row['lane'] = $lane }
+            $json = $Row | ConvertTo-Json -Compress -Depth 8
+            Add-Content -LiteralPath $nd   -Value $json -Encoding Ascii
+            Add-Content -LiteralPath $ciNd -Value $json -Encoding Ascii
+          }
+          $rawOut = & python -m unittest tests.test_heuristics -v 2>&1
+          $exitCode = $LASTEXITCODE
+          $outStr = ($rawOut -join "`n")
+          $pass = ($exitCode -eq 0)
+          $summary = ($rawOut | Select-String -Pattern '(OK|FAILED|ERROR|Ran \d+)' | Select-Object -Last 1)
+          if ($summary) { $summaryStr = $summary.Line.Trim() } else { $summaryStr = "exit=$exitCode" }
+          Write-NdjsonRow ([ordered]@{
+            id      = 'self.heuristics.pytest'
+            pass    = $pass
+            desc    = 'heuristics unittest: test_heuristics.py all tests pass'
+            details = [ordered]@{ summary = $summaryStr; exit = $exitCode }
+          })
+          if (-not $pass) { Write-Host $outStr; exit 1 }
+
       - name: "Self-test: runtime.txt write-back (real/conda-full only)"
         if: ${{ matrix.mode == 'real' || matrix.mode == 'conda-full' }}
         shell: pwsh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -252,6 +252,7 @@ self.exe.warnfix.install, self.exe.warnfix.pass, self.exe.warnfix.xfail,
 self.exe.warnfix.real, self.exe.warnfix.real_warnfix,
 self.exe.warnfix.real_warnfix_delayed,
 self.parse_warn.table.v6, self.parse_warn.pytest,
+self.heuristics.pytest,
 self.runtime.writeback,
 self.pandas.openpyxl.install, self.pandas.openpyxl.import,
 pyvisa.detect, pyvisa.nivisa.branch,
@@ -289,6 +290,17 @@ contract-uv-fail lane rows (HP_TEST_UV_FAIL=1, flag-triggered):
 
 ```
 self.contract.uv.fail
+```
+
+Dynamic-tests NDJSON (from dynamic_tests.py, selftest artifact `dynamic/` subdirectory):
+
+```
+pr.to_conda (x many), pr.pandas.openpyxl, pr.pandas.xlsxwriter,
+pr.requests.certifi, pr.sqlalchemy.pymysql, pr.matplotlib.tk,
+pr.cryptography.cffi, pr.pycryptodome.cffi,
+app.visa.detect, app.pyserial.detect,
+dp.pep440 (x many), dp.detect.runtime, dp.detect.pyproject,
+entry.select.single, entry.select.main_vs_app, entry.select.common_vs_generic
 ```
 
 Test-logs NDJSON (from harness/selftest, additional rows):

--- a/README.md
+++ b/README.md
@@ -178,11 +178,11 @@ Defines how dependencies are discovered, selected, installed, augmented, and rep
 ### Heuristic Dependency Augmentation (Bootstrap-Time)
 
 - REQ-005.8 -- Heuristic extras: Augment dependencies based on known ecosystem gaps that are not already included.
-  - REQ-005.8.1 -- pandas -> openpyxl (+ xlsxwriter): Ensures Excel backends are available. TESTED: `tests/selfapps_pandas_excel.ps1`
-  - REQ-005.8.2 -- requests -> certifi: Ensures SSL certificate bundle is present. STATUS: Not explicitly tested
-  - REQ-005.8.3 -- sqlalchemy -> pymysql: Provides common MySQL driver. STATUS: Not explicitly tested
-  - REQ-005.8.4 -- matplotlib -> tk: Enables common GUI backend support. STATUS: Not explicitly tested
-  - REQ-005.8.5 -- cryptography / pycryptodome -> cffi: Supports compiled crypto backends. STATUS: Not explicitly tested
+  - REQ-005.8.1 -- pandas -> openpyxl (+ xlsxwriter): Ensures Excel backends are available. TESTED: `tests/selfapps_pandas_excel.ps1`, `tests/test_heuristics.py`, `tests/dynamic_tests.py`
+  - REQ-005.8.2 -- requests -> certifi: Ensures SSL certificate bundle is present. TESTED: `tests/test_heuristics.py`, `tests/dynamic_tests.py`
+  - REQ-005.8.3 -- sqlalchemy -> pymysql: Provides common MySQL driver. TESTED: `tests/test_heuristics.py`, `tests/dynamic_tests.py`
+  - REQ-005.8.4 -- matplotlib -> tk: Enables common GUI backend support. TESTED: `tests/test_heuristics.py`, `tests/dynamic_tests.py`
+  - REQ-005.8.5 -- cryptography / pycryptodome -> cffi: Supports compiled crypto backends. TESTED: `tests/test_heuristics.py`, `tests/dynamic_tests.py`
   - Logging Contract: Heuristics must emit `[HEURISTIC] <source->target>` -- required for test validation.
 
 ---

--- a/tests/dynamic_tests.py
+++ b/tests/dynamic_tests.py
@@ -159,6 +159,23 @@ def main():
     conda_lines = open(pr.OUT_CONDA, "r", encoding="ascii").read().splitlines()
     pip_lines = open(pr.OUT_PIP, "r", encoding="ascii").read().splitlines()
     record({"id":"pr.pandas.openpyxl","pass": any('openpyxl' in x for x in pip_lines) and any('openpyxl' in x for x in conda_lines),"conda":conda_lines,"pip":pip_lines})
+    record({"id":"pr.pandas.xlsxwriter","pass": any('xlsxwriter' in x for x in pip_lines) and any('xlsxwriter' in x for x in conda_lines),"conda":conda_lines,"pip":pip_lines})
+
+    for _pkg, _content, _target, _conda_only in [
+        ("requests",     "requests\n",     "certifi", False),
+        ("sqlalchemy",   "sqlalchemy\n",   "pymysql", False),
+        ("matplotlib",   "matplotlib\n",   "tk",      True),
+        ("cryptography", "cryptography\n", "cffi",    False),
+        ("pycryptodome", "pycryptodome\n", "cffi",    False),
+    ]:
+        with open(tmp, "w", encoding="ascii") as f:
+            f.write(_content)
+        pr.main()
+        conda_lines = open(pr.OUT_CONDA, "r", encoding="ascii").read().splitlines()
+        pip_lines   = open(pr.OUT_PIP,   "r", encoding="ascii").read().splitlines()
+        conda_ok = any(_target in x for x in conda_lines)
+        pip_ok   = _conda_only or any(_target in x for x in pip_lines)
+        record({"id":f"pr.{_pkg}.{_target}","pass":conda_ok and pip_ok,"conda":conda_lines,"pip":pip_lines})
 
     app_text = "import pyvisa\nimport serial\n"
     visa_hit = bool(re.search(r'(?m)^\s*(from\s+pyvisa|import\s+pyvisa|import\s+visa)\b', app_text))

--- a/tests/test_heuristics.py
+++ b/tests/test_heuristics.py
@@ -1,14 +1,19 @@
 # ASCII only. Cross-platform unit tests for HP_PREP_REQUIREMENTS heuristic rules.
-# Extracts the embedded helper from run_setup.bat and exercises all 6 heuristic
-# dependency-augmentation rules (REQ-005), the kill-switch, and idempotency.
+# Covers all 6 REQ-005.8 rules, the HP_DISABLE_HEURISTICS kill-switch, idempotency,
+# and no-false-positives. Runnable with: python -m unittest tests.test_heuristics -v
 import base64
 import importlib.util
 import os
 import re
-import pytest
+import shutil
+import tempfile
+import unittest
 
 REPO = os.path.dirname(os.path.dirname(__file__))
 RUN_SETUP = os.path.join(REPO, "run_setup.bat")
+
+# Module-level singleton: HP_PREP_REQUIREMENTS extracted and imported once.
+_PR_MODULE = None
 
 
 def _extract_payload(varname):
@@ -21,25 +26,30 @@ def _extract_payload(varname):
     raise RuntimeError(f"{varname} not found in run_setup.bat")
 
 
-@pytest.fixture(scope="session")
-def pr(tmp_path_factory):
-    tmp = tmp_path_factory.mktemp("heuristics")
-    script = tmp / "prep_requirements.py"
-    script.write_bytes(_extract_payload("HP_PREP_REQUIREMENTS"))
-    spec = importlib.util.spec_from_file_location("pr", script)
-    mod = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(mod)
-    return mod
+def _get_pr():
+    global _PR_MODULE
+    if _PR_MODULE is None:
+        tmp = tempfile.mkdtemp(prefix="heuristics.")
+        script = os.path.join(tmp, "prep_requirements.py")
+        with open(script, "wb") as fh:
+            fh.write(_extract_payload("HP_PREP_REQUIREMENTS"))
+        spec = importlib.util.spec_from_file_location("pr", script)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        _PR_MODULE = mod
+    return _PR_MODULE
 
 
-def _run(pr, tmp_path, reqs, extra_env=None):
-    inp = tmp_path / "requirements.txt"
-    out_conda = tmp_path / "reqs_conda.txt"
-    out_pip = tmp_path / "reqs_pip.txt"
-    inp.write_text(reqs, encoding="ascii")
-    pr.INP = str(inp)
-    pr.OUT_CONDA = str(out_conda)
-    pr.OUT_PIP = str(out_pip)
+def _run(tmp_dir, reqs, extra_env=None):
+    pr = _get_pr()
+    inp = os.path.join(tmp_dir, "requirements.txt")
+    out_conda = os.path.join(tmp_dir, "reqs_conda.txt")
+    out_pip = os.path.join(tmp_dir, "reqs_pip.txt")
+    with open(inp, "w", encoding="ascii") as fh:
+        fh.write(reqs)
+    pr.INP = inp
+    pr.OUT_CONDA = out_conda
+    pr.OUT_PIP = out_pip
     saved = {}
     try:
         for k, v in (extra_env or {}).items():
@@ -55,8 +65,10 @@ def _run(pr, tmp_path, reqs, extra_env=None):
                 os.environ.pop(k, None)
             else:
                 os.environ[k] = v
-    conda = out_conda.read_text(encoding="ascii").splitlines()
-    pip = out_pip.read_text(encoding="ascii").splitlines()
+    with open(out_conda, encoding="ascii") as fh:
+        conda = fh.read().splitlines()
+    with open(out_pip, encoding="ascii") as fh:
+        pip = fh.read().splitlines()
     return conda, pip
 
 
@@ -64,60 +76,72 @@ def _has(lines, pkg):
     return any(pkg.lower() in ln.lower() for ln in lines)
 
 
-class TestPandas:
-    def test_adds_openpyxl(self, pr, tmp_path):
-        conda, pip = _run(pr, tmp_path, "pandas\n")
-        assert _has(conda, "openpyxl") and _has(pip, "openpyxl")
+class _Base(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.mkdtemp(prefix="heuristics.")
 
-    def test_adds_xlsxwriter(self, pr, tmp_path):
-        conda, pip = _run(pr, tmp_path, "pandas\n")
-        assert _has(conda, "xlsxwriter") and _has(pip, "xlsxwriter")
-
-    def test_no_dup_openpyxl(self, pr, tmp_path):
-        _, pip = _run(pr, tmp_path, "pandas\nopenpyxl\n")
-        assert sum(1 for ln in pip if "openpyxl" in ln.lower()) == 1
+    def tearDown(self):
+        shutil.rmtree(self._tmp, ignore_errors=True)
 
 
-class TestRequests:
-    def test_adds_certifi(self, pr, tmp_path):
-        conda, pip = _run(pr, tmp_path, "requests\n")
-        assert _has(conda, "certifi") and _has(pip, "certifi")
+class TestPandas(_Base):
+    def test_adds_openpyxl(self):
+        conda, pip = _run(self._tmp, "pandas\n")
+        self.assertTrue(_has(conda, "openpyxl") and _has(pip, "openpyxl"))
+
+    def test_adds_xlsxwriter(self):
+        conda, pip = _run(self._tmp, "pandas\n")
+        self.assertTrue(_has(conda, "xlsxwriter") and _has(pip, "xlsxwriter"))
+
+    def test_no_dup_openpyxl(self):
+        _, pip = _run(self._tmp, "pandas\nopenpyxl\n")
+        self.assertEqual(sum(1 for ln in pip if "openpyxl" in ln.lower()), 1)
 
 
-class TestSQLAlchemy:
-    def test_adds_pymysql(self, pr, tmp_path):
-        conda, pip = _run(pr, tmp_path, "sqlalchemy\n")
-        assert _has(conda, "pymysql") and _has(pip, "pymysql")
+class TestRequests(_Base):
+    def test_adds_certifi(self):
+        conda, pip = _run(self._tmp, "requests\n")
+        self.assertTrue(_has(conda, "certifi") and _has(pip, "certifi"))
 
 
-class TestMatplotlib:
-    def test_adds_tk(self, pr, tmp_path):
-        # tk ships as a conda package; verify conda output only
-        conda, _ = _run(pr, tmp_path, "matplotlib\n")
-        assert _has(conda, "tk")
+class TestSQLAlchemy(_Base):
+    def test_adds_pymysql(self):
+        conda, pip = _run(self._tmp, "sqlalchemy\n")
+        self.assertTrue(_has(conda, "pymysql") and _has(pip, "pymysql"))
 
 
-class TestCrypto:
-    def test_cryptography_adds_cffi(self, pr, tmp_path):
-        conda, pip = _run(pr, tmp_path, "cryptography\n")
-        assert _has(conda, "cffi") and _has(pip, "cffi")
-
-    def test_pycryptodome_adds_cffi(self, pr, tmp_path):
-        conda, pip = _run(pr, tmp_path, "pycryptodome\n")
-        assert _has(conda, "cffi") and _has(pip, "cffi")
+class TestMatplotlib(_Base):
+    def test_adds_tk(self):
+        # tk ships as a conda system package; verify conda output only
+        conda, _ = _run(self._tmp, "matplotlib\n")
+        self.assertTrue(_has(conda, "tk"))
 
 
-class TestDisable:
-    def test_kill_switch(self, pr, tmp_path):
-        conda, pip = _run(pr, tmp_path, "pandas\nrequests\n",
+class TestCrypto(_Base):
+    def test_cryptography_adds_cffi(self):
+        conda, pip = _run(self._tmp, "cryptography\n")
+        self.assertTrue(_has(conda, "cffi") and _has(pip, "cffi"))
+
+    def test_pycryptodome_adds_cffi(self):
+        conda, pip = _run(self._tmp, "pycryptodome\n")
+        self.assertTrue(_has(conda, "cffi") and _has(pip, "cffi"))
+
+
+class TestDisable(_Base):
+    def test_kill_switch(self):
+        conda, pip = _run(self._tmp, "pandas\nrequests\n",
                           extra_env={"HP_DISABLE_HEURISTICS": "1"})
-        assert not _has(conda, "openpyxl")
-        assert not _has(pip, "certifi")
+        self.assertFalse(_has(conda, "openpyxl"))
+        self.assertFalse(_has(pip, "certifi"))
 
 
-class TestNoFalsePositives:
-    def test_unrelated_package(self, pr, tmp_path):
-        conda, pip = _run(pr, tmp_path, "flask\n")
+class TestNoFalsePositives(_Base):
+    def test_unrelated_package(self):
+        conda, pip = _run(self._tmp, "flask\n")
         for pkg in ("openpyxl", "certifi", "pymysql", "cffi"):
-            assert not _has(conda, pkg), f"unexpected {pkg} in conda"
-            assert not _has(pip, pkg), f"unexpected {pkg} in pip"
+            self.assertFalse(_has(conda, pkg), f"unexpected {pkg} in conda")
+            self.assertFalse(_has(pip, pkg), f"unexpected {pkg} in pip")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Closes the full end-to-end trace for all 6 REQ-005.8 heuristic rules:
**Requirement → Code → Test → CI → Artifact → Report → Diagnostic site**

- **`tests/test_heuristics.py`**: rewritten to `unittest.TestCase` (no pytest install needed in CI); fixed `ResourceWarning` on output files; runnable via `python -m unittest tests.test_heuristics -v`
- **`tests/dynamic_tests.py`**: added `pr.*` NDJSON rows for all remaining heuristics (`pr.pandas.xlsxwriter`, `pr.requests.certifi`, `pr.sqlalchemy.pymysql`, `pr.matplotlib.tk`, `pr.cryptography.cffi`, `pr.pycryptodome.cffi`) — these land in the selftest artifact `dynamic/` subdirectory read by the diagnostic site
- **`.github/workflows/batch-check.yml`**: new step "Self-test: heuristics unittest" emits `self.heuristics.pytest` row to `tests/~test-results.ndjson` and `ci_test_results.ndjson` (same pattern as `self.parse_warn.pytest`)
- **`README.md`**: REQ-005.8.1–5.5 all marked TESTED with file references
- **`CLAUDE.md`**: added `self.heuristics.pytest` to CI-artifacts NDJSON surface; added Dynamic-tests NDJSON block documenting all `pr.*` rows

## Test plan

- [ ] `python -m unittest tests.test_heuristics -v` → 10 passed, no warnings
- [ ] `python -m compileall -q .` → clean
- [ ] `python tools/check_delimiters.py run_setup.bat` → no issues
- [ ] YAML validates OK
- [ ] CI: `self.heuristics.pytest` row appears in NDJSON artifact (all lanes)
- [ ] CI: `pr.requests.certifi`, `pr.sqlalchemy.pymysql`, `pr.matplotlib.tk`, `pr.cryptography.cffi`, `pr.pycryptodome.cffi` rows appear in dynamic selftest artifact

https://claude.ai/code/session_01GxyF4wM2Ufgg3p3Fdi1SUg

---
_Generated by [Claude Code](https://claude.ai/code/session_01GxyF4wM2Ufgg3p3Fdi1SUg)_