### PR TITLE
feat: REQ-009 Tier 3 -- wire venv fallback as default when conda fails

### DIFF
--- a/.github/workflows/batch-check.yml
+++ b/.github/workflows/batch-check.yml
@@ -1111,6 +1111,12 @@ jobs:
             tests\~selftest_corrupt_uv\~setup.log
             tests/~selftest_corrupt_uv/~bootstrap.status.json
             tests\~selftest_corrupt_uv\~bootstrap.status.json
+            tests/~selftest_venv_fallback/~venv_fallback.log
+            tests\~selftest_venv_fallback\~venv_fallback.log
+            tests/~selftest_venv_fallback/~setup.log
+            tests\~selftest_venv_fallback\~setup.log
+            tests/~selftest_venv_fallback/~bootstrap.status.json
+            tests\~selftest_venv_fallback\~bootstrap.status.json
             tests/~selftest-summary.txt
             tests\~selftest-summary.txt
             tests/~test-summary.txt

--- a/.github/workflows/batch-check.yml
+++ b/.github/workflows/batch-check.yml
@@ -1117,6 +1117,8 @@ jobs:
             tests\~selftest_venv_fallback\~setup.log
             tests/~selftest_venv_fallback/~bootstrap.status.json
             tests\~selftest_venv_fallback\~bootstrap.status.json
+            tests/~selftest_venv_fallback/~run.out.txt
+            tests\~selftest_venv_fallback\~run.out.txt
             tests/~selftest-summary.txt
             tests\~selftest-summary.txt
             tests/~test-summary.txt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -314,12 +314,17 @@ dp.compat, prep.multi.constraint, batch.paren.balance, env.foldername,
 conda.path,
 version.metadata,
 host.env.os, host.env.ps, host.env.python,
+batch.req009.venv_unconditional,
 self.stub.fastpath, self.stub.rebuild, self.stub.state_skip,
 self.corrupt.conda.detect,
 self.corrupt.conda.heal.decline,
-self.corrupt.uv.detect,
-self.cache.corrupted,
-self.cache.bootstrap.failed
+self.corrupt.uv.detect
+```
+
+selfapps-ux-hardening NDJSON rows (selfapps_ux_hardening.ps1, non-conda-full lanes):
+
+```
+self.venv.fallback
 ```
 
 ---

--- a/run_setup.bat
+++ b/run_setup.bat
@@ -112,10 +112,12 @@ rem HP_OFFLINE_MODE is set by :check_net_after_dl_fail when user declines or no 
 set "HP_OFFLINE_MODE=%HP_OFFLINE_MODE%"
 rem HP_TEST_FORCE_CONNECTIVITY_CHECK=1: triggers connectivity gate at startup for CI coverage
 set "HP_TEST_FORCE_CONNECTIVITY_CHECK=%HP_TEST_FORCE_CONNECTIVITY_CHECK%"
-rem HP_TEST_FORCE_VENV_FAIL=1: simulates venv creation failure for REQ-014 branch coverage
+rem HP_TEST_FORCE_VENV_FAIL=1: simulates venv creation failure for REQ-009/REQ-014 branch coverage
 set "HP_TEST_FORCE_VENV_FAIL=%HP_TEST_FORCE_VENV_FAIL%"
-rem HP_TEST_FORCE_CONDA_FAIL=1: simulates conda env creation failure for REQ-014 branch coverage
+rem HP_TEST_FORCE_CONDA_FAIL=1: simulates conda env creation failure for REQ-009/REQ-014 branch coverage
 set "HP_TEST_FORCE_CONDA_FAIL=%HP_TEST_FORCE_CONDA_FAIL%"
+rem HP_ALLOW_VENV_FALLBACK (deprecated): venv fallback is now unconditional when conda fails; accepted but ignored.
+set "HP_ALLOW_VENV_FALLBACK=%HP_ALLOW_VENV_FALLBACK%"
 rem HP_TEST_FORCE_CONSENT_CHECK=1: directly triggers consent gate at startup for REQ-014 branch coverage
 set "HP_TEST_FORCE_CONSENT_CHECK=%HP_TEST_FORCE_CONSENT_CHECK%"
 rem HP_TEST_CORRUPT_CONDA=1: simulates a corrupt conda binary for REQ-020 branch coverage (corruption hardening)
@@ -128,7 +130,6 @@ set "HP_TEST_CORRUPT_UV=%HP_TEST_CORRUPT_UV%"
 rem derived requirement: CI's conda-only lane must surface conda regressions instead of masking them with opt-in fallbacks.
 if "%HP_FORCE_CONDA_ONLY%"=="1" (
   rem derived requirement: conda-full diagnostics must avoid venv/system fallbacks so iterate can flag real conda regressions.
-  set "HP_ALLOW_VENV_FALLBACK="
   set "HP_ALLOW_SYSTEM_FALLBACK="
   call :log "[INFO] Conda-only flag active: fallbacks disabled."
 )
@@ -1275,12 +1276,11 @@ if "%HP_FORCE_CONDA_ONLY%"=="1" (
   exit /b 0
 )
 
-if "%HP_ALLOW_VENV_FALLBACK%"=="1" (
-  call :try_venv_fallback
-  if not errorlevel 1 (
-    set "HP_ENV_READY=1"
-    exit /b 0
-  )
+rem REQ-009: venv fallback is always attempted when conda fails; HP_ALLOW_VENV_FALLBACK is deprecated/ignored.
+call :try_venv_fallback
+if not errorlevel 1 (
+  set "HP_ENV_READY=1"
+  exit /b 0
 )
 if "%HP_ALLOW_SYSTEM_FALLBACK%"=="1" (
   call :try_system_fallback

--- a/tests/harness.ps1
+++ b/tests/harness.ps1
@@ -290,6 +290,8 @@ Write-Result "batch.req011.dircheck" "REQ-011: directory integrity check present
 $req009Patterns = @('\[BOOT\] REQ-009.*Selected.*UV', '\[BOOT\] REQ-009.*Selected.*Conda', '\[BOOT\] REQ-009.*Selected.*Local venv', '\[BOOT\] REQ-009.*Selected.*System Python')
 $hasReq009 = ($req009Patterns | Where-Object { -not ($AllText -match $_) }).Count -eq 0
 Write-Result "batch.req009.provider_logs" "REQ-009: all four provider log lines present in run_setup.bat" $hasReq009 @{}
+$venvGuardFound = $AllText -match [regex]::Escape('"%HP_ALLOW_VENV_FALLBACK%"=="1"')
+Write-Result "batch.req009.venv_unconditional" "REQ-009: venv fallback not guarded by HP_ALLOW_VENV_FALLBACK (fallback is unconditional)" (-not $venvGuardFound) @{ guardFound = $venvGuardFound }
 $hasReq002Entry = $AllText -match '\[BOOT\] REQ-002.*Entry selected'
 Write-Result "batch.req002.entry_log" "REQ-002: entry selection log line present in run_setup.bat" $hasReq002Entry @{}
 $feMatch = [regex]::Match($AllText, 'set "HP_FIND_ENTRY=([A-Za-z0-9+/=]+)"')

--- a/tests/selfapps_ux_hardening.ps1
+++ b/tests/selfapps_ux_hardening.ps1
@@ -375,6 +375,73 @@ if ($env:HP_FORCE_CONDA_ONLY -eq '1') {
     })
 }
 
-$allPass = $giMerged -and $giPreserved -and $giIdem -and ($gaMerged -and $gaBatCrlf) -and $gaIdem -and $pfFound -and ($connPromptFound -and $connOfflineLog) -and $connPromptFound -and $uvOfflinePass -and $condaOfflinePass -and ($sysPromptFound -and $sysDeclineLog) -and $sysPromptFound -and $sysRealPass
+# ===== REQ-009 Tier 3: Venv fallback success path =====
+# Forces conda to fail; verifies venv fallback fires automatically and app bootstraps via .venv.
+# Skipped in conda-full lane where HP_FORCE_CONDA_ONLY=1 blocks all fallbacks unconditionally.
+$venvFbDir = Join-Path $here '~selftest_venv_fallback'
+if (Test-Path $venvFbDir) { Remove-Item -Recurse -Force $venvFbDir }
+New-Item -ItemType Directory -Force -Path $venvFbDir | Out-Null
+Copy-Item -LiteralPath (Join-Path $repo 'run_setup.bat') -Destination $venvFbDir -Force
+Set-Content -LiteralPath (Join-Path $venvFbDir 'app.py') -Value 'print("venv-fallback-ok")' -Encoding Ascii
+
+$venvFbPass = $true
+if ($env:HP_FORCE_CONDA_ONLY -eq '1') {
+    Write-NdjsonRow ([ordered]@{
+        id      = 'self.venv.fallback'
+        req     = 'REQ-009'
+        pass    = $true
+        desc    = 'REQ-009 Tier 3: venv fallback success path test'
+        details = [ordered]@{ skip = $true; reason = 'HP_FORCE_CONDA_ONLY-prohibits-venv-fallback' }
+    })
+} else {
+    $savedCondaFail4 = $env:HP_TEST_FORCE_CONDA_FAIL
+    $savedOffline4   = $env:HP_OFFLINE_MODE
+    $savedSkipPR4    = $env:HP_SKIP_PIPREQS
+    $savedLane4      = $env:HP_CI_LANE
+    $env:HP_TEST_FORCE_CONDA_FAIL = '1'
+    $env:HP_OFFLINE_MODE          = '1'
+    $env:HP_SKIP_PIPREQS          = '1'
+    $env:HP_CI_LANE               = 'test'
+    $venvFbLog = Join-Path $venvFbDir '~venv_fallback.log'
+    Push-Location -LiteralPath $venvFbDir
+    try {
+        cmd /c "run_setup.bat > ~venv_fallback.log 2>&1"
+        $venvFbExit = $LASTEXITCODE
+    } finally {
+        Pop-Location
+    }
+    $env:HP_TEST_FORCE_CONDA_FAIL = $savedCondaFail4
+    $env:HP_OFFLINE_MODE          = $savedOffline4
+    $env:HP_SKIP_PIPREQS          = $savedSkipPR4
+    $env:HP_CI_LANE               = $savedLane4
+
+    $venvFbText = ''
+    if (Test-Path -LiteralPath $venvFbLog) {
+        $venvFbText = Get-Content -LiteralPath $venvFbLog -Raw -Encoding Ascii
+    }
+    $venvFbSetupLog = Join-Path $venvFbDir '~setup.log'
+    $venvFbSetupText = ''
+    if (Test-Path -LiteralPath $venvFbSetupLog) {
+        $venvFbSetupText = Get-Content -LiteralPath $venvFbSetupLog -Raw -Encoding Ascii
+    }
+    $venvFbReady    = ($venvFbSetupText -match [regex]::Escape('[INFO] venv fallback ready:'))
+    $venvFbProvider = ($venvFbSetupText -match [regex]::Escape('[BOOT] REQ-009: Selected Python provider: Local venv (fallback).'))
+    $venvFbAppRan   = ($venvFbText -match [regex]::Escape('venv-fallback-ok'))
+    $venvFbPass = ($venvFbReady -and $venvFbProvider -and $venvFbAppRan)
+    Write-NdjsonRow ([ordered]@{
+        id      = 'self.venv.fallback'
+        req     = 'REQ-009'
+        pass    = $venvFbPass
+        desc    = 'REQ-009 Tier 3: venv fallback fires when conda fails and app bootstraps via .venv'
+        details = [ordered]@{
+            venvReadyLog     = $venvFbReady
+            providerLogFound = $venvFbProvider
+            appRan           = $venvFbAppRan
+            exit             = $venvFbExit
+        }
+    })
+}
+
+$allPass = $giMerged -and $giPreserved -and $giIdem -and ($gaMerged -and $gaBatCrlf) -and $gaIdem -and $pfFound -and ($connPromptFound -and $connOfflineLog) -and $connPromptFound -and $uvOfflinePass -and $condaOfflinePass -and ($sysPromptFound -and $sysDeclineLog) -and $sysPromptFound -and $sysRealPass -and $venvFbPass
 if (-not $allPass) { exit 1 }
 exit 0

--- a/tests/selfapps_ux_hardening.ps1
+++ b/tests/selfapps_ux_hardening.ps1
@@ -415,18 +415,19 @@ if ($env:HP_FORCE_CONDA_ONLY -eq '1') {
     $env:HP_SKIP_PIPREQS          = $savedSkipPR4
     $env:HP_CI_LANE               = $savedLane4
 
-    $venvFbText = ''
-    if (Test-Path -LiteralPath $venvFbLog) {
-        $venvFbText = Get-Content -LiteralPath $venvFbLog -Raw -Encoding Ascii
-    }
     $venvFbSetupLog = Join-Path $venvFbDir '~setup.log'
     $venvFbSetupText = ''
     if (Test-Path -LiteralPath $venvFbSetupLog) {
         $venvFbSetupText = Get-Content -LiteralPath $venvFbSetupLog -Raw -Encoding Ascii
     }
+    $venvFbRunOut = Join-Path $venvFbDir '~run.out.txt'
+    $venvFbRunText = ''
+    if (Test-Path -LiteralPath $venvFbRunOut) {
+        $venvFbRunText = Get-Content -LiteralPath $venvFbRunOut -Raw -Encoding Ascii
+    }
     $venvFbReady    = ($venvFbSetupText -match [regex]::Escape('[INFO] venv fallback ready:'))
     $venvFbProvider = ($venvFbSetupText -match [regex]::Escape('[BOOT] REQ-009: Selected Python provider: Local venv (fallback).'))
-    $venvFbAppRan   = ($venvFbText -match [regex]::Escape('venv-fallback-ok'))
+    $venvFbAppRan   = ($venvFbRunText -match [regex]::Escape('venv-fallback-ok'))
     $venvFbPass = ($venvFbReady -and $venvFbProvider -and $venvFbAppRan)
     Write-NdjsonRow ([ordered]@{
         id      = 'self.venv.fallback'


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Root cause fixed**: `HP_ALLOW_VENV_FALLBACK` was never set in production, making the venv fallback in `:handle_conda_failure` dead code — violating REQ-009 Tier 3 (Local venv fallback must fire when conda fails)
- **Fix**: Remove the `if "%HP_ALLOW_VENV_FALLBACK%"=="1"` guard; venv fallback now fires unconditionally on conda failure. `HP_FORCE_CONDA_ONLY` still protects the conda-full CI lane.
- **New test**: `self.venv.fallback` scenario in `tests/selfapps_ux_hardening.ps1` — runs `run_setup.bat` with `HP_TEST_FORCE_CONDA_FAIL=1` + `HP_OFFLINE_MODE=1` and verifies `.venv` is created and app executes
- **New static check**: `batch.req009.venv_unconditional` in `tests/harness.ps1` — verifies the guard string is absent from `run_setup.bat` to catch regression

## Changed files

| File | Change |
|------|--------|
| `run_setup.bat` | Remove `HP_ALLOW_VENV_FALLBACK` guard in `:handle_conda_failure`; add deprecation comment |
| `tests/selfapps_ux_hardening.ps1` | Add `self.venv.fallback` test (skips in conda-full lane) |
| `tests/harness.ps1` | Add `batch.req009.venv_unconditional` static check |
| `.github/workflows/batch-check.yml` | Upload `~selftest_venv_fallback/` artifacts |
| `CLAUDE.md` | Update NDJSON surface table |

## Test plan

- [ ] `batch.req009.venv_unconditional` passes (static: guard string absent)
- [ ] `self.venv.fallback` passes in real/cache lanes (skips with pass=true in conda-full lane)
- [ ] All existing NDJSON rows still green (non-decreasing row count)
- [ ] `self.ux.system.gate.real` still passes (venv still fails before system gate when `HP_TEST_FORCE_VENV_FAIL=1`)

https://claude.ai/code/session_01CjwFCn2Js1Ch9RaVk7357P
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CjwFCn2Js1Ch9RaVk7357P)_