### PR TITLE
test: add self.corrupt.conda.heal.accept for REQ-020 accept branch coverage

### DIFF
--- a/.github/workflows/batch-check.yml
+++ b/.github/workflows/batch-check.yml
@@ -1238,6 +1238,14 @@ jobs:
             tests\~selftest_heal_decline\~pipreqs.diff.txt
             tests/~selftest_heal_decline/~bootstrap.status.json
             tests\~selftest_heal_decline\~bootstrap.status.json
+            tests/~selftest_heal_accept/~heal_accept_bootstrap.log
+            tests\~selftest_heal_accept\~heal_accept_bootstrap.log
+            tests/~selftest_heal_accept/~setup.log
+            tests\~selftest_heal_accept\~setup.log
+            tests/~selftest_heal_accept/~pipreqs.diff.txt
+            tests\~selftest_heal_accept\~pipreqs.diff.txt
+            tests/~selftest_heal_accept/~bootstrap.status.json
+            tests\~selftest_heal_accept\~bootstrap.status.json
             tests/~selftest_corrupt_uv/~corrupt_uv_bootstrap.log
             tests\~selftest_corrupt_uv\~corrupt_uv_bootstrap.log
             tests/~selftest_corrupt_uv/~setup.log

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -394,6 +394,7 @@ self.guardrail.g1, self.guardrail.g2, self.guardrail.g3,
 self.pep723.valid, self.pep723.malformed, self.pep723.pyproject.override,
 self.corrupt.conda.detect,
 self.corrupt.conda.heal.decline,
+self.corrupt.conda.heal.accept,
 self.corrupt.uv.detect
 ```
 

--- a/run_setup.bat
+++ b/run_setup.bat
@@ -126,6 +126,10 @@ rem HP_TEST_HEAL_ANSWER=Y|N: bypasses the interactive Y/N prompt in :conda_binar
 set "HP_TEST_HEAL_ANSWER=%HP_TEST_HEAL_ANSWER%"
 rem HP_TEST_CORRUPT_UV=1: simulates a corrupt uv binary; clears cache and re-downloads for REQ-020 branch coverage
 set "HP_TEST_CORRUPT_UV=%HP_TEST_CORRUPT_UV%"
+rem HP_TEST_SKIP_EVICT=1: CI-only; skips the rmdir and Miniconda re-download in :evict_and_rebuild.
+rem Use with HP_TEST_CORRUPT_CONDA=1 + HP_TEST_HEAL_ANSWER=Y to test the accept branch without
+rem deleting the real CI Miniconda installation. The eviction log line is still emitted.
+set "HP_TEST_SKIP_EVICT=%HP_TEST_SKIP_EVICT%"
 rem HP_SKIP_NIVISA=1: REQ-008 opt-out -- skip the NI-VISA driver install even when pyvisa/visa is detected (debugging)
 set "HP_SKIP_NIVISA=%HP_SKIP_NIVISA%"
 rem HP_NIVISA_WAIT_SECS=<n>: REQ-008 diagnostic -- post-install registry poll budget in seconds.
@@ -2084,25 +2088,32 @@ exit /b 2
 :evict_and_rebuild
 echo.
 echo   [INFO] Removing corrupt Miniconda installation...
-rmdir /s /q "%MINICONDA_ROOT%" 2>nul
-if exist "%MINICONDA_ROOT%" (
-  echo.
-  echo   [WARN] Could not fully remove %MINICONDA_ROOT%.
-  echo   Some files may be locked. Close any Python/conda windows and try again.
-  echo.
-  call :die "[ERROR] Could not delete corrupt conda dir; files may be locked." 3
-  exit /b 3
+rem HP_TEST_SKIP_EVICT: CI branch-coverage flag -- skip actual deletion and re-download so
+rem the test does not destroy the CI Miniconda installation. The eviction log line fires to
+rem prove the accept branch was reached. Must not be set in production.
+if not defined HP_TEST_SKIP_EVICT (
+  rmdir /s /q "%MINICONDA_ROOT%" 2>nul
+  if exist "%MINICONDA_ROOT%" (
+    echo.
+    echo   [WARN] Could not fully remove %MINICONDA_ROOT%.
+    echo   Some files may be locked. Close any Python/conda windows and try again.
+    echo.
+    call :die "[ERROR] Could not delete corrupt conda dir; files may be locked." 3
+    exit /b 3
+  )
+  echo   [INFO] Corrupt installation removed. Downloading fresh copy...
 )
-echo   [INFO] Corrupt installation removed. Downloading fresh copy...
 call :log "[INFO] Self-healing: corrupt conda evicted from %MINICONDA_ROOT%."
 set "CONDA_BAT="
 set "HP_CONDA_JUST_INSTALLED="
 set "HP_ENV_STATE_RESULT="
-call :download_miniconda_exe
-if exist "%TEMP%\miniconda.exe" (
-  call :try_conda_install
+if not defined HP_TEST_SKIP_EVICT (
+  call :download_miniconda_exe
+  if exist "%TEMP%\miniconda.exe" (
+    call :try_conda_install
+  )
+  if exist "%TEMP%\miniconda.exe" del "%TEMP%\miniconda.exe" >nul 2>&1
 )
-if exist "%TEMP%\miniconda.exe" del "%TEMP%\miniconda.exe" >nul 2>&1
 call :select_conda_bat
 if not defined CONDA_BAT (
   call :die "[ERROR] Fresh Miniconda install failed after self-healing eviction." 4

--- a/tests/selftest.ps1
+++ b/tests/selftest.ps1
@@ -751,6 +751,57 @@ Write-NdjsonRow ([ordered]@{
 })
 if ($healExit -eq 2 -and $healDeclineMsgFound) { $summary.Add('Heal decline: PASS') } else { $summary.Add('Heal decline: FAIL') }
 
+# --- Conda binary corruption heal-accept test (REQ-020) ---
+# Arrange: HP_TEST_CORRUPT_CONDA=1 + HP_TEST_HEAL_ANSWER=Y + HP_TEST_SKIP_EVICT=1.
+# HP_TEST_SKIP_EVICT prevents the actual rmdir + Miniconda re-download so CI conda stays intact.
+# The eviction log line is still emitted, proving the Y-branch (goto :evict_and_rebuild) fired.
+# Assert: exit 0, eviction log line present, bootstrap status ok.
+$healAcceptDir = Join-Path $TestsDir '~selftest_heal_accept'
+if (Test-Path $healAcceptDir) { Remove-Item -Recurse -Force $healAcceptDir }
+New-Item -ItemType Directory -Force -Path $healAcceptDir | Out-Null
+Copy-Item -Path $BatchPath -Destination $healAcceptDir -Force
+Set-Content -Path (Join-Path $healAcceptDir 'app_heal_accept_test.py') -Value 'print("heal-accept-ok")' -Encoding ASCII
+$healAcceptLogName = '~heal_accept_bootstrap.log'
+$env:HP_TEST_CORRUPT_CONDA = '1'
+$env:HP_TEST_HEAL_ANSWER = 'Y'
+$env:HP_TEST_SKIP_EVICT = '1'
+$prevCILaneHA = $env:HP_CI_LANE
+if (-not $env:HP_CI_LANE) { $env:HP_CI_LANE = 'selftest' }
+Push-Location $healAcceptDir
+try {
+  cmd /c "call run_setup.bat > $healAcceptLogName 2>&1"
+  $healAcceptExit = $LASTEXITCODE
+} finally {
+  Pop-Location
+  $env:HP_TEST_CORRUPT_CONDA = ''
+  $env:HP_TEST_HEAL_ANSWER = ''
+  $env:HP_TEST_SKIP_EVICT = ''
+  $env:HP_CI_LANE = $prevCILaneHA
+}
+$healAcceptLogPath = Join-Path $healAcceptDir $healAcceptLogName
+$healAcceptLines = if (Test-Path $healAcceptLogPath) { Get-Content -LiteralPath $healAcceptLogPath -Encoding ASCII } else { @() }
+$healAcceptEvictMsgFound = ($healAcceptLines | Where-Object { $_ -like '*Self-healing: corrupt conda evicted*' }).Count -gt 0
+$healAcceptStatusPath = Join-Path $healAcceptDir '~bootstrap.status.json'
+$healAcceptState = if (Test-Path $healAcceptStatusPath) {
+  try { (Get-Content -LiteralPath $healAcceptStatusPath -Raw | ConvertFrom-Json).state } catch { 'read-error' }
+} else { 'missing' }
+Write-NdjsonRow ([ordered]@{
+  id      = 'self.corrupt.conda.heal.accept'
+  req     = 'REQ-020'
+  pass    = ($healAcceptExit -eq 0 -and $healAcceptEvictMsgFound -and $healAcceptState -eq 'ok')
+  desc    = 'HP_TEST_HEAL_ANSWER=Y + HP_TEST_SKIP_EVICT=1: accept branch fires, eviction logged, bootstrap ok'
+  details = [ordered]@{
+    exitCode   = $healAcceptExit
+    evictFound = $healAcceptEvictMsgFound
+    state      = $healAcceptState
+  }
+})
+if ($healAcceptExit -eq 0 -and $healAcceptEvictMsgFound -and $healAcceptState -eq 'ok') {
+  $summary.Add('Heal accept: PASS')
+} else {
+  $summary.Add('Heal accept: FAIL')
+}
+
 # --- UV binary corruption eviction test (REQ-020 Task 4) ---
 # Arrange: create fake ~uv_bin\uv.exe + HP_TEST_CORRUPT_UV=1 simulates corrupt cached uv binary.
 # Assert:  bootstrap logs the eviction warning.


### PR DESCRIPTION
## Summary

- **Gap**: The `:evict_and_rebuild` path in `run_setup.bat` (REQ-020 self-healing) fired when the user said Y to the corrupt-conda prompt, but this Y-branch had no CI test. The decline path (`self.corrupt.conda.heal.decline`) and detection path (`self.corrupt.conda.detect`) were covered; the accept path was not.
- **Fix**: Added `HP_TEST_SKIP_EVICT=1` flag to `run_setup.bat` that guards the actual `rmdir` and Miniconda re-download in `:evict_and_rebuild`, so the test can exercise the branch without deleting the shared CI Miniconda installation. The eviction log line still fires, proving `goto :evict_and_rebuild` was reached.
- **Test**: New `self.corrupt.conda.heal.accept` row in `tests/selftest.ps1` runs with `HP_TEST_CORRUPT_CONDA=1 + HP_TEST_HEAL_ANSWER=Y + HP_TEST_SKIP_EVICT=1` and asserts exit 0, eviction log line present, and `~bootstrap.status.json` state=ok. CI confirmed all three conditions pass.

## CI Results (run 27151425794)

- Harness NDJSON: **73 rows, 73 pass, 0 fail** (up from 72)
- New row: `self.corrupt.conda.heal.accept` — PASS (exitCode=0, evictFound=true, state=ok)
- All existing rows unchanged and passing

## Test plan

- [x] `python tools/check_delimiters.py run_setup.bat` — no issues
- [x] `python -m compileall -q .` — clean
- [x] `python -m pyflakes .` — clean
- [x] `pwsh -NoLogo -NoProfile -File tools/ps-compileall.ps1` — Syntax OK (29 files)
- [x] `python -m pytest tests/test_*.py` — 123 passed, 11 skipped
- [x] CI green on diagnostics site: https://mixmansoundude.github.io/Python_vs_Windows/diag/27151425794-1/

https://claude.ai/code/session_011BXRSg92bEXhVEZRdJEUc8

---
_Generated by [Claude Code](https://claude.ai/code/session_011BXRSg92bEXhVEZRdJEUc8)_