### PR TITLE
diag: classify NI-VISA installer failure (download method, size, PE validity)

### DIFF
--- a/run_setup.bat
+++ b/run_setup.bat
@@ -1060,8 +1060,10 @@ if not errorlevel 1 (
   goto visa_done
 )
 set "NIVISA_INSTALLER=~ni-visa-runtime.exe"
+set "HP_VISA_DLVIA=curl"
 curl -L --silent --fail -o "%NIVISA_INSTALLER%" "https://download.ni.com/support/nipkg/products/ni-v/ni-visa/21.5/online/ni-visa_21.5_online.exe" 2>> "%LOG%"
 if errorlevel 1 (
+  set "HP_VISA_DLVIA=powershell"
   rem derived requirement: curl can leave a partial file on failure; delete before fallback
   rem so PowerShell does not find a corrupt file and skip its own download attempt.
   if exist "%NIVISA_INSTALLER%" del "%NIVISA_INSTALLER%" >nul 2>&1
@@ -1071,6 +1073,18 @@ if not exist "%NIVISA_INSTALLER%" (
   call :log "[VISA] install_failed (download)"
   goto visa_done
 )
+rem REQ-008 diagnostic: record the downloaded installer's provenance, size, and PE validity so a
+rem non-zero installer exit code can be classified (blocked/redirected payload vs a real installer
+rem that refused unattended install). These are read-only probes -- they never touch the install.
+call :log "[VISA] download method: %HP_VISA_DLVIA%"
+set "HP_VISA_DLSIZE=0"
+for %%S in ("%NIVISA_INSTALLER%") do set "HP_VISA_DLSIZE=%%~zS"
+call :log "[VISA] installer file size: %HP_VISA_DLSIZE% bytes"
+powershell -NoProfile -Command "try { $fs=[System.IO.File]::OpenRead('%NIVISA_INSTALLER%'); $a=$fs.ReadByte(); $b=$fs.ReadByte(); $fs.Close(); if ($a -eq 77 -and $b -eq 90) { 'PE_OK' } else { 'NOT_PE' } } catch { 'PROBE_ERR' }" > "~visa_pe.txt" 2>nul
+set "HP_VISA_PE="
+if exist "~visa_pe.txt" for /f "usebackq delims=" %%P in ("~visa_pe.txt") do set "HP_VISA_PE=%%P"
+if exist "~visa_pe.txt" del "~visa_pe.txt" >nul 2>&1
+call :log "[VISA] installer PE check: %HP_VISA_PE%"
 start /wait "" "%NIVISA_INSTALLER%" --quiet --accept-eulas --prevent-reboot --prevent-activation
 set "HP_VISA_INSTALLER_RC=%ERRORLEVEL%"
 rem derived requirement: capture the installer exit code so diagnostics can tell a hard failure

--- a/tests/selfapps_pyvisa.ps1
+++ b/tests/selfapps_pyvisa.ps1
@@ -108,6 +108,14 @@ $nisaReasonPass = ($installerRcMatch.Success) `
     -or ($log -match '\[VISA\] skipped')
 $nisaReasonDetails = [ordered]@{ exitCode = $exitCode; reasonFound = $nisaReasonPass }
 if ($installerRcMatch.Success) { $nisaReasonDetails.installerRc = $installerRcMatch.Groups[1].Value }
+# REQ-008 diagnostic: surface download provenance so a non-zero installer rc is classifiable
+# (e.g. tiny size + NOT_PE => blocked/redirected payload; valid PE + rc!=0 => unattended refusal).
+$dlViaMatch  = [regex]::Match($log, '\[VISA\] download method:\s*(\S+)')
+$dlSizeMatch = [regex]::Match($log, '\[VISA\] installer file size:\s*(\d+)\s*bytes')
+$peMatch     = [regex]::Match($log, '\[VISA\] installer PE check:\s*(\S+)')
+if ($dlViaMatch.Success)  { $nisaReasonDetails.downloadVia  = $dlViaMatch.Groups[1].Value }
+if ($dlSizeMatch.Success) { $nisaReasonDetails.installerSize = $dlSizeMatch.Groups[1].Value }
+if ($peMatch.Success)     { $nisaReasonDetails.peCheck       = $peMatch.Groups[1].Value }
 Write-NdjsonRow ([ordered]@{
     id      = 'pyvisa.nivisa.reason'
     req     = 'REQ-008'


### PR DESCRIPTION
## Summary

Diagnostic loop following up on the `-125083` NI-VISA installer exit code observed in #269's CI. Classifies *what kind* of failure it is, before running the installer:

- `run_setup.bat`: log the NI-VISA installer's **download method** (curl vs PowerShell fallback), **byte size**, and **PE validity** (MZ header check) before `start /wait`. Read-only probes — they never touch the install.
- `tests/selfapps_pyvisa.ps1`: surface `downloadVia` / `installerSize` / `peCheck` in the existing `pyvisa.nivisa.reason` NDJSON details.

## Why

#269 proved the prior `install_failed (post_check)` was masking a hard, near-instant failure (`rc=-125083`, failed in <1s), not a slow install. This loop classifies the root cause so it's legible on the diag site:
- tiny size + `NOT_PE` ⇒ blocked/redirected download (junk payload)
- valid PE + `rc!=0` ⇒ a real installer that refused unattended/online install on the runner (environmental)

Either way it confirms **no real-install lane is warranted** — there's no slow-but-succeeding install to wait out.

## Test plan

- [x] `python tools/check_delimiters.py run_setup.bat` — no issues (parens/braces in the PE-probe PowerShell line balanced)
- [x] PowerShell AST parse of `tests/selfapps_pyvisa.ps1` — OK
- [x] `compileall` / `pyflakes` clean
- [x] Probes are read-only and gated behind the existing download-success guard (skipped if `install_failed (download)`)
- [ ] CI green; diag site shows `peCheck`/`installerSize`/`downloadVia` for the conda-full pyvisa run (will verify)

https://claude.ai/code/session_01X4ZPhgUv9CEqJ7jSMvBM9G

---
_Generated by [Claude Code](https://claude.ai/code/session_01X4ZPhgUv9CEqJ7jSMvBM9G)_