### PR TITLE
fix: add .uv_env to HP_FAST_CHECK infra exclusion; fix [/\\] separator for Windows paths

### DIFF
--- a/run_setup.bat
+++ b/run_setup.bat
@@ -1925,14 +1925,14 @@ set "HP_PRINT_PYVER=aW1wb3J0IHN5cwoKcHJpbnQoZiJweXRob24te3N5cy52ZXJzaW9uX2luZm9b
 rem HP_FAST_CHECK decoded content:
 rem $exe = $args[0]
 rem if (-not $exe) { $exe = $env:HP_FAST_EXE }
-rem $infraPattern = '(?i)(^|[\/])(\.git|\.github|dist|\.venv|__pycache__|\.conda)([\/]|$)'
+rem $infraPattern = '(?i)(^|[/\\])(\.git|\.github|dist|\.venv|\.uv_env|__pycache__|\.conda)([/\\]|$)'
 rem $sources = Get-ChildItem -Recurse -File -Filter '*.py' | Where-Object { $_.FullName -notmatch $infraPattern -and $_.Name -notlike '~*.py' }
 rem if (-not $sources) { exit 1 }
 rem $latest = ($sources | Sort-Object -Property LastWriteTimeUtc -Descending | Select-Object -First 1).LastWriteTimeUtc
 rem $exeTime = (Get-Item -LiteralPath $exe).LastWriteTimeUtc
 rem if ($exeTime -ge $latest) { 'fresh' }
 rem If HP_FAST_CHECK changes, update this decoded comment block to match the base64 payload.
-set "HP_FAST_CHECK=JGV4ZSA9ICRhcmdzWzBdCmlmICgtbm90ICRleGUpIHsgJGV4ZSA9ICRlbnY6SFBfRkFTVF9FWEUgfQokaW5mcmFQYXR0ZXJuID0gJyg/aSkoXnxbXC9dKShcLmdpdHxcLmdpdGh1YnxkaXN0fFwudmVudnxfX3B5Y2FjaGVfX3xcLmNvbmRhKShbXC9dfCQpJwokc291cmNlcyA9IEdldC1DaGlsZEl0ZW0gLVJlY3Vyc2UgLUZpbGUgLUZpbHRlciAnKi5weScgfCBXaGVyZS1PYmplY3QgeyAkXy5GdWxsTmFtZSAtbm90bWF0Y2ggJGluZnJhUGF0dGVybiAtYW5kICRfLk5hbWUgLW5vdGxpa2UgJ34qLnB5JyB9CmlmICgtbm90ICRzb3VyY2VzKSB7IGV4aXQgMSB9CiRsYXRlc3QgPSAoJHNvdXJjZXMgfCBTb3J0LU9iamVjdCAtUHJvcGVydHkgTGFzdFdyaXRlVGltZVV0YyAtRGVzY2VuZGluZyB8IFNlbGVjdC1PYmplY3QgLUZpcnN0IDEpLkxhc3RXcml0ZVRpbWVVdGMKJGV4ZVRpbWUgPSAoR2V0LUl0ZW0gLUxpdGVyYWxQYXRoICRleGUpLkxhc3RXcml0ZVRpbWVVdGMKaWYgKCRleGVUaW1lIC1nZSAkbGF0ZXN0KSB7ICdmcmVzaCcgfQo="
+set "HP_FAST_CHECK=JGV4ZSA9ICRhcmdzWzBdCmlmICgtbm90ICRleGUpIHsgJGV4ZSA9ICRlbnY6SFBfRkFTVF9FWEUgfQokaW5mcmFQYXR0ZXJuID0gJyg/aSkoXnxbL1xcXSkoXC5naXR8XC5naXRodWJ8ZGlzdHxcLnZlbnZ8XC51dl9lbnZ8X19weWNhY2hlX198XC5jb25kYSkoWy9cXF18JCknCiRzb3VyY2VzID0gR2V0LUNoaWxkSXRlbSAtUmVjdXJzZSAtRmlsZSAtRmlsdGVyICcqLnB5JyB8IFdoZXJlLU9iamVjdCB7ICRfLkZ1bGxOYW1lIC1ub3RtYXRjaCAkaW5mcmFQYXR0ZXJuIC1hbmQgJF8uTmFtZSAtbm90bGlrZSAnfioucHknIH0KaWYgKC1ub3QgJHNvdXJjZXMpIHsgZXhpdCAxIH0KJGxhdGVzdCA9ICgkc291cmNlcyB8IFNvcnQtT2JqZWN0IC1Qcm9wZXJ0eSBMYXN0V3JpdGVUaW1lVXRjIC1EZXNjZW5kaW5nIHwgU2VsZWN0LU9iamVjdCAtRmlyc3QgMSkuTGFzdFdyaXRlVGltZVV0YwokZXhlVGltZSA9IChHZXQtSXRlbSAtTGl0ZXJhbFBhdGggJGV4ZSkuTGFzdFdyaXRlVGltZVV0YwppZiAoJGV4ZVRpbWUgLWdlICRsYXRlc3QpIHsgJ2ZyZXNoJyB9Cg=="
 :: --- Embedded helper: HP_PREP_REQUIREMENTS (~prep_requirements.py) ---
 :: Purpose:
 ::   - Normalize pip/conda specifiers from requirements.txt

--- a/tests/test_fast_check_pattern.py
+++ b/tests/test_fast_check_pattern.py
@@ -1,0 +1,185 @@
+"""
+Tests for the HP_FAST_CHECK embedded payload (fast-path EXE freshness check).
+
+The PowerShell script is base64-encoded inside run_setup.bat.  These tests
+extract the $infraPattern regex and verify it correctly classifies paths so
+the EXE fast path only fires when the user's own .py files are unchanged.
+
+Coverage goal: every directory name in the exclusion list has a test; every
+directory that must NOT be excluded has a test; and adversarial names that
+share a prefix with an excluded name (e.g. "distribute" ~ "dist") are verified
+to be included.  Both forward-slash and backslash path separators are tested
+because Windows paths use backslashes and the .NET regex engine (PowerShell)
+treats backslash-slash as forward-slash only -- the pattern must use [/\\\\] for correctness.
+"""
+import base64
+import pathlib
+import re
+import unittest
+
+_BAT = pathlib.Path(__file__).parent.parent / "run_setup.bat"
+
+
+def _extract_infra_pattern() -> str:
+    for line in _BAT.read_text(encoding="utf-8", errors="replace").splitlines():
+        stripped = line.strip()
+        if stripped.startswith('set "HP_FAST_CHECK='):
+            # split at first = only; the base64 payload may contain = padding
+            b64 = stripped.split("=", 1)[1].rstrip('"')
+            ps = base64.b64decode(b64).decode("utf-8")
+            m = re.search(r"\$infraPattern\s*=\s*'([^']+)'", ps)
+            if m:
+                return m.group(1)
+    raise ValueError("HP_FAST_CHECK or $infraPattern not found in run_setup.bat")
+
+
+_PATTERN = _extract_infra_pattern()
+_RX = re.compile(_PATTERN)
+
+# Paths whose .py files must be EXCLUDED (matched by the regex).
+# Includes both forward-slash (/)) and backslash (\\) variants because
+# Windows uses backslashes and the regex must handle both.
+_EXCLUDED = [
+    # .git
+    "C:/app/.git/hooks/pre-commit.py",
+    r"C:\app\.git\hooks\pre-commit.py",
+    ".git/config.py",
+    # .github
+    "C:/app/.github/scripts/check.py",
+    r"C:\app\.github\scripts\check.py",
+    # dist (PyInstaller output)
+    "C:/app/dist/myapp/myapp.py",
+    r"C:\app\dist\myapp\myapp.py",
+    # .venv (standard virtual environment)
+    "C:/app/.venv/site-packages/requests/__init__.py",
+    r"C:\app\.venv\Lib\site-packages\requests\__init__.py",
+    # .uv_env (UV virtual environment -- REQ-009 UV provider)
+    "C:/app/.uv_env/Lib/site-packages/requests/__init__.py",
+    r"C:\app\.uv_env\Lib\site-packages\requests\__init__.py",
+    ".uv_env/site-packages/numpy/core/_multiarray_umath.py",
+    # __pycache__
+    "C:/app/__pycache__/main.cpython-311.pyc.py",
+    r"C:\app\__pycache__\util.cpython-311.py",
+    "src/__pycache__/helper.py",
+    # .conda (conda package cache)
+    "C:/app/.conda/pkgs/numpy/__init__.py",
+    r"C:\app\.conda\pkgs\numpy\__init__.py",
+]
+
+# Paths whose .py files must be INCLUDED (NOT matched by the regex).
+_INCLUDED = [
+    "C:/app/main.py",
+    r"C:\app\main.py",
+    "C:/app/src/app.py",
+    "C:/app/utils/helper.py",
+    "./run.py",
+    # Names that share a prefix with an excluded component but differ
+    "C:/app/distribute/lib.py",       # 'dist' prefix but not a path component
+    "C:/app/distribution/utils.py",
+    "C:/app/vendor/condautils/pkg.py",  # 'conda' inside word, not a .conda dir
+    "C:/app/githubtools/api.py",       # 'github' prefix, no leading dot
+    "C:/app/venv_wrapper/proxy.py",    # 'venv' prefix, not '.venv'
+    "C:/app/src/uv_helpers.py",        # 'uv_' in filename, not a dir
+]
+
+
+class InfraPatternExcludedTest(unittest.TestCase):
+    def test_git_dir_excluded(self) -> None:
+        for path in _EXCLUDED:
+            if ".git" in path and ".github" not in path:
+                self.assertIsNotNone(_RX.search(path), f"Expected excluded: {path!r}")
+
+    def test_github_dir_excluded(self) -> None:
+        for path in _EXCLUDED:
+            if ".github" in path:
+                self.assertIsNotNone(_RX.search(path), f"Expected excluded: {path!r}")
+
+    def test_dist_dir_excluded(self) -> None:
+        for path in _EXCLUDED:
+            if "/dist/" in path or "\\dist\\" in path:
+                self.assertIsNotNone(_RX.search(path), f"Expected excluded: {path!r}")
+
+    def test_venv_dir_excluded(self) -> None:
+        for path in _EXCLUDED:
+            if ".venv" in path:
+                self.assertIsNotNone(_RX.search(path), f"Expected excluded: {path!r}")
+
+    def test_uv_env_dir_excluded(self) -> None:
+        for path in _EXCLUDED:
+            if ".uv_env" in path:
+                self.assertIsNotNone(_RX.search(path), f"Expected excluded: {path!r}")
+
+    def test_pycache_dir_excluded(self) -> None:
+        for path in _EXCLUDED:
+            if "__pycache__" in path:
+                self.assertIsNotNone(_RX.search(path), f"Expected excluded: {path!r}")
+
+    def test_conda_dir_excluded(self) -> None:
+        for path in _EXCLUDED:
+            if ".conda" in path:
+                self.assertIsNotNone(_RX.search(path), f"Expected excluded: {path!r}")
+
+    def test_backslash_paths_excluded(self) -> None:
+        backslash_paths = [p for p in _EXCLUDED if "\\" in p]
+        self.assertTrue(backslash_paths, "No backslash test paths in _EXCLUDED list")
+        for path in backslash_paths:
+            self.assertIsNotNone(
+                _RX.search(path),
+                f"Backslash path expected to be excluded: {path!r}",
+            )
+
+
+class InfraPatternIncludedTest(unittest.TestCase):
+    def test_source_paths_included(self) -> None:
+        for path in _INCLUDED:
+            self.assertIsNone(_RX.search(path), f"Expected included (not excluded): {path!r}")
+
+    def test_distribute_not_falsely_excluded(self) -> None:
+        self.assertIsNone(_RX.search("C:/app/distribute/lib.py"))
+        self.assertIsNone(_RX.search("C:/app/distribution/utils.py"))
+
+    def test_githubtools_not_falsely_excluded(self) -> None:
+        self.assertIsNone(_RX.search("C:/app/githubtools/api.py"))
+
+    def test_venv_prefix_not_falsely_excluded(self) -> None:
+        self.assertIsNone(_RX.search("C:/app/venv_wrapper/proxy.py"))
+
+    def test_uv_env_in_filename_not_excluded(self) -> None:
+        self.assertIsNone(_RX.search("C:/app/src/uv_helpers.py"))
+
+
+class InfraPatternPayloadSyncTest(unittest.TestCase):
+    def test_uv_env_present_in_pattern(self) -> None:
+        self.assertIn(
+            r"\.uv_env",
+            _PATTERN,
+            "REQ-009 UV provider creates .uv_env/; it must be in the exclusion list",
+        )
+
+    def test_venv_present_in_pattern(self) -> None:
+        self.assertIn(r"\.venv", _PATTERN)
+
+    def test_conda_present_in_pattern(self) -> None:
+        self.assertIn(r"\.conda", _PATTERN)
+
+    def test_git_present_in_pattern(self) -> None:
+        self.assertIn(r"\.git", _PATTERN)
+
+    def test_dist_present_in_pattern(self) -> None:
+        self.assertIn("dist", _PATTERN)
+
+    def test_pycache_present_in_pattern(self) -> None:
+        self.assertIn("__pycache__", _PATTERN)
+
+    def test_pattern_uses_dual_separator(self) -> None:
+        # backslash-slash [\/] only matches forward slash in both Python and .NET regex.
+        # The pattern must use [/\\] to also match Windows backslash paths.
+        self.assertNotIn(
+            r"[\/]",
+            _PATTERN,
+            r"Pattern must use [/\\] not [\/]; the latter only matches '/' in .NET regex",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- **Bug fix**: `HP_FAST_CHECK` `$infraPattern` used `[\/]` as a path separator, which in .NET regex (PowerShell) only matches forward-slash `/`. Windows paths use backslash `\`, so the EXE freshness check was silently broken for backslash paths. Fixed to `[/\\]` which correctly matches both separators.
- **Bug fix**: `.uv_env/` (the UV virtual environment directory created by the REQ-009 UV provider) was missing from the infra exclusion list. Without it, `pip`-installed `.py` files inside `.uv_env/` would cause the fast path to rebuild the EXE unnecessarily.
- **New test**: `tests/test_fast_check_pattern.py` — 20 unit tests that decode the `HP_FAST_CHECK` base64 payload from `run_setup.bat`, extract `$infraPattern`, and verify correct classification of paths. Covers all excluded directories, adversarial prefix names (`distribute`, `githubtools`, `venv_wrapper`, `uv_helpers.py`), and both slash and backslash variants. Also asserts `[\/]` is absent (must use `[/\\]`).

## Test plan

- [ ] `self.pytest.unit` passes in CI with 128 tests (up from prior baseline) — confirmed in run `26648973700-1` (128 passed, 2 skipped)
- [ ] `self.fastpath` passes — EXE fast path still works end-to-end in conda-full lane
- [ ] All gating lanes (real, conda-full) pass — confirmed STATUS.txt = "completed / success"
- [ ] No regression in other test categories across all lanes

https://claude.ai/code/session_01MYFxEnx7vmmhseP8TVqH6y

---
_Generated by [Claude Code](https://claude.ai/code/session_01MYFxEnx7vmmhseP8TVqH6y)_