### PR TITLE
docs: add REQ-013 through REQ-016 and REQ-020 to README; sync CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -240,10 +240,16 @@ CI-artifacts NDJSON (from selfapps tests, conda-full lane):
 
 ```
 self.harness.started, self.bootstrap.state, self.empty_repo.msg,
-self.env.smoke.conda, self.env.smoke.run, self.exe.build, self.exe.run,
+self.empty_repo.no_spurious_warn,
+self.env.smoke.conda, self.env.smoke.run, self.env.smoke.uv,
+self.exe.build, self.exe.run,
+self.exe.smokerun.xfail, self.exe.smokerun.exedata.xfail, self.exe.smokerun.exedyn.xfail,
 self.fastpath,
+self.entry.results, self.entry.spaced-path,
 reqspec.translate.{gte,eq,compat,gt,neq,lte}, reqspec.conda.dryrun,
 reqspec.conda.channelpin, reqspec.conda.dryrun.failcase,
+reqspec.conda.channelpin.req006, reqspec.conda.dryrun.req006,
+reqspec.gte.explicit,
 reqspec.install.import, reqspec.ingest.translate,
 reqspec.ingest.conda.dryrun, reqspec.ingest.install.import,
 self.depcheck.install, self.depcheck.skip,
@@ -255,9 +261,20 @@ self.parse_warn.table.v6, self.parse_warn.pytest,
 self.heuristics.pytest,
 self.runtime.writeback,
 self.pandas.openpyxl.install, self.pandas.openpyxl.import,
-pyvisa.detect, pyvisa.nivisa.branch,
+pandas_excel.translate, pandas_excel.conda.install, pandas_excel.conda.install.req006,
+pandas_excel.runtime,
+pyvisa.detect, pyvisa.nivisa.branch, pyvisa.nivisa.outcome,
 pyproject.precedence.detect, pyproject.precedence.writeback,
-pyproject.dep.detect
+pyproject.dep.detect,
+self.prime.bootstrap, self.prime.run, self.prime.spaced-path,
+self.prime.exe.build, self.prime.exe.run,
+self.ux.connectivity.offline.n, self.ux.connectivity.prompt.shown,
+self.ux.connectivity.offline.uv.skip, self.ux.connectivity.offline.conda.skip,
+self.ux.system.gate.n, self.ux.system.gate.prompt, self.ux.system.gate.real,
+self.ux.gitignore.merge, self.ux.gitignore.preserve, self.ux.gitignore.idem,
+self.ux.gitattributes.merge, self.ux.gitattributes.idem,
+self.ux.postflight,
+self.venv.fallback
 ```
 
 justme-test lane rows (subset, flag-triggered):
@@ -325,6 +342,12 @@ self.corrupt.uv.detect
 selfapps-ux-hardening NDJSON rows (selfapps_ux_hardening.ps1, non-conda-full lanes):
 
 ```
+self.ux.gitignore.merge, self.ux.gitignore.preserve, self.ux.gitignore.idem,
+self.ux.gitattributes.merge, self.ux.gitattributes.idem,
+self.ux.postflight,
+self.ux.connectivity.offline.n, self.ux.connectivity.prompt.shown,
+self.ux.connectivity.offline.uv.skip, self.ux.connectivity.offline.conda.skip,
+self.ux.system.gate.n, self.ux.system.gate.prompt, self.ux.system.gate.real,
 self.venv.fallback
 ```
 
@@ -350,6 +373,7 @@ Test files and what they cover:
 | `test_ps_colon_scan.py` | PowerShell scoped variable detection ($var:) |
 | `test_check_delimiters_import.py` | Delimiter checker import guard |
 | `test_heuristics.py` | Heuristic dep-augmentation rules (REQ-005: all 6 rules, kill-switch, idempotency) |
+| `test_parse_warn.py` | PyInstaller warn-file translation table (REQ-007: 5.x and 6.x formats, all TRANSLATIONS entries) |
 | `test_publish_index_regex.py` | Regex patterns in diagnostics publisher |
 | `test_sanitize_iterate_payload.py` | NDJSON redaction and deduplication |
 

--- a/README.md
+++ b/README.md
@@ -318,6 +318,73 @@ At completion:
 
 ---
 
+## [REQ-013] Internet Connectivity Guard
+
+- When a primary download fails (Miniconda or uv), the bootstrapper checks internet reachability before cascading to a fallback URL.
+  - First, ICMP ping to 8.8.8.8 (fast path).
+  - If ICMP is blocked, fall back to a lightweight HTTPS probe.
+  - If both fail: prompt the user to confirm offline mode or retry.
+- In offline mode, internet-dependent steps (uv download, Miniconda download) are skipped.
+  - If the user already has a cached Miniconda or uv install, those are used as-is.
+- Log contract:
+  - `[INFO] REQ-013: Connectivity check: internet reachable. Cascading to fallback.`
+  - `[INFO] REQ-013: Connectivity check: internet reachable via HTTPS (ICMP blocked). Cascading to fallback.`
+  - `[WARN] REQ-013: Connectivity check: no internet detected (ICMP and HTTPS check failed).`
+  - `[INFO] REQ-013: Offline mode: skipping uv download.`
+  - `[INFO] REQ-013: Offline mode: skipping Miniconda download.`
+- CI test flag: `HP_TEST_OFFLINE=1` simulates ping failure for branch coverage.
+
+---
+
+## [REQ-014] System Python Consent Gate
+
+- Before using system Python as the last-resort execution provider (REQ-009 Tier 4), the bootstrapper must obtain explicit user consent.
+- Without consent, the bootstrapper aborts rather than silently running under an unmanaged system Python.
+- Log contract:
+  - `[INFO] REQ-014: System Python fallback aborted: consent not granted.`
+  - `[INFO] REQ-014: System Python consent: user accepted.`
+  - `[INFO] REQ-014: System Python consent: user declined.`
+- CI test flag: `HP_TEST_FORCE_CONSENT_CHECK=1` directly triggers the consent gate for branch coverage.
+
+---
+
+## [REQ-015] Idempotent Git Config Merge
+
+- At bootstrap time, the bootstrapper appends standard `.gitignore` and `.gitattributes` entries to the working directory.
+- Uses a sentinel comment line to detect existing entries; never duplicates content already present.
+- `.gitignore` additions: tilde-prefix work files (`~*`), env directories (`.venv/`, `.uv/`, `.*_env/`, `.cache/`, `.conda/`), build artifacts (`dist/`, `build/`).
+- `.gitattributes` additions: `*.bat eol=crlf`, `*.cmd eol=crlf`, `*.exe binary`.
+- Silent if no changes needed; logs when appending.
+- Log contract:
+  - `[INFO] REQ-015: Appending standard ignores to .gitignore.`
+  - `[INFO] REQ-015: Appending standard attributes to .gitattributes.`
+
+---
+
+## [REQ-016] Post-flight Briefing
+
+- After a successful full EXE build, the bootstrapper prints a scannable summary panel identifying the output EXE, files to keep, and files safe to delete.
+- The terminal window is **retained** on both success and error so the user can read the output before it closes.
+- Log contract:
+  - `[INFO] REQ-016: Post-flight briefing printed.`
+
+---
+
+## [REQ-020] Cache Corruption Hardening
+
+- On startup, if a previously downloaded conda or uv binary is found, the bootstrapper validates it with a health check before use.
+- Corrupt conda binary: runs `conda.bat info`; on failure, halts with a user-friendly error message and offers to self-heal (re-download Miniconda). If the user declines, exits with code 2.
+- Corrupt uv binary: detected at startup by a version probe; the cached binary is evicted so the next run downloads a fresh copy. Bootstrap continues via conda.
+- Log contract:
+  - `[ERROR] Corrupt conda binary detected at: <path>` (real corruption)
+  - `[WARN] Cached uv.exe failed health check; clearing and re-downloading.` (real uv corruption)
+  - `[INFO] Self-healing: corrupt conda evicted from <path>.` (user accepts self-heal)
+  - `[ERROR] Corrupt conda env; user declined rebuild.` (user declines)
+- CI test flags: `HP_TEST_CORRUPT_CONDA=1`, `HP_TEST_CORRUPT_UV=1`, `HP_TEST_HEAL_ANSWER=N`.
+- Test NDJSON rows: `self.corrupt.conda.detect`, `self.corrupt.conda.heal.decline`, `self.corrupt.uv.detect` (in `tests/selftest.ps1`).
+
+---
+
 ## Maintenance, Logging, and Lessons Learned
 
 - Update conda base periodically (~30 days), but **skip on first Miniconda install**. Ensure base is configured to conda-forge before updating to avoid prompts.

--- a/tests/selftest.ps1
+++ b/tests/selftest.ps1
@@ -585,6 +585,7 @@ $corruptLines = if (Test-Path $corruptLogPath) { Get-Content -LiteralPath $corru
 $corruptMsgFound = ($corruptLines | Where-Object { $_ -like '*Corrupt conda binary*' }).Count -gt 0
 Write-NdjsonRow ([ordered]@{
   id      = 'self.corrupt.conda.detect'
+  req     = 'REQ-020'
   pass    = ($corruptExit -eq 2 -and $corruptMsgFound)
   desc    = 'HP_TEST_CORRUPT_CONDA=1: bootstrap detects corruption, logs error, exits 2'
   details = [ordered]@{ exitCode = $corruptExit; msgFound = $corruptMsgFound }
@@ -620,6 +621,7 @@ $healLines = if (Test-Path $healLogPath) { Get-Content -LiteralPath $healLogPath
 $healDeclineMsgFound = ($healLines | Where-Object { $_ -like '*declined*' }).Count -gt 0
 Write-NdjsonRow ([ordered]@{
   id      = 'self.corrupt.conda.heal.decline'
+  req     = 'REQ-020'
   pass    = ($healExit -eq 2 -and $healDeclineMsgFound)
   desc    = 'HP_TEST_HEAL_ANSWER=N: user declines self-heal, bootstrap logs declined and exits 2'
   details = [ordered]@{ exitCode = $healExit; declineMsgFound = $healDeclineMsgFound }
@@ -633,6 +635,7 @@ if ($healExit -eq 2 -and $healDeclineMsgFound) { $summary.Add('Heal decline: PAS
 if ($env:HP_FORCE_CONDA_ONLY -eq '1') {
   Write-NdjsonRow ([ordered]@{
     id      = 'self.corrupt.uv.detect'
+    req     = 'REQ-020'
     pass    = $true
     desc    = 'HP_TEST_CORRUPT_UV: uv eviction test skipped in conda-only lane'
     details = [ordered]@{ skipped = $true; reason = 'HP_FORCE_CONDA_ONLY=1' }
@@ -665,6 +668,7 @@ if ($env:HP_FORCE_CONDA_ONLY -eq '1') {
   $uvEvictMsgFound = ($uvLines | Where-Object { $_ -like '*HP_TEST_CORRUPT_UV*' }).Count -gt 0
   Write-NdjsonRow ([ordered]@{
     id      = 'self.corrupt.uv.detect'
+    req     = 'REQ-020'
     pass    = $uvEvictMsgFound
     desc    = 'HP_TEST_CORRUPT_UV=1: bootstrap evicts cached uv binary and logs warning'
     details = [ordered]@{ exitCode = $uvTestExit; evictMsgFound = $uvEvictMsgFound }


### PR DESCRIPTION
## Summary

- **README.md**: Add formal requirement entries for REQ-013 (internet connectivity guard), REQ-014 (system Python consent gate), REQ-015 (idempotent git config merge), REQ-016 (post-flight briefing), and REQ-020 (cache corruption hardening). All five were fully implemented and CI-tested but had no spec entry in the authoritative requirements document. Each entry includes the behavior description, accurate log contract, and CI test flag references.
- **CLAUDE.md**: Expand the NDJSON surface from ~35 outdated rows to all 75 actual rows emitted by the conda-full lane (adds self.prime.*, self.ux.*, self.entry.*, self.env.smoke.uv, extra reqspec/pandas_excel/pyvisa rows); expand the selfapps-ux-hardening row list from 1 entry to all 14; add test_parse_warn.py to the Python unit test table (was missing).
- **tests/selftest.ps1**: Add `req='REQ-020'` to the three `self.corrupt.*` NDJSON rows so req_coverage.py can track REQ-020 coverage end-to-end.

## Test plan

- [x] CI green: run 26175216416-1, 75 pass / 0 fail (conda-full lane), 1 pass / 0 fail (cache lane)
- [x] self.corrupt.conda.detect, self.corrupt.conda.heal.decline, self.corrupt.uv.detect all pass with req=REQ-020
- [x] python -m compileall, pyflakes, check_delimiters.py all clean
- [x] test_parse_warn.py: 40 passed locally

https://claude.ai/code/session_01SumJkTUDQvwzrnBkm6Lskx

---
_Generated by [Claude Code](https://claude.ai/code/session_01SumJkTUDQvwzrnBkm6Lskx)_