### PR TITLE
fix: drag-and-drop message and HP_ENTRY empty on first :determine_entry call (REQ-002)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -526,6 +526,13 @@ Items deferred to future loops:
 
 Items completed and shipped:
 
+- **Drag-and-drop message empty filename**: `:determine_entry` printed
+  `*** Using drag-and-drop file: ` with no name (and set `HP_ENTRY` empty on the first
+  call) because `%MAIN_FILE%` was expanded at parse time inside the parenthesized
+  `if exist "%~1" (...)` block, before `set "MAIN_FILE=%~1"` ran. Fixed by using the `%~1`
+  parameter directly for both `HP_ENTRY` and the message. Guarded by the tightened
+  `self.entry.override` assertion (drag line must include the filename). CLOSED by this PR.
+
 - **Warn-file driven missing-import install**: after PyInstaller build, read the warn file,
   extract flagged missing modules, apply the import-to-conda translation table, install via
   conda, and rebuild once. Supersedes the earlier runtime retry-loop design. CLOSED by

--- a/run_setup.bat
+++ b/run_setup.bat
@@ -1574,10 +1574,13 @@ if not "%~1"=="" (
     exit /b 11
   )
   if exist "%~1" (
-    set "MAIN_FILE=%~1"
-    set "HP_ENTRY=%MAIN_FILE%"
+    rem derived requirement: use the %~1 parameter directly, not %MAIN_FILE%. Inside this
+    rem parenthesized block %MAIN_FILE% expands at parse time (before "set MAIN_FILE" runs),
+    rem which yielded an empty HP_ENTRY and an empty "Using drag-and-drop file:" message.
+    rem %~1 is the call parameter and expands to the argument value, so both are correct.
+    set "HP_ENTRY=%~1"
     if not defined HP_DRAG_MSG_EMITTED (
-      echo *** Using drag-and-drop file: %MAIN_FILE%
+      echo *** Using drag-and-drop file: %~1
       set "HP_DRAG_MSG_EMITTED=1"
     )
     exit /b 0

--- a/tests/selfapps_ux_hardening.ps1
+++ b/tests/selfapps_ux_hardening.ps1
@@ -607,8 +607,10 @@ if ($env:HP_FORCE_CONDA_ONLY -eq '1') {
     if (Test-Path -LiteralPath $entryOvRunOut) {
         $entryOvRunText = Get-Content -LiteralPath $entryOvRunOut -Raw -Encoding Ascii
     }
-    # Priority-0 branch fired (drag message) and the chosen entry is the override, not main.py.
-    $entryOvDragMsg  = ($entryOvBootText -match [regex]::Escape('Using drag-and-drop file:')) -and ($entryOvBootText -match [regex]::Escape('zzz_override.py'))
+    # Priority-0 branch fired and the drag message now prints the filename (regression guard
+    # for the parse-time-expansion fix in :determine_entry, which previously printed an empty
+    # name). Also confirm the chosen entry is the override, not main.py.
+    $entryOvDragMsg  = ($entryOvBootText -match [regex]::Escape('Using drag-and-drop file: .\zzz_override.py'))
     $entryOvSelected = ($entryOvSetupText -match [regex]::Escape('[BOOT] REQ-002: Entry selected:')) -and ($entryOvSetupText -match [regex]::Escape('zzz_override.py'))
     $entryOvRanOverride = ($entryOvRunText -match [regex]::Escape('from-override'))
     $entryOvNotMain  = -not ($entryOvRunText -match [regex]::Escape('from-main'))


### PR DESCRIPTION
## Summary

Fixes a parse-time-expansion bug in `run_setup.bat` `:determine_entry` (discovered while writing the `self.entry.override` test in #264).

`:determine_entry` printed `*** Using drag-and-drop file: ` with **no filename**, and set `HP_ENTRY` to **empty** on its first call, because `%MAIN_FILE%` was expanded at parse time inside the parenthesized `if exist "%~1" (...)` block — *before* `set "MAIN_FILE=%~1"` executed:

```bat
if exist "%~1" (
    set "MAIN_FILE=%~1"
    set "HP_ENTRY=%MAIN_FILE%"          rem %MAIN_FILE% empty at parse time
    ...
    echo *** Using drag-and-drop file: %MAIN_FILE%   rem empty
)
```

The drag override still ultimately worked because `:determine_entry` is also called a second time at `:after_env_bootstrap` (by which point `MAIN_FILE` was populated), but:
- the console message stayed empty (cosmetic), and
- the **PEP 723 detection** at the post-entry check (line ~644) was skipped for dragged files on the first pass, since `HP_ENTRY` was empty there.

## Fix

Use the `%~1` parameter directly (correctly bound at call time) for both `HP_ENTRY` and the message, and drop the now-redundant `MAIN_FILE` assignment. This makes `HP_ENTRY` correct after the first call (so PEP 723 detection works for dragged files) and the message print the real filename.

## Test

Tightened the `self.entry.override` assertion to require the filename on the drag line itself (`Using drag-and-drop file: .\zzz_override.py`) — previously it matched the substring across two separate log lines, so it would not have caught the empty-filename regression. This now guards the fix.

## Verification (run 27048733459-1)

- All 10 jobs green, including the gating `real` and `conda-full` lanes.
- `self.entry.override` row `pass=true` with `dragMsgFound=true` (stricter), `entrySelected=true`, `ranOverride=true`, `notMain=true` in real and uv.
- Diag log now shows: `*** Using drag-and-drop file: .\zzz_override.py` (filename present).

## Local sanity checks

- `python tools/check_delimiters.py run_setup.bat` clean (batch edit)
- `python -m compileall -q .` clean, `python -m pyflakes .` clean
- `pwsh tools/ps-compileall.ps1` → Syntax OK (28 files); AST parse of modified test OK
- `check_delimiters.py` on the modified `.ps1` clean

https://claude.ai/code/session_01X4ZPhgUv9CEqJ7jSMvBM9G

---
_Generated by [Claude Code](https://claude.ai/code/session_01X4ZPhgUv9CEqJ7jSMvBM9G)_