### PR TITLE
test: drive real bootstrap for pip gap-fill coverage (regression guard)

### DIFF
--- a/.github/workflows/batch-check.yml
+++ b/.github/workflows/batch-check.yml
@@ -1106,6 +1106,12 @@ jobs:
             tests\~pandas_excel\~pandas_excel.log
             tests/~pipgap/~pipgap.log
             tests\~pipgap\~pipgap.log
+            tests/~pipgap/~pipgap_bootstrap.log
+            tests\~pipgap\~pipgap_bootstrap.log
+            tests/~pipgap/~setup.log
+            tests\~pipgap\~setup.log
+            tests/~pipgap/~run.out.txt
+            tests\~pipgap\~run.out.txt
             tests/~selftest_parse_warn_table/
             tests\~selftest_parse_warn_table\
             tests/~selftest_runtime_writeback/~runtime_writeback_bootstrap.log

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ tests/
   selfapps_single.ps1          Single Python file bootstrap test
   selfapps_reqspec.ps1         Requirements specifier parsing tests (~= compatible release)
   selfapps_pandas_excel.ps1    Pandas/openpyxl heuristic tests
-  selfapps_pipgap.ps1          pip gap-fill safety net (conda misses opencv-python; pip fills it)
+  selfapps_pipgap.ps1          pip gap-fill safety net (runs run_setup.bat: conda misses opencv-python, pip fills it)
   selfapps_isolation.ps1       REQ-010/REQ-011 behavioral tests (unconditional, HP_CI_SKIP_ENV=1)
   dynamic_tests.py             Python-side entry detection and version precedence tests
   test_*.py                    Python unit tests (14 files, see Testing section)

--- a/tests/selfapps_pipgap.ps1
+++ b/tests/selfapps_pipgap.ps1
@@ -1,51 +1,31 @@
-# REQ-005: pip gap-fill safety net -- a requirement that conda-forge cannot supply under the
-# pipreqs-produced name (opencv-python, for `import cv2`) must be installed by the pip gap-fill
-# step (`pip install -r requirements.txt`) that run_setup.bat runs after conda. This mirrors the
-# documented cv2/opencv name-mismatch limitation: conda misses it, pip catches it.
+# REQ-005: pip gap-fill safety net -- EXERCISED THROUGH THE REAL BOOTSTRAP.
+#
+# This test runs run_setup.bat (the product code) end-to-end on an app whose only requirement
+# is opencv-python -- a package pipreqs emits for `import cv2` but which conda-forge cannot supply
+# under that name (the cv2/opencv remap lives only in the warnfix path, tools/parse_warn.py). So
+# the bootstrapper must: attempt the conda bulk install, fail, fall through to the per-package
+# install, fail again, then have the pip gap-fill (`pip install -r requirements.txt`) install it
+# from PyPI -- after which `import cv2` works. If anyone removes/reorders/guards-out the gap-fill
+# in run_setup.bat, pipgap.pip.fill and pipgap.import go red. That is the regression signal.
+#
+# Python is pinned to 3.12 via the PVW_TARGET_PY super-user override so an opencv-python wheel
+# always exists on PyPI (avoids bleeding-edge-Python no-wheel noise that would mask the signal).
 $ErrorActionPreference = 'Continue'
 $here = $PSScriptRoot
-$repo = Split-Path -Path $here -Parent
-$nd = Join-Path $here '~test-results.ndjson'
-$ciNd = Join-Path $repo 'ci_test_results.ndjson'
-if (-not (Test-Path -LiteralPath $nd)) { New-Item -ItemType File -Path $nd -Force | Out-Null }
+if (-not $here) { $here = Split-Path -Parent $MyInvocation.MyCommand.Path }
+$repoRoot = Split-Path -Path $here -Parent
+$nd   = Join-Path -Path $here -ChildPath '~test-results.ndjson'
+$ciNd = Join-Path -Path $repoRoot -ChildPath 'ci_test_results.ndjson'
+if (-not (Test-Path -LiteralPath $nd))   { New-Item -ItemType File -Path $nd   -Force | Out-Null }
 if (-not (Test-Path -LiteralPath $ciNd)) { New-Item -ItemType File -Path $ciNd -Force | Out-Null }
 
 function Write-NdjsonRow {
     param([hashtable]$Row)
-
     $lane = [Environment]::GetEnvironmentVariable('HP_CI_LANE')
     if ($lane -and -not $Row.ContainsKey('lane')) { $Row['lane'] = $lane }
     $json = $Row | ConvertTo-Json -Compress -Depth 8
-    Add-Content -LiteralPath $nd -Value $json -Encoding Ascii
+    Add-Content -LiteralPath $nd   -Value $json -Encoding Ascii
     Add-Content -LiteralPath $ciNd -Value $json -Encoding Ascii
-}
-
-function Get-CondaBatPath {
-    $publicRoot = [Environment]::GetEnvironmentVariable('PUBLIC')
-    $publicRootClean = if ($publicRoot) { $publicRoot.Trim().Trim('"') } else { '' }
-    $condaBatCandidates = @()
-    if ($publicRootClean) {
-        $condaBatCandidates += Join-Path $publicRootClean 'Documents\Miniconda3\condabin\conda.bat'
-        $condaBatCandidates += Join-Path $publicRootClean 'Documents\Miniconda3\Scripts\conda.bat'
-    }
-    $condaBatCandidates += 'C:\Miniconda3\condabin\conda.bat'
-    $condaBatCandidates += 'C:\Miniconda3\Scripts\conda.bat'
-    $condaBatCandidates += 'C:\ProgramData\Miniconda3\condabin\conda.bat'
-    $condaBatCandidates += 'C:\ProgramData\Miniconda3\Scripts\conda.bat'
-    $condaBatCandidates += 'C:\Users\Public\Documents\Miniconda3\condabin\conda.bat'
-    $condaBatCandidates += 'C:\Users\Public\Documents\Miniconda3\Scripts\conda.bat'
-
-    $condaBat = $condaBatCandidates | Where-Object { Test-Path -LiteralPath $_ } | Select-Object -First 1
-    if (-not $condaBat) {
-        $whereResult = where.exe conda 2>$null
-        if ($whereResult) { $condaBat = ($whereResult -split "`r?`n")[0].Trim() }
-    }
-
-    return [ordered]@{
-        path = $condaBat
-        candidates = $condaBatCandidates
-        publicRoot = if ($publicRoot) { $publicRoot } else { '(empty)' }
-    }
 }
 
 if (-not $IsWindows) {
@@ -56,73 +36,88 @@ if (-not $IsWindows) {
     exit 0
 }
 
-$work = Join-Path $here '~pipgap'
-$logPath = Join-Path $work '~pipgap.log'
+$work    = Join-Path -Path $here -ChildPath '~pipgap'
+$logName = '~pipgap_bootstrap.log'
+$logPath = Join-Path -Path $work -ChildPath $logName
+$setupLogPath = Join-Path -Path $work -ChildPath '~setup.log'
+$runOutPath   = Join-Path -Path $work -ChildPath '~run.out.txt'
+$installedPath = Join-Path -Path $work -ChildPath '~dependency_installed.txt'
+
+if (Test-Path -LiteralPath $work) { Remove-Item -LiteralPath $work -Recurse -Force -ErrorAction SilentlyContinue }
 New-Item -ItemType Directory -Force -Path $work | Out-Null
-if (Test-Path -LiteralPath $logPath) { Remove-Item -LiteralPath $logPath -Force -ErrorAction SilentlyContinue }
 
-$appPath = Join-Path $work 'main.py'
-$reqPath = Join-Path $work 'requirements.txt'
-# ~reqs_conda.txt is what run_setup.bat feeds conda; opencv-python is not on conda-forge under this
-# name (the cv2/opencv remap lives only in the warnfix path, tools/parse_warn.py), so conda must miss it.
-$condaReqPath = Join-Path $work '~reqs_conda.txt'
+Copy-Item -LiteralPath (Join-Path -Path $repoRoot -ChildPath 'run_setup.bat') -Destination $work -Force
 
-Set-Content -LiteralPath $appPath -Encoding Ascii -Value @'
+# main.py prints a sentinel only reachable if `import cv2` succeeds; run_setup.bat runs the entry
+# as a smoke test and captures stdout to ~run.out.txt, giving an end-to-end import proof.
+Set-Content -LiteralPath (Join-Path -Path $work -ChildPath 'main.py') -Encoding Ascii -Value @'
 import cv2
 print("PIPGAP_CV2_OK", cv2.__version__)
 '@
-Set-Content -LiteralPath $reqPath -Encoding Ascii -Value 'opencv-python'
-Set-Content -LiteralPath $condaReqPath -Encoding Ascii -Value 'opencv-python'
+Set-Content -LiteralPath (Join-Path -Path $work -ChildPath 'requirements.txt') -Value 'opencv-python' -Encoding Ascii -NoNewline
 
-$envName = '_pipgap'
-$condaMissDetails = [ordered]@{ exitCode = -1; notFound = $false; env = $envName }
-$pipFillDetails   = [ordered]@{ exitCode = -1; env = $envName }
-$importDetails    = [ordered]@{ exitCode = -1; cv2Marker = $false; viaPypi = $false }
-
-$condaInfo = Get-CondaBatPath
-$condaBat = $condaInfo.path
-if (-not $condaBat) {
-    $condaMissDetails.reason = 'conda-not-found'
-    $condaMissDetails.condaBatCandidates = $condaInfo.candidates
-    Write-NdjsonRow ([ordered]@{ id = 'pipgap.conda.miss'; req = 'REQ-005'; pass = $false; desc = 'conda cannot supply opencv-python (PackagesNotFoundError)'; details = $condaMissDetails })
-    Write-NdjsonRow ([ordered]@{ id = 'pipgap.pip.fill';   req = 'REQ-005'; pass = $false; desc = 'pip gap-fill installs opencv-python from PyPI'; details = $pipFillDetails })
-    Write-NdjsonRow ([ordered]@{ id = 'pipgap.import';      req = 'REQ-005'; pass = $false; desc = 'import cv2 succeeds after pip gap-fill'; details = $importDetails })
-    exit 0
+$exitCode = $null
+$errorMessage = $null
+# Force the conda env path and pin Python to 3.12 (PyPI opencv wheel guaranteed). conda-full
+# already sets HP_FORCE_CONDA_ONLY; set it explicitly so the test is lane-robust.
+$savedTargetPy = $env:PVW_TARGET_PY
+$savedForceConda = $env:HP_FORCE_CONDA_ONLY
+$env:PVW_TARGET_PY = 'python=3.12'
+$env:HP_FORCE_CONDA_ONLY = '1'
+try {
+    Push-Location -LiteralPath $work
+    try {
+        cmd /c .\run_setup.bat *> $logName
+        $exitCode = $LASTEXITCODE
+    } finally {
+        Pop-Location
+    }
+} catch {
+    $errorMessage = $_.Exception.Message
+} finally {
+    $env:PVW_TARGET_PY = $savedTargetPy
+    $env:HP_FORCE_CONDA_ONLY = $savedForceConda
 }
 
-# Isolated env with a pinned, wheel-supported Python so opencv-python always has a PyPI wheel
-# (avoids bleeding-edge-Python no-wheel flakiness that would muddy the gap-fill signal).
-$createOut = cmd /c "`"$condaBat`" create -y -n $envName --override-channels -c conda-forge python=3.12 pip" 2>&1
-Add-Content -LiteralPath $logPath -Value 'conda create output:' -Encoding Ascii
-Add-Content -LiteralPath $logPath -Value ($createOut | Out-String) -Encoding Ascii
+# Combine the bootstrapper's internal log (~setup.log: [INSTALL] lines + conda stderr) with the
+# captured console stream so assertions see both the call :log echoes and conda's own output.
+$setupLog = if (Test-Path -LiteralPath $setupLogPath) { Get-Content -LiteralPath $setupLogPath -Raw -Encoding Ascii } else { '' }
+$consoleLog = if (Test-Path -LiteralPath $logPath) { Get-Content -LiteralPath $logPath -Raw -Encoding Ascii } else { '' }
+$log = $setupLog + "`n" + $consoleLog
+$runOut = if (Test-Path -LiteralPath $runOutPath) { Get-Content -LiteralPath $runOutPath -Raw -Encoding Ascii } else { '' }
+$installed = if (Test-Path -LiteralPath $installedPath) { Get-Content -LiteralPath $installedPath -Raw -Encoding Ascii } else { '' }
 
-# 1) conda install from conda-forge -- expected to FAIL: opencv-python is not a conda-forge package name
-$installOut = cmd /c "`"$condaBat`" install -y -n $envName --override-channels -c conda-forge --file `"$condaReqPath`"" 2>&1
-$condaMissDetails.exitCode = $LASTEXITCODE
-$installStr = ($installOut | Out-String)
-Add-Content -LiteralPath $logPath -Value 'conda install output (expected miss):' -Encoding Ascii
-Add-Content -LiteralPath $logPath -Value $installStr -Encoding Ascii
-$condaMissDetails.notFound = ($installStr -match 'PackagesNotFoundError') -or ($installStr -match 'Nothing provides') -or ($installStr -match 'not available from')
-$condaMissPass = ($condaMissDetails.exitCode -ne 0) -and [bool]$condaMissDetails.notFound
+# 1) conda product path genuinely misses opencv-python: bulk attempted -> per-pkg fallback fired
+#    -> conda reports it is not available from conda-forge.
+$bulkAttempted   = ($log -match [regex]::Escape('[INSTALL] conda bulk from ~reqs_conda.txt'))
+$perpkgFallback  = ($log -match [regex]::Escape('[INSTALL] conda per-pkg fallback'))
+$condaNotFound   = ($log -match 'PackagesNotFoundError') -or ($log -match 'not available from current channels') -or ($log -match 'Nothing provides')
+$condaMissPass   = $bulkAttempted -and $perpkgFallback -and $condaNotFound
+Write-NdjsonRow ([ordered]@{
+    id = 'pipgap.conda.miss'; req = 'REQ-005'; pass = $condaMissPass
+    desc = 'run_setup.bat conda bulk+per-pkg both miss opencv-python (PackagesNotFoundError)'
+    details = [ordered]@{ exitCode = $exitCode; bulkAttempted = $bulkAttempted; perpkgFallback = $perpkgFallback; condaNotFound = $condaNotFound; error = $errorMessage }
+})
 
-# 2) pip gap-fill -- mirrors run_setup.bat's `python -m pip install -r requirements.txt`; should SUCCEED via PyPI
-$pipOut = cmd /c "`"$condaBat`" run -n $envName python -m pip install -r `"$reqPath`"" 2>&1
-$pipFillDetails.exitCode = $LASTEXITCODE
-Add-Content -LiteralPath $logPath -Value 'pip gap-fill output:' -Encoding Ascii
-Add-Content -LiteralPath $logPath -Value ($pipOut | Out-String) -Encoding Ascii
-$pipFillPass = ($pipFillDetails.exitCode -eq 0)
+# 2) pip gap-fill in run_setup.bat ran and succeeded -> opencv-python landed in the env (pip freeze).
+$gapFillRan    = ($log -match [regex]::Escape('[INSTALL] pip gap fill from requirements.txt'))
+$gapFillFailed = ($log -match [regex]::Escape('pip install -r requirements.txt failed'))
+$installedOpencv = ($installed -match '(?im)^opencv-python\b')
+$pipFillPass   = $gapFillRan -and (-not $gapFillFailed) -and $installedOpencv
+Write-NdjsonRow ([ordered]@{
+    id = 'pipgap.pip.fill'; req = 'REQ-005'; pass = $pipFillPass
+    desc = 'run_setup.bat pip gap-fill installs opencv-python from PyPI after conda misses it'
+    details = [ordered]@{ exitCode = $exitCode; gapFillRan = $gapFillRan; gapFillFailed = $gapFillFailed; installedOpencv = [bool]$installedOpencv }
+})
 
-# 3) import cv2 now works -- pip supplied what conda could not
-$importOut = cmd /c "`"$condaBat`" run -n $envName python `"$appPath`"" 2>&1
-$importDetails.exitCode = $LASTEXITCODE
-$importStr = ($importOut | Out-String)
-Add-Content -LiteralPath $logPath -Value 'runtime output:' -Encoding Ascii
-Add-Content -LiteralPath $logPath -Value $importStr -Encoding Ascii
-$importDetails.cv2Marker = ($importStr -match 'PIPGAP_CV2_OK')
-$listOut = cmd /c "`"$condaBat`" list -n $envName" 2>&1
-$importDetails.viaPypi = (($listOut | Out-String) -match '(?m)^opencv-python\s.*pypi')
-$importPass = ($importDetails.exitCode -eq 0) -and [bool]$importDetails.cv2Marker
+# 3) End-to-end: the bootstrapped env can `import cv2` (entry smoke stdout carries the sentinel).
+$importPass = ($runOut -match 'PIPGAP_CV2_OK')
+Write-NdjsonRow ([ordered]@{
+    id = 'pipgap.import'; req = 'REQ-005'; pass = $importPass
+    desc = 'import cv2 succeeds in the bootstrapped env (entry smoke prints sentinel)'
+    details = [ordered]@{ exitCode = $exitCode; sentinelFound = $importPass; runOutLen = $runOut.Length }
+})
 
-Write-NdjsonRow ([ordered]@{ id = 'pipgap.conda.miss'; req = 'REQ-005'; pass = $condaMissPass; desc = 'conda cannot supply opencv-python (PackagesNotFoundError)'; details = $condaMissDetails })
-Write-NdjsonRow ([ordered]@{ id = 'pipgap.pip.fill';   req = 'REQ-005'; pass = $pipFillPass;   desc = 'pip gap-fill installs opencv-python from PyPI'; details = $pipFillDetails })
-Write-NdjsonRow ([ordered]@{ id = 'pipgap.import';      req = 'REQ-005'; pass = $importPass;    desc = 'import cv2 succeeds after pip gap-fill'; details = $importDetails })
+if (-not $condaMissPass) { Write-Host '[pipgap] conda did not miss opencv-python as expected' }
+if (-not $pipFillPass)   { Write-Host '[pipgap] pip gap-fill did not install opencv-python' }
+if (-not $importPass)    { Write-Host '[pipgap] import cv2 sentinel not found in entry smoke output' }


### PR DESCRIPTION
## Why

Follow-up to #272. That test reimplemented the conda→pip sequence *inside the test script*, so it never executed `run_setup.bat`. It proved "pip gap-fill works in principle" but would **not** have failed CI if someone broke the gap-fill *in the product code* (deleted/reordered/guarded-out the `pip install -r requirements.txt` at `run_setup.bat:953-954`). That's the wrong end of the value chain for a regression guard — exactly the gap called out in review.

## What changed

`tests/selfapps_pipgap.ps1` now runs **`run_setup.bat` end-to-end** (modeled on `selfapps_pyvisa.ps1`) on an `opencv-python` app, so the real product path is exercised and feeds in at the latest stage — tripping the actual conda bulk failure → per-package failure → pip gap-fill:

| Row | Backed by real product execution |
|-----|-----------------------------------|
| `pipgap.conda.miss` | `[INSTALL] conda bulk from ~reqs_conda.txt` attempted → `[INSTALL] conda per-pkg fallback` fires → `PackagesNotFoundError` in `~setup.log` |
| `pipgap.pip.fill` | `[INSTALL] pip gap fill from requirements.txt` runs, no failure WARN, `opencv-python` present in `~dependency_installed.txt` (pip freeze) |
| `pipgap.import` | entry smoke stdout (`~run.out.txt`) carries the `PIPGAP_CV2_OK` sentinel → `import cv2` works in the bootstrapped env |

Now a regression in the product gap-fill turns CI red: kill the gap-fill line and `pipgap.pip.fill` + `pipgap.import` fail.

## Engineering notes

- **Python pinned to 3.12** via the `PVW_TARGET_PY` super-user override (`run_setup.bat:421`) so a PyPI opencv wheel always exists — avoids bleeding-edge-Python (3.14) no-wheel noise that would mask the real signal.
- **`HP_FORCE_CONDA_ONLY=1`** set explicitly (and restored) for lane robustness; conda-full already sets it.
- Conda genuinely can't supply `opencv-python` (cv2→opencv remap is warnfix-only, `tools/parse_warn.py`), so the miss is real and doubles as a guard for that documented limitation.
- Adds `~pipgap_bootstrap.log` / `~setup.log` / `~run.out.txt` artifact uploads for diagnosis.

## Test plan

- [x] PowerShell AST parse — OK
- [x] `check_delimiters.py` — clean
- [x] Workflow YAML parses
- [x] Verified product log lines (`run_setup.bat:944/947/953`) and that `:conda_bulk_install` propagates the failure errorlevel so the per-pkg fallback fires
- [x] Verified entry smoke writes stdout to `~run.out.txt` (`run_setup.bat:1743`)
- [ ] CI green on conda-full; diag shows `pipgap.*` rows pass (will verify)

https://claude.ai/code/session_01X4ZPhgUv9CEqJ7jSMvBM9G

---
_Generated by [Claude Code](https://claude.ai/code/session_01X4ZPhgUv9CEqJ7jSMvBM9G)_