### PR TITLE
feat: REQ-009/010/011 — env hierarchy docs, session isolation, directory integrity

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,20 @@ This repository serves as a proof of concept of this new approach.
   - `No Python files detected; skipping environment bootstrap.`
 - **Exactly 1 Python file**: run that file directly.
 - **2 or more Python files**: prefer a clear entry by:
+  0) Manual override (`%1` argument, e.g. drag-and-drop) -- if the file is co-located with the bootstrapper (REQ-011), it is used directly and skips all auto-detection.
   1) Common names in order: `main.py` > `app.py` > `run.py` > `cli.py`
   2) Otherwise, any file containing `if __name__ == "__main__":`
   - If no clear entry is found after those checks, the bootstrapper chooses deterministically and logs the choice.
+
+**Entry selection criteria (priority order):**
+
+| Criterion | Priority | REQ |
+|-----------|----------|-----|
+| Manual override `%1` (co-located) | 0 (highest) | REQ-002, REQ-011 |
+| `main.py` | 1 | REQ-002 |
+| `app.py` | 2 | REQ-002 |
+| `run.py` / `cli.py` | 3 | REQ-002 |
+| File with `__main__` guard | 4 | REQ-002 |
 
 ---
 
@@ -91,12 +102,34 @@ This repository serves as a proof of concept of this new approach.
     healthy.
   - The fast path (reusing `dist/<envname>.exe` when non-helper sources are unchanged) sits on top of either provider,
     whether the env originated from Conda or venv.
+- [REQ-009] Environment discovery hierarchy (priority order):
+  1. **UV** -- if `uv.exe` is available (cached or downloadable), create a `.uv_env` virtual environment using UV for fast dependency installs.
+  2. **Conda (Portable / Miniconda)** -- install or reuse Miniconda at `%PUBLIC%\Documents\Miniconda3` (non-admin) and create a named conda env.
+  3. **Local venv** (environment-creation fallback) -- if Conda is unavailable or fails, create a `.venv` virtual environment using whatever `python` / `py` is found on PATH (`python -m venv`). Still isolated, but depends on a pre-existing Python installation to create the env.
+  4. **System Python** (final degraded execution mode) -- if no isolated environment can be created, run the entry point directly under the first `python` / `py` on PATH with no env isolation. Dependencies may conflict with system packages.
+
+  **Provider selection criteria (priority order):**
+
+  | Provider | Priority | Notes |
+  |----------|----------|-------|
+  | UV (`.uv_env`) | 1st | REQ-009 |
+  | Conda / Miniconda | 2nd | REQ-009 |
+  | Local venv (`.venv`) | 3rd | REQ-009; env creation fallback |
+  | System Python | 4th | REQ-009; degraded execution mode, no isolation |
+
 - [REQ-006] Channels policy (determinism and legal-friction avoidance):
   - Before any updates or installs, force **community conda-forge only**:
     ```
     conda config --env --add channels conda-forge
     ```
   - Always install with `--override-channels -c conda-forge`.
+- [REQ-010] Session isolation (leak-proof environment):
+  - At script start, `PYTHONPATH` and `PYTHONHOME` are explicitly cleared so the host shell cannot inject external site-packages into the bootstrapped environment.
+  - Portable provider directories (UV `.uv_env\Scripts`, Conda env `\Scripts`) are **prepended** to `PATH` to shadow any global Python installation.
+- [REQ-011] Directory integrity for explicit file arguments:
+  - When a `.py` file is passed as `%1` (drag-and-drop or CLI argument), its parent directory (`%~dp1`) must equal the batch file directory (`%~dp0`). Both expand to a fully-qualified drive+path with trailing backslash; comparison is case-insensitive.
+  - On mismatch: `[ERROR] REQ-011: Dragged files must reside in the bootstrapper root folder for environment cleanliness.` -- script aborts (exit 1).
+  - This prevents accidental cross-project contamination when users drag a file from a different project folder onto `run_setup.bat`.
 
 ---
 

--- a/run_setup.bat
+++ b/run_setup.bat
@@ -69,6 +69,9 @@ if /I not "%HP_SCRIPT_ROOT:OneDrive=%"=="%HP_SCRIPT_ROOT%" (
 )
 if exist "%STATUS_FILE%" del "%STATUS_FILE%"
 set "HP_BOOTSTRAP_STATE=ok"
+rem REQ-010: nullify host-system Python path variables to prevent library interference
+set "PYTHONPATH="
+set "PYTHONHOME="
 set "HP_ENV_MODE=conda"
 set "HP_ENV_READY="
 set "HP_SKIP_PIPREQS=%HP_SKIP_PIPREQS%"
@@ -520,6 +523,10 @@ set "PEP723_BLOCK_FOUND="
 set "PEP723_REQ=~requirements.pep723.txt"
 if exist "%PEP723_REQ%" del "%PEP723_REQ%" >nul 2>&1
 call :determine_entry "%~1"
+if errorlevel 11 (
+  call :write_status "error" 1 %PYCOUNT%
+  exit /b 1
+)
 if errorlevel 1 call :die "[ERROR] Could not determine entry point"
 set "HP_PYPROJ_REQ=~requirements.pyproject.txt"
 if exist "%HP_PYPROJ_REQ%" del "%HP_PYPROJ_REQ%" >nul 2>&1
@@ -1104,6 +1111,10 @@ goto :after_env_bootstrap
 :after_env_bootstrap
 if defined HP_CI_SKIP_ENV goto :after_env_skip
 call :determine_entry "%~1"
+if errorlevel 11 (
+  call :write_status "error" 1 %PYCOUNT%
+  exit /b 1
+)
 if errorlevel 1 call :die "[ERROR] Could not determine entry point"
 if "%HP_ENTRY%"=="" (
   call :log "[INFO] No entry script detected; skipping PyInstaller packaging."
@@ -1434,14 +1445,22 @@ exit /b %errorlevel%
 set "HP_ENTRY="
 set "HP_ENTRY_CMD="
 set "HP_ENTRY_ARGS="
-if not "%~1"=="" if exist "%~1" (
-  set "MAIN_FILE=%~1"
-  set "HP_ENTRY=%MAIN_FILE%"
-  if not defined HP_DRAG_MSG_EMITTED (
-    echo *** Using drag-and-drop file: %MAIN_FILE%
-    set "HP_DRAG_MSG_EMITTED=1"
+if not "%~1"=="" (
+  rem REQ-011: %~dp1 = caller's argument directory; %~dp0 = batch script directory (both include trailing \)
+  if /i not "%~dp1"=="%~dp0" (
+    echo [ERROR] REQ-011: Dragged files must reside in the bootstrapper root folder for environment cleanliness.
+    call :log "[ERROR] REQ-011: Dragged files must reside in the bootstrapper root folder."
+    exit /b 11
   )
-  exit /b 0
+  if exist "%~1" (
+    set "MAIN_FILE=%~1"
+    set "HP_ENTRY=%MAIN_FILE%"
+    if not defined HP_DRAG_MSG_EMITTED (
+      echo *** Using drag-and-drop file: %MAIN_FILE%
+      set "HP_DRAG_MSG_EMITTED=1"
+    )
+    exit /b 0
+  )
 )
 call :emit_from_base64 "~find_entry.py" HP_FIND_ENTRY
 if errorlevel 1 exit /b 1

--- a/tests/harness.ps1
+++ b/tests/harness.ps1
@@ -266,7 +266,7 @@ $hasHostPython = ($AllText -match 'Host Python:')
 Write-Result "host.env.python" "Host Python diagnostic print present" $hasHostPython @{}
 $hasReq010 = ($AllText -match 'set\s+"PYTHONPATH="') -and ($AllText -match 'set\s+"PYTHONHOME="')
 Write-Result "batch.req010.isolation" "REQ-010: PYTHONPATH and PYTHONHOME cleared at script start" $hasReq010 @{}
-$hasReq011 = ($AllText -match 'REQ-011') -and ($AllText -match '%%~dpI')
+$hasReq011 = ($AllText -match 'REQ-011') -and ($AllText -match '%~dp1')
 Write-Result "batch.req011.dircheck" "REQ-011: directory integrity check present in run_setup.bat" $hasReq011 @{}
 $results = Get-Content -LiteralPath $ResultsPath -Encoding ASCII | ForEach-Object { $_ | ConvertFrom-Json }
 $fail = @($results | Where-Object { -not $_.pass })

--- a/tests/harness.ps1
+++ b/tests/harness.ps1
@@ -264,6 +264,10 @@ $hasHostPS = ($AllText -match 'Host PowerShell:')
 Write-Result "host.env.ps" "Host PowerShell diagnostic print present" $hasHostPS @{}
 $hasHostPython = ($AllText -match 'Host Python:')
 Write-Result "host.env.python" "Host Python diagnostic print present" $hasHostPython @{}
+$hasReq010 = ($AllText -match 'set\s+"PYTHONPATH="') -and ($AllText -match 'set\s+"PYTHONHOME="')
+Write-Result "batch.req010.isolation" "REQ-010: PYTHONPATH and PYTHONHOME cleared at script start" $hasReq010 @{}
+$hasReq011 = ($AllText -match 'REQ-011') -and ($AllText -match '%%~dpI')
+Write-Result "batch.req011.dircheck" "REQ-011: directory integrity check present in run_setup.bat" $hasReq011 @{}
 $results = Get-Content -LiteralPath $ResultsPath -Encoding ASCII | ForEach-Object { $_ | ConvertFrom-Json }
 $fail = @($results | Where-Object { -not $_.pass })
 $pass = @($results | Where-Object { $_.pass })

--- a/tests/selfapps_entry.ps1
+++ b/tests/selfapps_entry.ps1
@@ -319,6 +319,156 @@ Write-EntryRow -Id 'self.entry.entryB' -Expected $expectedB -Scenario $scenarioB
 Check-PipreqsFailure -LogPath $scenarioB.setupPath -LogText $scenarioB.setupLog
 Check-HelperInvokeFailure -LogPath $scenarioB.bootstrapPath -LogText $scenarioB.bootstrapLog
 
+# Scenario C: REQ-011 -- cross-dir explicit arg must abort (negative test)
+$scenarioCBoot = Join-Path -Path $here -ChildPath '~entryC_boot'
+$scenarioCExt  = Join-Path -Path $here -ChildPath '~entryC_ext'
+try {
+    foreach ($d in @($scenarioCBoot, $scenarioCExt)) {
+        if (Test-Path -LiteralPath $d) { Remove-Item -LiteralPath $d -Recurse -Force }
+        New-Item -ItemType Directory -Force -Path $d | Out-Null
+    }
+    Copy-Item -LiteralPath (Join-Path $repoRoot 'run_setup.bat') -Destination $scenarioCBoot -Force
+    $extPy = Join-Path $scenarioCExt 'external.py'
+    Set-Content -LiteralPath $extPy -Value 'print("external")' -Encoding Ascii -NoNewline
+
+    Push-Location -LiteralPath $scenarioCBoot
+    try {
+        # PowerShell quotes $extPy automatically if it contains spaces.
+        cmd /c .\run_setup.bat $extPy *> '~entryC_bootstrap.log'
+        $exitC = $LASTEXITCODE
+    } finally {
+        Pop-Location
+    }
+
+    $logCPath = Join-Path $scenarioCBoot '~entryC_bootstrap.log'
+    $logCText = if (Test-Path -LiteralPath $logCPath) { Get-Content $logCPath -Raw -Encoding Ascii } else { '' }
+    $req011InLog = [bool]($logCText -match 'REQ-011')
+    $passC = ($exitC -ne 0) -and $req011InLog
+
+    Write-NdjsonRow ([ordered]@{
+        id      = 'self.entry.req011.crossdir'
+        req     = 'REQ-011'
+        pass    = $passC
+        desc    = 'REQ-011: cross-dir file argument must abort bootstrap'
+        details = [ordered]@{ exitCode = $exitC; req011InLog = $req011InLog }
+    })
+} catch {
+    Write-NdjsonRow ([ordered]@{
+        id      = 'self.entry.req011.crossdir'
+        req     = 'REQ-011'
+        pass    = $false
+        desc    = 'REQ-011: cross-dir test threw an exception'
+        details = [ordered]@{ error = $_.Exception.Message }
+    })
+}
+
+# Scenario D: REQ-011 -- same-dir explicit arg must succeed (positive test)
+$scenarioDRoot = Join-Path -Path $here -ChildPath '~entryD_boot'
+try {
+    if (Test-Path -LiteralPath $scenarioDRoot) { Remove-Item -LiteralPath $scenarioDRoot -Recurse -Force }
+    New-Item -ItemType Directory -Force -Path $scenarioDRoot | Out-Null
+    Copy-Item -LiteralPath (Join-Path $repoRoot 'run_setup.bat') -Destination $scenarioDRoot -Force
+    Set-Content -LiteralPath (Join-Path $scenarioDRoot 'direct.py') -Value 'print("direct")' -Encoding Ascii -NoNewline
+
+    Push-Location -LiteralPath $scenarioDRoot
+    try {
+        # Pass relative arg -- the canonicalization in run_setup.bat resolves .\direct.py
+        # relative to the boot dir so the directory check matches HP_SELF_DIR.
+        cmd /c '.\run_setup.bat ".\direct.py"' *> '~entryD_bootstrap.log'
+        $exitD = $LASTEXITCODE
+    } finally {
+        Pop-Location
+    }
+
+    $setupDPath = Join-Path $scenarioDRoot '~setup.log'
+    $setupDText = if (Test-Path -LiteralPath $setupDPath) { Get-Content $setupDPath -Raw -Encoding Ascii } else { '' }
+    # Match basename only -- log may preserve .\direct.py or show canonicalized full path.
+    $entryInLog = [bool]($setupDText -match 'direct\.py')
+    $passD = ($exitD -eq 0) -and $entryInLog
+
+    Write-NdjsonRow ([ordered]@{
+        id      = 'self.entry.req011.sameDir'
+        req     = 'REQ-011'
+        pass    = $passD
+        desc    = 'REQ-011: same-dir file argument must succeed'
+        details = [ordered]@{ exitCode = $exitD; entryInLog = $entryInLog }
+    })
+} catch {
+    Write-NdjsonRow ([ordered]@{
+        id      = 'self.entry.req011.sameDir'
+        req     = 'REQ-011'
+        pass    = $false
+        desc    = 'REQ-011: same-dir test threw an exception'
+        details = [ordered]@{ error = $_.Exception.Message }
+    })
+}
+
+# REQ-010 behavioral isolation test: entry script reports PYTHONPATH value so we can
+# verify that run_setup.bat cleared it before any Python subprocess ran.
+# Without SET "PYTHONPATH=" in run_setup.bat the conda Python would see the injected
+# marker value and the assertion below would fail.
+$req010Root    = Join-Path -Path $here -ChildPath '~req010_test'
+$prevPythonPath = $env:PYTHONPATH
+try {
+    if (Test-Path -LiteralPath $req010Root) { Remove-Item -LiteralPath $req010Root -Recurse -Force }
+    New-Item -ItemType Directory -Force -Path $req010Root | Out-Null
+    Copy-Item -LiteralPath (Join-Path $repoRoot 'run_setup.bat') -Destination $req010Root -Force
+
+    # Entry script writes PYTHONPATH / PYTHONHOME to ~isolation_check.txt.
+    $entryContent = @'
+import os
+pythonpath = os.environ.get('PYTHONPATH', '')
+pythonhome = os.environ.get('PYTHONHOME', '')
+with open('~isolation_check.txt', 'w') as fh:
+    fh.write('PYTHONPATH={}\nPYTHONHOME={}\n'.format(pythonpath, pythonhome))
+'@
+    Set-Content -LiteralPath (Join-Path $req010Root 'isolation_check.py') -Value $entryContent -Encoding Ascii
+
+    $env:PYTHONPATH = 'C:\req010_poison_marker'
+
+    Push-Location -LiteralPath $req010Root
+    try {
+        cmd /c .\run_setup.bat *> '~req010_bootstrap.log'
+        $exit010 = $LASTEXITCODE
+    } finally {
+        Pop-Location
+    }
+
+    $checkPath = Join-Path $req010Root '~isolation_check.txt'
+    if (-not (Test-Path -LiteralPath $checkPath)) {
+        $pass010 = $false
+        $checkText = 'FILE_NOT_CREATED'
+        $pythonpathCleared = $false
+    } else {
+        $checkText = Get-Content $checkPath -Raw -Encoding Ascii
+        $ppLine = ($checkText -split '\r?\n' | Where-Object { $_ -match '^PYTHONPATH=' } | Select-Object -First 1)
+        $pythonpathCleared = $ppLine -eq 'PYTHONPATH='
+        $pass010 = ($exit010 -eq 0) -and $pythonpathCleared
+    }
+
+    Write-NdjsonRow ([ordered]@{
+        id      = 'self.isolation.req010.pythonpath'
+        req     = 'REQ-010'
+        pass    = $pass010
+        desc    = 'REQ-010: PYTHONPATH is cleared before Python subprocesses run'
+        details = [ordered]@{ exitCode = $exit010; pythonpathCleared = $pythonpathCleared; checkSnippet = ($checkText.Trim() | Select-Object -First 1) }
+    })
+} catch {
+    Write-NdjsonRow ([ordered]@{
+        id      = 'self.isolation.req010.pythonpath'
+        req     = 'REQ-010'
+        pass    = $false
+        desc    = 'REQ-010: isolation test threw an exception'
+        details = [ordered]@{ error = $_.Exception.Message }
+    })
+} finally {
+    if ($null -eq $prevPythonPath) {
+        Remove-Item -Path 'env:PYTHONPATH' -ErrorAction SilentlyContinue
+    } else {
+        $env:PYTHONPATH = $prevPythonPath
+    }
+}
+
 $parsedRows = @()
 if (Test-Path -LiteralPath $ciNd) {
     foreach ($line in Get-Content -LiteralPath $ciNd -Encoding Ascii) {


### PR DESCRIPTION
## Summary

- **REQ-010 (Session Isolation)**: Clear `PYTHONPATH` and `PYTHONHOME` at script start (before any Python subprocess) to prevent the host shell from injecting external site-packages into the bootstrapped environment.
- **REQ-011 (Directory Integrity)**: In `:determine_entry`, reject `%1` arguments whose parent directory (`%~dp1`) differs from the batch file directory (`%~dp0`). Emits `[ERROR] REQ-011` and exits errorlevel 11; both call sites updated to intercept 11 before the generic errorlevel 1 check.
- **REQ-009 (Provider Hierarchy)**: Document the 4-tier discovery order (UV → Conda → Local venv → System Python) in README, clarifying that tier 3 is an env-creation fallback and tier 4 is the final degraded execution mode.
- **README**: Add REQ-002 manual-override step 0, entry/provider priority tables, and REQ-010/011 spec sections.

## Test plan

- [ ] `tests/selfapps_entry.ps1` Scenario C: cross-dir `%1` must abort — `self.entry.req011.crossdir` passes
- [ ] `tests/selfapps_entry.ps1` Scenario D: same-dir `%1` must succeed — `self.entry.req011.sameDir` passes
- [ ] `tests/selfapps_entry.ps1` REQ-010 behavioral test: entry script writes `PYTHONPATH=` (empty) to `~isolation_check.txt` — `self.isolation.req010.pythonpath` passes
- [ ] `tests/harness.ps1` static checks: `batch.req010.isolation` and `batch.req011.dircheck` pass
- [ ] All existing `self.entry.entry1/entryA/entryB` rows continue to pass
- [ ] `python tools/check_delimiters.py run_setup.bat` — no issues
- [ ] `python -m compileall -q .` and `python -m pyflakes .` — clean

https://claude.ai/code/session_014N3VpdFkv6736sj49c47v6

---
_Generated by [Claude Code](https://claude.ai/code/session_014N3VpdFkv6736sj49c47v6)_