### PR TITLE
feat: REQ-004 forward Python version to uv venv via --python X.Y

### DIFF
--- a/.github/workflows/batch-check.yml
+++ b/.github/workflows/batch-check.yml
@@ -1115,6 +1115,10 @@ jobs:
             tests\~selftest_venv_fallback\~venv_fallback.log
             tests/~selftest_venv_fallback/~setup.log
             tests\~selftest_venv_fallback\~setup.log
+            tests/~uv_pyver_test/~pyver_bootstrap.log
+            tests\~uv_pyver_test\~pyver_bootstrap.log
+            tests/~uv_pyver_test/~setup.log
+            tests\~uv_pyver_test\~setup.log
             tests/~selftest_venv_fallback/~bootstrap.status.json
             tests\~selftest_venv_fallback\~bootstrap.status.json
             tests/~selftest_venv_fallback/~run.out.txt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -480,3 +480,9 @@ Items completed and shipped:
   `[INFO] runtime.txt written: python-X.Y.Z`. Write-back guarded by `HP_RUNTIME_TXT_PREEXIST`
   so Tier 1 files (pre-existing runtime.txt) are never overwritten. Silent WARN on write
   failure (read-only filesystem). CLOSED by this PR.
+- **REQ-004 uv Python version forwarding (Tiers 1-2)**: When PYSPEC is set from runtime.txt
+  (Tier 1) or pyproject.toml (Tier 2), the detected Python version is now forwarded to
+  `uv venv` via `--python X.Y`. PYSPEC is parsed by inline PowerShell regex to extract the
+  lower-bound version from all forms (python=X.Y, python==X.Y, python>=X.Y, python>X.Y).
+  Log line: `[INFO] uv: creating venv at .uv_env with Python X.Y`. Covered by new NDJSON
+  row `self.contract.uv.pyver` (contract-uv lane). CLOSED by this PR.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -284,6 +284,7 @@ contract-uv lane rows (flag-triggered):
 
 ```
 self.contract.uv
+self.contract.uv.pyver
 ```
 
 contract-uv-fail lane rows (HP_TEST_UV_FAIL=1, flag-triggered):

--- a/run_setup.bat
+++ b/run_setup.bat
@@ -434,8 +434,8 @@ set "ENV_PATH=%MINICONDA_ROOT%\envs\%ENVNAME%"
 rem === uv venv creation (primary path when uv was acquired) ====================
 rem derived requirement: uv creates a pip-native venv at .uv_env in the project
 rem folder, short-circuiting conda create. On failure, :try_conda_create runs the
-rem existing conda path unchanged. Python version from PYSPEC is not yet forwarded
-rem to uv (version-pinning deferred; uv picks the system default Python).
+rem existing conda path unchanged. REQ-004 Tier 1-2 Python version (PYSPEC) is
+rem forwarded to uv via --python X.Y when a lower-bound version can be extracted.
 if not defined HP_UV_EXE goto :try_conda_create
 set "HP_UV_ENV_PATH=%HP_SCRIPT_ROOT%.uv_env"
 if defined PVW_WORKSPACE set "HP_UV_ENV_PATH=%PVW_WORKSPACE%"
@@ -449,8 +449,20 @@ if exist "%HP_UV_ENV_PATH%\Scripts\python.exe" (
     goto :uv_venv_ready
   )
 )
-call :log "[INFO] uv: creating venv at .uv_env..."
-"%HP_UV_EXE%" venv --seed "%HP_UV_ENV_PATH%" >> "%LOG%" 2>&1
+rem Extract Python version lower-bound from PYSPEC for uv --python (REQ-004 Tiers 1-2).
+rem Handles: python=X.Y (runtime.txt), python==X.Y, python>=X.Y, python>X.Y.
+rem [Console]::Write avoids the trailing CR from Write-Output that for /f does not strip.
+set "HP_UV_PY_VER="
+if defined PYSPEC (
+  for /f "usebackq delims=" %%V in (`powershell -NoProfile -ExecutionPolicy Bypass -Command "if ($env:PYSPEC -match 'python==([0-9]+\.[0-9]+)') { [Console]::Write($Matches[1]) } elseif ($env:PYSPEC -match 'python=([0-9]+\.[0-9]+)') { [Console]::Write($Matches[1]) } elseif ($env:PYSPEC -match 'python>=([0-9]+\.[0-9]+)') { [Console]::Write($Matches[1]) } elseif ($env:PYSPEC -match 'python>([0-9]+\.[0-9]+)') { [Console]::Write($Matches[1]) } else { [Console]::Write('') }"`) do set "HP_UV_PY_VER=%%V"
+)
+if defined HP_UV_PY_VER (
+  call :log "[INFO] uv: creating venv at .uv_env with Python %HP_UV_PY_VER%..."
+  "%HP_UV_EXE%" venv --seed --python "%HP_UV_PY_VER%" "%HP_UV_ENV_PATH%" >> "%LOG%" 2>&1
+) else (
+  call :log "[INFO] uv: creating venv at .uv_env..."
+  "%HP_UV_EXE%" venv --seed "%HP_UV_ENV_PATH%" >> "%LOG%" 2>&1
+)
 if errorlevel 1 goto :uv_venv_fail
 if not exist "%HP_UV_ENV_PATH%\Scripts\python.exe" goto :uv_venv_fail
 set "HP_ENV_MODE=uv"

--- a/tests/selfapps_contract_uv.ps1
+++ b/tests/selfapps_contract_uv.ps1
@@ -96,4 +96,70 @@ if ($lane -eq 'contract-uv-fail') {
         details = $assertions
         lane    = $lane
     })
+
+    # self.contract.uv.pyver: assert that REQ-004 Python version (from runtime.txt) is
+    # forwarded to uv venv via --python X.Y when PYSPEC is set.
+    # Runs a dedicated minimal bootstrap with runtime.txt pre-created so PYSPEC is set
+    # on the first run and the version forwarding log line is observable.
+    $uvBin = Join-Path $envsmoke '~uv_bin\uv.exe'
+    $uvBinExists = Test-Path -LiteralPath $uvBin
+    $runtimeVersionForPyver = ''
+    if ($runtimeValid -and $runtimeContent -match '^python-([0-9]+\.[0-9]+)') {
+        $runtimeVersionForPyver = $Matches[1]
+    }
+
+    $pyverPass = $false
+    $pyverDetails = [ordered]@{}
+
+    if (-not $uvBinExists) {
+        $pyverPass = $true
+        $pyverDetails = [ordered]@{ skip=$true; reason='uv-not-acquired'; uvBin=$uvBin }
+    } elseif (-not $runtimeVersionForPyver) {
+        $pyverPass = $true
+        $pyverDetails = [ordered]@{ skip=$true; reason='no-runtime-version'; runtimeExists=$runtimeExists; runtimeValid=$runtimeValid }
+    } else {
+        $pyverTest = Join-Path $here '~uv_pyver_test'
+        New-Item -ItemType Directory -Force -Path $pyverTest | Out-Null
+        Copy-Item -LiteralPath (Join-Path $repo 'run_setup.bat') -Destination $pyverTest -Force
+        Set-Content -LiteralPath (Join-Path $pyverTest 'app.py') -Value "print('pyver-test-ok')" -NoNewline
+        Set-Content -LiteralPath (Join-Path $pyverTest 'runtime.txt') -Value "python-$runtimeVersionForPyver" -NoNewline
+        $pyverSetupLog = Join-Path $pyverTest '~setup.log'
+        $prevPvwUv = [Environment]::GetEnvironmentVariable('PVW_UV_EXE')
+        $env:PVW_UV_EXE = $uvBin
+        $pyverExit = -1
+        Push-Location -LiteralPath $pyverTest
+        try {
+            cmd /c .\run_setup.bat *> '~pyver_bootstrap.log'
+            $pyverExit = $LASTEXITCODE
+        } finally {
+            if ($null -eq $prevPvwUv) {
+                Remove-Item Env:PVW_UV_EXE -ErrorAction SilentlyContinue
+            } else {
+                $env:PVW_UV_EXE = $prevPvwUv
+            }
+            Pop-Location
+        }
+        $pyverLog = if (Test-Path -LiteralPath $pyverSetupLog) {
+            Get-Content -LiteralPath $pyverSetupLog -Raw -ErrorAction SilentlyContinue
+        } else { '' }
+        # Match the exact log line emitted by run_setup.bat when --python is forwarded.
+        $expectedLogLine = "[INFO] uv: creating venv at .uv_env with Python $runtimeVersionForPyver"
+        $versionForwarded = ($pyverLog -match [regex]::Escape($expectedLogLine))
+        $pyverPass = [bool]$versionForwarded
+        $pyverDetails = [ordered]@{
+            runtimeVersion   = $runtimeVersionForPyver
+            exitCode         = $pyverExit
+            versionForwarded = $versionForwarded
+            expectedLogLine  = $expectedLogLine
+        }
+    }
+
+    Write-NdjsonRow ([ordered]@{
+        id      = 'self.contract.uv.pyver'
+        req     = 'REQ-004'
+        pass    = [bool]$pyverPass
+        desc    = 'uv venv --python X.Y forwarded from runtime.txt (PYSPEC REQ-004 Tiers 1-2)'
+        details = $pyverDetails
+        lane    = $lane
+    })
 }


### PR DESCRIPTION
## Summary

- **`run_setup.bat`**: When `PYSPEC` is set (from runtime.txt Tier 1 or pyproject.toml Tier 2), the detected Python version is now extracted via inline PowerShell regex and forwarded to `uv venv --python X.Y`. Handles all PYSPEC forms: `python=X.Y`, `python==X.Y`, `python>=X.Y`, `python>X.Y`. Log line: `[INFO] uv: creating venv at .uv_env with Python X.Y`. Uses `[Console]::Write()` to avoid the trailing CR that `Write-Output` emits into `for /f` variable capture.
- **`tests/selfapps_contract_uv.ps1`**: Added `self.contract.uv.pyver` NDJSON row (REQ-004) to the contract-uv happy-path lane. Reads the Python version from the envsmoke-written runtime.txt, runs a minimal bootstrap with `PVW_UV_EXE` pointing at the cached uv binary, and asserts the version-forwarding log line. Gracefully skips if uv binary or runtime version are unavailable.
- **`.github/workflows/batch-check.yml`**: Added artifact upload paths for `tests/~uv_pyver_test/` logs.
- **`CLAUDE.md`**: Added `self.contract.uv.pyver` to NDJSON surface table; closed backlog entry.

## CI verification

Run `26091242349-1` (on the feature commit) — all gated lanes green:
- `real`: rows=75 pass=75 fail=0
- `conda-full`: rows=75 pass=75 fail=0
- `contract-uv`: `self.contract.uv.pyver` pass=true, `versionForwarded=true`, Python 3.13

## Test plan

- [x] `self.contract.uv.pyver` NDJSON row passes on contract-uv lane
- [x] `versionForwarded=true` confirmed in artifact details
- [x] `exitCode=0` for the pyver bootstrap run
- [x] Delimiter check clean (`python tools/check_delimiters.py run_setup.bat`)
- [x] No false positives — skip logic fires correctly when uv binary absent
- [x] `python>=X.Y` form tested adversarially (regex prioritizes `==` before `=` to avoid partial match)

https://claude.ai/code/session_01B4oxYrcS1oia5MWAyD5fRN

---
_Generated by [Claude Code](https://claude.ai/code/session_01B4oxYrcS1oia5MWAyD5fRN)_