### PR TITLE
ci: explicit HP_CACHE_CORRUPTED guard on cache save step

### DIFF
--- a/.github/workflows/batch-check.yml
+++ b/.github/workflows/batch-check.yml
@@ -1129,6 +1129,9 @@ jobs:
           retention-days: 14
 
       # Professional note: cache/save runs separately so failed bootstrap attempts do not persist a partial Miniconda tree.
+      # HP_CACHE_CORRUPTED guard on both validate and save: if the restored cache was corrupt (health
+      # check fired) or bootstrap failed (catch step set HP_CACHE_CORRUPTED=1), skip the save so we
+      # never write a corrupt tree back to the cache store (prevents the rolling-corruption-factory loop).
       - name: Validate Miniconda before cache save
         if: ${{ matrix.mode == 'cache' && steps.conda_cache_restore.outputs.cache-hit != 'true' && env.HP_CACHE_CORRUPTED != '1' }}
         id: conda_validate
@@ -1145,11 +1148,11 @@ jobs:
           }
 
       - name: Save Miniconda cache
-        if: ${{ matrix.mode == 'cache' && steps.conda_cache_restore.outputs.cache-hit != 'true' && steps.conda_validate.outputs.conda_ok == 'true' }}
+        if: ${{ matrix.mode == 'cache' && steps.conda_cache_restore.outputs.cache-hit != 'true' && env.HP_CACHE_CORRUPTED != '1' && steps.conda_validate.outputs.conda_ok == 'true' }}
         uses: actions/cache/save@v4
         with:
           path: C:\Users\Public\Documents\Miniconda3
-          key: win-${{ runner.os }}-py311b-conda-${{ hashFiles('run_setup.bat') }}-${{ env.HP_PIPREQS_VERSION }}
+          key: ${{ steps.conda_cache_restore.outputs.cache-primary-key }}
 
       - name: Summarize bootstrap result
         if: always()


### PR DESCRIPTION
## Summary

- Adds `env.HP_CACHE_CORRUPTED != '1'` explicitly to the **Save Miniconda cache** step condition, closing the rolling-corruption-factory loop described by Codex (P2 badge).
- Previously the save was blocked *transitively*: validate was skipped (its own `HP_CACHE_CORRUPTED` guard), leaving `conda_ok` empty, which blocked the save. That relies on skipped-step output semantics — fragile.
- Now the save step has an explicit guard: if the health check detected corruption *or* bootstrap failed (catch step), the corrupt Miniconda tree is never written back to the cache store.
- Also changed the save `key:` to use `steps.conda_cache_restore.outputs.cache-primary-key` so restore and save keys are always in sync without duplication.

## Root cause (Codex P2 badge analysis)

When a restore-key match provides an old/corrupt cache:
1. Cache is restored → `cache-hit = false` (restore-key match, not exact)
2. Health check detects corruption → `HP_CACHE_CORRUPTED=1`
3. Bootstrap is skipped
4. **Old behavior**: save relied only on `conda_ok == 'true'`; if validate was skipped, `conda_ok` is empty string — this *should* block the save, but it's implicit
5. **New behavior**: explicit `env.HP_CACHE_CORRUPTED != '1'` on the save step makes the defense unambiguous

## Test plan

- [ ] Cache lane CI passes (1.5 min on hit, normal on miss)
- [ ] Real and conda-full lanes pass (unaffected — no cache steps)
- [ ] Verify no new corrupt caches appear in the cache store after CI

https://claude.ai/code/session_01SkjoiBnCm87UVVQZxVdtrC

---
_Generated by [Claude Code](https://claude.ai/code/session_01SkjoiBnCm87UVVQZxVdtrC)_