### PR TITLE
test: cover REQ-002 priority-0 manual %1 override beats auto-detection (self.entry.override)

### DIFF
--- a/.github/workflows/batch-check.yml
+++ b/.github/workflows/batch-check.yml
@@ -1244,6 +1244,12 @@ jobs:
             tests\~selftest_venv_fallback\~bootstrap.status.json
             tests/~selftest_venv_fallback/~run.out.txt
             tests\~selftest_venv_fallback\~run.out.txt
+            tests/~selftest_entry_override/~override.log
+            tests\~selftest_entry_override\~override.log
+            tests/~selftest_entry_override/~setup.log
+            tests\~selftest_entry_override\~setup.log
+            tests/~selftest_entry_override/~run.out.txt
+            tests\~selftest_entry_override\~run.out.txt
             tests/~entry_cli/~entry_cli_bootstrap.log
             tests\~entry_cli\~entry_cli_bootstrap.log
             tests/~entry_cli/~setup.log

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -319,7 +319,7 @@ self.ux.system.gate.n, self.ux.system.gate.prompt, self.ux.system.gate.real,
 self.ux.gitignore.merge, self.ux.gitignore.preserve, self.ux.gitignore.idem,
 self.ux.gitattributes.merge, self.ux.gitattributes.idem,
 self.ux.postflight,
-self.venv.fallback
+self.venv.fallback, self.entry.override
 ```
 
 justme-test lane rows (subset, flag-triggered):
@@ -405,7 +405,7 @@ self.ux.connectivity.offline.n, self.ux.connectivity.prompt.shown,
 self.ux.connectivity.offline.uv.skip, self.ux.connectivity.offline.conda.skip,
 self.ux.connectivity.online, self.ux.connectivity.retry,
 self.ux.system.gate.n, self.ux.system.gate.prompt, self.ux.system.gate.real,
-self.venv.fallback
+self.venv.fallback, self.entry.override
 ```
 
 ---

--- a/tests/selfapps_ux_hardening.ps1
+++ b/tests/selfapps_ux_hardening.ps1
@@ -62,6 +62,13 @@ if (-not $IsWindows) {
             details = $skipDetails
         })
     }
+    Write-NdjsonRow ([ordered]@{
+        id      = 'self.entry.override'
+        req     = 'REQ-002'
+        pass    = $true
+        desc    = 'REQ-002 priority-0 override test skipped on non-Windows host'
+        details = $skipDetails
+    })
     exit 0
 }
 
@@ -538,6 +545,89 @@ if ($env:HP_FORCE_CONDA_ONLY -eq '1') {
     })
 }
 
-$allPass = $giMerged -and $giPreserved -and $giIdem -and ($gaMerged -and $gaBatCrlf) -and $gaIdem -and $pfFound -and ($connPromptFound -and $connOfflineLog) -and $connPromptFound -and $uvOfflinePass -and $condaOfflinePass -and $connReachableFound -and $connRetryFound -and ($sysPromptFound -and $sysDeclineLog) -and $sysPromptFound -and $sysRealPass -and $venvFbPass
+# ===== REQ-002 priority 0: manual %1 override beats auto-detection (main.py) =====
+# REQ-002 ranks a co-located %1 argument (drag-and-drop) above every auto-detected name:
+# it is used directly and skips all auto-detection. Prior tests only cover auto-detection
+# ordering (entryA-D) and REQ-011 same-dir with a SOLE file -- none prove the override
+# WINS over a higher-priority name. The :ci_skip_entry path (HP_CI_SKIP_ENV=1) ignores %1,
+# so this needs the real (non-skip) determine_entry. Reuse the proven forced-venv pattern
+# (cheaper than conda; gated by real/uv lanes): stage main.py (would win auto-detection by
+# name = priority 1) plus zzz_override.py, pass ".\zzz_override.py" as %1, and assert the
+# override is chosen and run -- not main.py. Skipped in conda-full where HP_FORCE_CONDA_ONLY
+# blocks the venv fallback (same as the venv/sysgate-real tests above).
+$entryOvDir = Join-Path $here '~selftest_entry_override'
+if (Test-Path $entryOvDir) { Remove-Item -Recurse -Force $entryOvDir }
+New-Item -ItemType Directory -Force -Path $entryOvDir | Out-Null
+Copy-Item -LiteralPath (Join-Path $repo 'run_setup.bat') -Destination $entryOvDir -Force
+Set-Content -LiteralPath (Join-Path $entryOvDir 'main.py') -Value 'print("from-main")' -Encoding Ascii
+Set-Content -LiteralPath (Join-Path $entryOvDir 'zzz_override.py') -Value 'print("from-override")' -Encoding Ascii
+
+$entryOvPass = $true
+if ($env:HP_FORCE_CONDA_ONLY -eq '1') {
+    Write-NdjsonRow ([ordered]@{
+        id      = 'self.entry.override'
+        req     = 'REQ-002'
+        pass    = $true
+        desc    = 'REQ-002 priority 0: manual %1 override beats auto-detection'
+        details = [ordered]@{ skip = $true; reason = 'HP_FORCE_CONDA_ONLY-prohibits-venv-fallback' }
+    })
+} else {
+    $savedCondaFailOv = $env:HP_TEST_FORCE_CONDA_FAIL
+    $savedOfflineOv   = $env:HP_OFFLINE_MODE
+    $savedSkipPROv    = $env:HP_SKIP_PIPREQS
+    $savedLaneOv      = $env:HP_CI_LANE
+    $env:HP_TEST_FORCE_CONDA_FAIL = '1'
+    $env:HP_OFFLINE_MODE          = '1'
+    $env:HP_SKIP_PIPREQS          = '1'
+    $env:HP_CI_LANE               = 'test'
+    Push-Location -LiteralPath $entryOvDir
+    try {
+        cmd /c "run_setup.bat .\zzz_override.py > ~override.log 2>&1"
+        $entryOvExit = $LASTEXITCODE
+    } finally {
+        Pop-Location
+    }
+    $env:HP_TEST_FORCE_CONDA_FAIL = $savedCondaFailOv
+    $env:HP_OFFLINE_MODE          = $savedOfflineOv
+    $env:HP_SKIP_PIPREQS          = $savedSkipPROv
+    $env:HP_CI_LANE               = $savedLaneOv
+
+    $entryOvBootText = ''
+    $entryOvBootLog = Join-Path $entryOvDir '~override.log'
+    if (Test-Path -LiteralPath $entryOvBootLog) {
+        $entryOvBootText = Get-Content -LiteralPath $entryOvBootLog -Raw -Encoding Ascii
+    }
+    $entryOvSetupText = ''
+    $entryOvSetupLog = Join-Path $entryOvDir '~setup.log'
+    if (Test-Path -LiteralPath $entryOvSetupLog) {
+        $entryOvSetupText = Get-Content -LiteralPath $entryOvSetupLog -Raw -Encoding Ascii
+    }
+    $entryOvRunText = ''
+    $entryOvRunOut = Join-Path $entryOvDir '~run.out.txt'
+    if (Test-Path -LiteralPath $entryOvRunOut) {
+        $entryOvRunText = Get-Content -LiteralPath $entryOvRunOut -Raw -Encoding Ascii
+    }
+    # Priority-0 branch fired (drag message) and the chosen entry is the override, not main.py.
+    $entryOvDragMsg  = ($entryOvBootText -match [regex]::Escape('Using drag-and-drop file:')) -and ($entryOvBootText -match [regex]::Escape('zzz_override.py'))
+    $entryOvSelected = ($entryOvSetupText -match [regex]::Escape('[BOOT] REQ-002: Entry selected:')) -and ($entryOvSetupText -match [regex]::Escape('zzz_override.py'))
+    $entryOvRanOverride = ($entryOvRunText -match [regex]::Escape('from-override'))
+    $entryOvNotMain  = -not ($entryOvRunText -match [regex]::Escape('from-main'))
+    $entryOvPass = ($entryOvDragMsg -and $entryOvSelected -and $entryOvRanOverride -and $entryOvNotMain)
+    Write-NdjsonRow ([ordered]@{
+        id      = 'self.entry.override'
+        req     = 'REQ-002'
+        pass    = $entryOvPass
+        desc    = 'REQ-002 priority 0: co-located %1 override is chosen and run over main.py'
+        details = [ordered]@{
+            dragMsgFound  = $entryOvDragMsg
+            entrySelected = $entryOvSelected
+            ranOverride   = $entryOvRanOverride
+            notMain       = $entryOvNotMain
+            exit          = $entryOvExit
+        }
+    })
+}
+
+$allPass = $giMerged -and $giPreserved -and $giIdem -and ($gaMerged -and $gaBatCrlf) -and $gaIdem -and $pfFound -and ($connPromptFound -and $connOfflineLog) -and $connPromptFound -and $uvOfflinePass -and $condaOfflinePass -and $connReachableFound -and $connRetryFound -and ($sysPromptFound -and $sysDeclineLog) -and $sysPromptFound -and $sysRealPass -and $venvFbPass -and $entryOvPass
 if (-not $allPass) { exit 1 }
 exit 0


### PR DESCRIPTION
## Summary

Adds one missing test (per the AGENTS.md branch-coverage policy and the one-change-per-loop iteration contract) for **REQ-002 priority 0** — the highest entry-selection rank, which had no behavioral coverage proving it *wins*.

REQ-002 ranks a co-located `%1` argument (drag-and-drop) above every auto-detected name: it is used directly and **skips all auto-detection**. Existing tests only cover auto-detection ordering (`entryA`–`entryD`) and REQ-011 same-dir with a *sole* file — none prove the override beats a higher-priority name like `main.py`. The `:ci_skip_entry` path (`HP_CI_SKIP_ENV=1`, used by the entry harnesses) **ignores `%1` entirely**, so this branch can only be exercised on the real (non-skip) `:determine_entry`, whose drag early-exit (`set HP_ENTRY=%~1`; skip the `~find_entry.py` helper) implements priority 0.

## Change

New NDJSON row `self.entry.override` in `tests/selfapps_ux_hardening.ps1`, reusing the proven forced-venv pattern from `self.venv.fallback` (cheaper than conda; gated by the `real`/`uv` lanes, skipped in conda-full where `HP_FORCE_CONDA_ONLY` blocks the venv fallback):
- Stage `main.py` (would win auto-detection by name = priority 1) plus `zzz_override.py`.
- Run `run_setup.bat .\zzz_override.py` with `HP_TEST_FORCE_CONDA_FAIL=1` + `HP_OFFLINE_MODE=1` + `HP_SKIP_PIPREQS=1`.
- Assert the override is chosen and run, **not** `main.py`: the drag-branch message, `[BOOT] REQ-002: Entry selected: .\zzz_override.py`, and `~run.out.txt` containing `from-override` but **not** `from-main`.

Also wires the new `~override.log`/`~setup.log`/`~run.out.txt` artifacts into the `test-logs` upload (both slash variants) and records the new row in `CLAUDE.md`'s NDJSON surface.

## Verification (run 27042898147-1)

- All 10 jobs green, including the gating `real` and `conda-full` lanes.
- `self.entry.override` row `pass=true` with `dragMsgFound=true, entrySelected=true, ranOverride=true, notMain=true` in real, uv, contract-uv, justme-test (skip row in conda-full per `HP_FORCE_CONDA_ONLY`; absent only in the informational cache lane).
- Diag log confirms: `[INFO] venv fallback ready: ...\.venv\Scripts\python.exe` → `[BOOT] REQ-002: Entry selected: .\zzz_override.py` (the override, not main.py).

## Side discovery (not fixed here — proposed backlog item)

The drag-and-drop console message prints an **empty filename**: `*** Using drag-and-drop file: ` (no name). This is a pre-existing parse-time-expansion quirk in `run_setup.bat` `:determine_entry` — within the parenthesized `if exist "%~1" (...)` block, `%MAIN_FILE%` is expanded before `set "MAIN_FILE=%~1"` runs. The override still functions correctly (it is honored on the second `:determine_entry` call at `:after_env_bootstrap`, by which point `MAIN_FILE` is populated), so this is cosmetic. Worth a follow-up loop to either use a sub-call or delayed-expansion-scoped emit. Not fixed here to keep this change atomic.

## Local sanity checks

- `python -m compileall -q .` clean, `python -m pyflakes .` clean
- `pwsh tools/ps-compileall.ps1` → Syntax OK (28 files); AST parse of modified script OK
- `yamllint` clean; `actionlint` clean (only the pre-existing `include-hidden-files` advisory)
- `check_delimiters.py` on the modified `.ps1` clean

https://claude.ai/code/session_01X4ZPhgUv9CEqJ7jSMvBM9G

---
_Generated by [Claude Code](https://claude.ai/code/session_01X4ZPhgUv9CEqJ7jSMvBM9G)_