### PR TITLE
test: verify REQ-016 post-flight panel content (EXE + keep + delete), not just the log line

### DIFF
--- a/tests/selfapps_ux_hardening.ps1
+++ b/tests/selfapps_ux_hardening.ps1
@@ -185,13 +185,33 @@ if (-not (Test-Path -LiteralPath $envsmokeLog)) {
     })
 } else {
     $envsmokeText = Get-Content -LiteralPath $envsmokeLog -Raw -Encoding Ascii
-    $pfFound = $envsmokeText -match [regex]::Escape($postflightSig)
+    $pfLogLine = $envsmokeText -match [regex]::Escape($postflightSig)
+    # REQ-016 requires the panel to identify the output EXE, files to keep, and files safe to
+    # delete -- not merely that a "printed" log line fired. The panel is echoed to stdout
+    # (captured in ~envsmoke_bootstrap.log), not ~setup.log, so verify its content there.
+    $pfDetails = [ordered]@{ logLineFound = $pfLogLine }
+    $pfContent = $true
+    $envsmokeBootLog = Join-Path $envsmokeDir '~envsmoke_bootstrap.log'
+    if (Test-Path -LiteralPath $envsmokeBootLog) {
+        $bootText = Get-Content -LiteralPath $envsmokeBootLog -Raw -Encoding Ascii
+        $pfExe    = $bootText -match [regex]::Escape('Your standalone application is ready:')
+        $pfKeep   = $bootText -match [regex]::Escape('KEEP these files')
+        $pfDelete = $bootText -match [regex]::Escape('SAFE TO DELETE')
+        $pfContent = ($pfExe -and $pfKeep -and $pfDelete)
+        $pfDetails.exeSectionFound    = $pfExe
+        $pfDetails.keepSectionFound   = $pfKeep
+        $pfDetails.deleteSectionFound = $pfDelete
+    } else {
+        # Defensive: never false-fail if the stdout capture is absent; fall back to the log line.
+        $pfDetails.bootLogMissing = $true
+    }
+    $pfFound = ($pfLogLine -and $pfContent)
     Write-NdjsonRow ([ordered]@{
         id      = 'self.ux.postflight'
         req     = 'REQ-016'
         pass    = $pfFound
-        desc    = 'Post-flight briefing log line in envsmoke setup log'
-        details = [ordered]@{ sigFound = $pfFound }
+        desc    = 'Post-flight briefing: log line plus panel content (EXE + keep + delete sections)'
+        details = $pfDetails
     })
 }
 


### PR DESCRIPTION
## Summary

Strengthens the REQ-016 post-flight briefing test. `self.ux.postflight` previously asserted only the `[INFO] REQ-016: Post-flight briefing printed.` log line — so the panel could lose the sections REQ-016 mandates ("identify the output EXE, files to keep, and files safe to delete") without any test noticing. The panel is echoed to stdout (captured in `~envsmoke_bootstrap.log`), not `~setup.log`, so its content was previously unverified.

## Change

Tighten the existing `self.ux.postflight` assertion to also verify, in the captured envsmoke bootstrap stdout, the three panel sections:
- `Your standalone application is ready:` (the output-EXE identification),
- `KEEP these files` (files to keep),
- `SAFE TO DELETE` (files safe to delete).

Falls back to the log-line-only check if the stdout capture is absent, so it never false-fails on a missing artifact. These lines are all emitted together with the log line in `:print_postflight_briefing`, so the stricter check passes exactly when the panel is intact. No new artifact (the bootstrap log is already uploaded) and no new NDJSON row — the existing row is strengthened.

## Verification (run 27064129870-1)

- All 10 jobs green, including gating `real` and `conda-full`.
- `self.ux.postflight` row `pass=true` with `logLineFound=true, exeSectionFound=true, keepSectionFound=true, deleteSectionFound=true` in real and conda-full (the lanes that run the envsmoke EXE build; the row skips where envsmoke didn't run, unchanged).

## Local sanity checks

- `python tools/check_delimiters.py tests/selfapps_ux_hardening.ps1` clean
- `pwsh tools/ps-compileall.ps1` → Syntax OK (28 files); AST parse OK
- `python -m compileall -q .` clean

https://claude.ai/code/session_01X4ZPhgUv9CEqJ7jSMvBM9G

---
_Generated by [Claude Code](https://claude.ai/code/session_01X4ZPhgUv9CEqJ7jSMvBM9G)_