### PR TITLE
fix: move REQ-020 conda health check after PATH update; add fresh-install warm-up

### DIFF
--- a/run_setup.bat
+++ b/run_setup.bat
@@ -2,10 +2,10 @@
 :: Project Home: https://github.com/mixmansoundude/Python_vs_Windows
 :: Description: Automated, zero-config Python environment management for Windows. Standalone and portable.
 :: [VERSION_METADATA]
-:: Last Verified Date: 2026-05-10
+:: Last Verified Date: 2026-06-08
 :: Verified Windows: Windows 10/11
 :: Verified PowerShell: 5.1+
-:: Verified Python: 3.14 (CI Latest)
+:: Verified Python: 3.14.5 (CI Latest)
 :: RECOVERY: If a future Python version breaks auto-detection, install a Python version matching the
 ::   'Last Verified' metadata above, then run 'set PVW_PYTHON_EXE=C:\path\to\python.exe' in your
 ::   terminal before running this script to bypass the broken detection.
@@ -271,17 +271,6 @@ if not defined CONDA_BAT (
   call :select_conda_bat
 )
 
-rem === Validate existing conda binary health (REQ-020: corruption hardening) ===
-rem Only fires for pre-existing installs (HP_CONDA_JUST_INSTALLED guards fresh downloads).
-rem Skipped when HP_TEST_FORCE_CONDA_FAIL=1 (test flag already simulates conda failure).
-if defined CONDA_BAT if not defined HP_CONDA_JUST_INSTALLED if not defined HP_TEST_FORCE_CONDA_FAIL (
-  if defined HP_TEST_CORRUPT_CONDA (
-    call :log "[ERROR] HP_TEST_CORRUPT_CONDA: simulating corrupt conda binary."
-    goto :conda_binary_corrupt
-  )
-  call "%CONDA_BAT%" info >nul 2>&1
-  if errorlevel 1 goto :conda_binary_corrupt
-)
 :after_conda_bat_validation
 
 if not defined CONDA_BAT (
@@ -292,6 +281,29 @@ if not defined CONDA_BAT (
 )
 
 set "PATH=%MINICONDA_ROOT%\condabin;%MINICONDA_ROOT%\Scripts;%MINICONDA_ROOT%\Library\bin;%MINICONDA_ROOT%;%PATH%"
+
+rem === Fresh install: warm up conda to initialize base-env state (REQ-020) ===
+rem derived requirement: Silent Miniconda install (/S /AddToPath=0) leaves the base
+rem environment in a state where conda info may return non-zero until conda is run
+rem once with its own directories in PATH. Calling conda info here (silently, after
+rem the PATH update) ensures subsequent bootstrap runs that find the pre-installed
+rem Miniconda pass the corruption health check instead of falsely flagging it corrupt.
+if defined HP_CONDA_JUST_INSTALLED if defined CONDA_BAT (
+  call "%CONDA_BAT%" info >nul 2>&1
+)
+
+rem === Validate existing conda binary health (REQ-020: corruption hardening) ===
+rem Only fires for pre-existing installs (HP_CONDA_JUST_INSTALLED guards fresh downloads).
+rem Skipped when HP_TEST_FORCE_CONDA_FAIL=1 (test flag already simulates conda failure).
+rem Placed after PATH update so conda.bat internal calls can resolve their dependencies.
+if defined CONDA_BAT if not defined HP_CONDA_JUST_INSTALLED if not defined HP_TEST_FORCE_CONDA_FAIL (
+  if defined HP_TEST_CORRUPT_CONDA (
+    call :log "[ERROR] HP_TEST_CORRUPT_CONDA: simulating corrupt conda binary."
+    goto :conda_binary_corrupt
+  )
+  call "%CONDA_BAT%" info >nul 2>&1
+  if errorlevel 1 goto :conda_binary_corrupt
+)
 where conda >> "%LOG%" 2>&1 || (
   set "HP_ENV_READY="
   call :handle_conda_failure "[ERROR] 'conda' not found on PATH after bootstrap."


### PR DESCRIPTION
## Summary

- **Root cause**: The REQ-020 corruption health check (`call "%CONDA_BAT%" info`) ran *before* `set "PATH=%MINICONDA_ROOT%\condabin;..."`, so conda.bat's internal calls couldn't resolve their own dependencies. In the `contract-uv` lane, Miniconda is freshly installed but never used (UV takes over the full env flow), leaving conda's base environment uninitialised. When `selftest.ps1`'s stub bootstrap later found the pre-existing Miniconda, the health check returned non-zero — a false-positive "Corrupt conda binary in CI" (exit 2). This terminated `selftest.ps1` via `$ErrorActionPreference = 'Stop'` before any NDJSON rows were written, suppressing all `contract-uv` selftest coverage including `self.corrupt.uv.detect`.
- **Fix**: Moved the corruption check to after the PATH update, and added a one-shot silent warm-up (`call "%CONDA_BAT%" info >nul 2>&1`) gated on `HP_CONDA_JUST_INSTALLED` so fresh installs exit the run with a fully initialised conda state.
- **Also updated** `VERSION_METADATA` block: last verified date `2026-05-10` → `2026-06-08`, Python `3.14` → `3.14.5` per AGENTS.md maintenance rule.

## Test plan

- [ ] `contract-uv` lane: `selftest.ps1` now runs to completion; `self.corrupt.uv.detect` fires with actual UV corruption test instead of being always-skipped
- [ ] `contract-uv` lane: test-logs NDJSON gains ~19 new selftest rows (`self.stub.*`, `self.corrupt.*`, `self.guardrail.*`, `self.pep723.*`, etc.)
- [ ] All existing lanes: corruption detection still fires correctly for pre-existing Miniconda (HP_CONDA_JUST_INSTALLED not set, check runs after PATH update → passes cleanly)
- [ ] `self.corrupt.conda.detect`, `self.corrupt.conda.heal.decline`, `self.corrupt.conda.heal.accept`: continue to pass in standard lanes
- [ ] Delimiter check passes: `python tools/check_delimiters.py run_setup.bat` → "No delimiter issues found."
- [ ] `:evict_and_rebuild` → sets `HP_CONDA_JUST_INSTALLED=1` → `goto :after_conda_bat_validation` → PATH updated → warm-up runs → corruption check skipped (correct for fresh install after self-heal)

https://claude.ai/code/session_01MzXuE85YRcN8efMqPKHLQG

---
_Generated by [Claude Code](https://claude.ai/code/session_01MzXuE85YRcN8efMqPKHLQG)_