### PR TITLE
test+fix+docs: REQ-020 hardening, NI-VISA diagnostics, new test coverage, CI arch fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -236,20 +236,21 @@ in `batch-check.yml`. No other agent or job may commit auto-fixes. See AGENTS.md
 
 **NDJSON files and who owns them:**
 - `tests/~test-results.ndjson` -- written by every `selfapps_*.ps1` test script during the
-  CI run. The selfapps scripts APPEND rows to this file. `harness.ps1` then DELETES and
-  REWRITES it from `ci_test_results.ndjson` (the root-level aggregator). Do not confuse
-  the mid-run append file with the final harness output.
-- `ci_test_results.ndjson` -- root-level aggregator written by selfapps scripts and read
-  by `harness.ps1`. This is the authoritative input for verdict computation.
-- Rows in `ci_test_results.ndjson` but not in `tests/~test-results.ndjson` after the run
-  means harness.ps1 ran after the selfapps scripts rewrote the file.
+  CI run. The selfapps scripts APPEND rows to this file. The CI "Verdict from NDJSON" step
+  reads it immediately after upload. Later, `harness.ps1` DELETES it and REWRITES it with
+  harness static check rows. The final artifact content is harness rows only.
+- `ci_test_results.ndjson` -- parallel aggregator written by selfapps scripts; used as
+  fallback by the "Verdict from NDJSON" step if `tests/~test-results.ndjson` is empty/missing.
+  `harness.ps1` does NOT read this file.
 
 **CI job step ordering (within each lane job):**
 1. Selfapps scripts run (each appends rows to both NDJSON files).
-2. Artifacts are uploaded (NDJSON snapshots, logs).
-3. `run_tests.bat` runs `tests/harness.ps1` (verdict -- reads `ci_test_results.ndjson`,
-   rewrites `tests/~test-results.ndjson`, emits pass/fail).
-4. `tests/selftest.ps1` runs the bootstrapper self-tests (empty repo + stub).
+2. Artifacts are uploaded (NDJSON snapshot of selfapps rows).
+3. "Verdict from NDJSON" CI step reads pre-harness selfapps rows (has_failures verdict).
+4. Dynamic tests run.
+5. `run_tests.bat` runs `tests/harness.ps1` (reads and deletes `tests/~test-results.ndjson`,
+   writes harness static check rows back to the same file).
+6. `tests/selftest.ps1` runs the bootstrapper self-tests (empty repo + stub).
 
 **selftest.ps1 vs selftests.ps1:**
 - `selftest.ps1` -- runs run_setup.bat on a real (empty) app directory, validates
@@ -384,6 +385,7 @@ batch.req010.isolation, batch.req011.dircheck,
 batch.req002.findentry_cli, batch.req002.findentry_run, batch.req002.entry_log, batch.req002.findentry_payload,
 batch.ux.pause.gated,
 batch.dep.diff.trace,
+batch.conda.warmup,
 self.bootstrap.state, self.empty_repo.msg, self.empty_repo.no_spurious_warn,
 self.harness.started,
 self.stub.fastpath, self.stub.rebuild, self.stub.state_skip,
@@ -432,6 +434,7 @@ Test files and what they cover:
 | `test_poll_public_diag_logging.py` | Diagnostics polling and logging |
 | `test_ps_colon_scan.py` | PowerShell scoped variable detection ($var:) |
 | `test_check_delimiters_import.py` | Delimiter checker import guard |
+| `test_fast_check_pattern.py` | HP_FAST_CHECK infra-dir exclusion regex ($infraPattern) |
 | `test_heuristics.py` | Heuristic dep-augmentation rules (REQ-005: all 6 rules, kill-switch, idempotency) |
 | `test_parse_warn.py` | PyInstaller warn-file translation table (REQ-007: 5.x and 6.x formats, all TRANSLATIONS entries) |
 | `test_publish_index_regex.py` | Regex patterns in diagnostics publisher |

--- a/README.md
+++ b/README.md
@@ -381,7 +381,7 @@ At completion:
   - `[INFO] Self-healing: corrupt conda evicted from <path>.` (user accepts self-heal)
   - `[ERROR] Corrupt conda env; user declined rebuild.` (user declines)
 - CI test flags: `HP_TEST_CORRUPT_CONDA=1`, `HP_TEST_CORRUPT_UV=1`, `HP_TEST_HEAL_ANSWER=N`.
-- Test NDJSON rows: `self.corrupt.conda.detect`, `self.corrupt.conda.heal.decline`, `self.corrupt.uv.detect` (in `tests/selftest.ps1`).
+- Test NDJSON rows: `self.corrupt.conda.detect`, `self.corrupt.conda.heal.decline`, `self.corrupt.conda.heal.accept`, `self.corrupt.uv.detect` (in `tests/selftest.ps1`).
 
 ---
 

--- a/run_setup.bat
+++ b/run_setup.bat
@@ -271,6 +271,7 @@ if not defined CONDA_BAT (
   call :select_conda_bat
 )
 
+set "PATH=%MINICONDA_ROOT%\condabin;%MINICONDA_ROOT%\Scripts;%MINICONDA_ROOT%\Library\bin;%MINICONDA_ROOT%;%PATH%"
 :after_conda_bat_validation
 
 if not defined CONDA_BAT (
@@ -279,8 +280,6 @@ if not defined CONDA_BAT (
   if defined HP_ENV_READY goto :after_env_mode_selection
   call :die "[ERROR] conda.bat not found after bootstrap."
 )
-
-set "PATH=%MINICONDA_ROOT%\condabin;%MINICONDA_ROOT%\Scripts;%MINICONDA_ROOT%\Library\bin;%MINICONDA_ROOT%;%PATH%"
 
 rem === Fresh install: warm up conda to initialize base-env state (REQ-020) ===
 rem derived requirement: Silent Miniconda install (/S /AddToPath=0) leaves the base

--- a/tests/harness.ps1
+++ b/tests/harness.ps1
@@ -306,7 +306,7 @@ $hasRun = $feMatch.Success -and ($feDecoded -match '"run\.py"')
 Write-Result "batch.req002.findentry_run" "REQ-002: HP_FIND_ENTRY PREFERRED includes run.py" $hasRun @{}
 $hasDiffTrace = ($Lines | Select-String -SimpleMatch 'REQ-005.5').Count -gt 0
 Write-Result "batch.dep.diff.trace" "REQ-005.5: dependency diff log line present in run_setup.bat source" $hasDiffTrace @{}
-$hasCondaWarmup = ($AllText -match 'HP_CONDA_JUST_INSTALLED') -and ($AllText -match 'call\s+"%CONDA_BAT%"\s+info\s+>nul')
+$hasCondaWarmup = ($AllText -match 'if defined HP_CONDA_JUST_INSTALLED\s+if defined CONDA_BAT') -and ($AllText -match 'call\s+"%CONDA_BAT%"\s+info\s+>nul')
 Write-Result "batch.conda.warmup" "REQ-020: fresh-install conda warm-up (HP_CONDA_JUST_INSTALLED guard) present in run_setup.bat" $hasCondaWarmup @{}
 $results = Get-Content -LiteralPath $ResultsPath -Encoding ASCII | ForEach-Object { $_ | ConvertFrom-Json }
 $fail = @($results | Where-Object { -not $_.pass })

--- a/tests/harness.ps1
+++ b/tests/harness.ps1
@@ -306,6 +306,8 @@ $hasRun = $feMatch.Success -and ($feDecoded -match '"run\.py"')
 Write-Result "batch.req002.findentry_run" "REQ-002: HP_FIND_ENTRY PREFERRED includes run.py" $hasRun @{}
 $hasDiffTrace = ($Lines | Select-String -SimpleMatch 'REQ-005.5').Count -gt 0
 Write-Result "batch.dep.diff.trace" "REQ-005.5: dependency diff log line present in run_setup.bat source" $hasDiffTrace @{}
+$hasCondaWarmup = ($AllText -match 'HP_CONDA_JUST_INSTALLED') -and ($AllText -match 'call\s+"%CONDA_BAT%"\s+info\s+>nul')
+Write-Result "batch.conda.warmup" "REQ-020: fresh-install conda warm-up (HP_CONDA_JUST_INSTALLED guard) present in run_setup.bat" $hasCondaWarmup @{}
 $results = Get-Content -LiteralPath $ResultsPath -Encoding ASCII | ForEach-Object { $_ | ConvertFrom-Json }
 $fail = @($results | Where-Object { -not $_.pass })
 $pass = @($results | Where-Object { $_.pass })


### PR DESCRIPTION
## Summary

### Fixes
- **PATH double-prepend after evict_and_rebuild** (`run_setup.bat`): The `:after_conda_bat_validation` label was moved before the PATH prepend in a prior refactor, causing `goto :after_conda_bat_validation` from `:evict_and_rebuild` to re-run PATH setup on every repair cycle. Fixed by placing `set "PATH=..."` before the label so the goto lands after PATH setup.
- **Drag-and-drop message empty filename** (`run_setup.bat`): `:determine_entry` printed `Using drag-and-drop file:` with no name because `%MAIN_FILE%` was expanded at parse time before the `set` ran. Fixed by using `%~1` directly. (REQ-002)
- **batch.conda.warmup false-pass** (`harness.ps1`): Regex used generic `HP_CONDA_JUST_INSTALLED` (matches 8+ unrelated references); removing the warmup block while leaving the health-check would still pass. Tightened to `if defined HP_CONDA_JUST_INSTALLED if defined CONDA_BAT` which is unique to the warmup block.

### New Features
- **NI-VISA install diagnostics** (`run_setup.bat`): REQ-008 extended with exit-code logging, configurable post-check budget (`HP_NIVISA_WAIT_SECS`), PE-validity check, download method/size logging, and `HP_SKIP_NIVISA` opt-out flag. NDJSON rows: `pyvisa.nivisa.{branch,outcome,reason,disabled}`.
- **REQ-020 conda health check + warm-up**: Fresh-install warm-up (`call conda info`) guarded by `HP_CONDA_JUST_INSTALLED`; moves PATH prepend before `:after_conda_bat_validation` label to fix double-prepend.

### New Tests (18 commits total)
- `self.corrupt.conda.heal.accept` -- REQ-020 accept branch coverage
- `self.stub.conda_perpkg` -- REQ-005.3 conda per-package fallback
- `self.ux.postflight` -- REQ-016 post-flight panel content validation
- `self.pyvisa.disabled` -- HP_SKIP_NIVISA opt-out coverage
- `self.entry.override` -- REQ-002 priority-0 manual %1 override
- `self.ux.connectivity.retry` -- REQ-013 internet-reachable Y-retry re-prompt branch
- `self.entry.entryD` -- run.py beats cli.py in REQ-002 priority
- `self.ux.connectivity.online` -- REQ-013 internet-reachable cascade branch
- `batch.dep.diff.trace` -- promoted dep.diff.trace to runtime validation
- `pipgap.*` -- pip gap-fill safety net (conda misses opencv-python, pip fills it)
- `batch.conda.warmup` -- REQ-020 fresh-install warm-up guard present

### Docs
- README: added `self.corrupt.conda.heal.accept` to REQ-020 NDJSON rows list
- CLAUDE.md: added `test_fast_check_pattern.py` to test table; fixed CI arch docs (harness reads `tests/~test-results.ndjson`; corrected step ordering; added `batch.conda.warmup` to NDJSON surface); recorded NI-VISA -125083 as environmental finding

## CI
- Run 27277187492 (attempt 1): **94 pass, 0 fail** -- all lanes green

## Test plan
- [x] `cache` lane: pass
- [x] `real` lane: pass (gating)
- [x] `conda-full` lane: pass (gating)
- [x] `contract-uv` / `contract-uv-fail` / `justme-test` / `uv` lanes: pass
- [x] Diagnostics site confirms 94/94: https://mixmansoundude.github.io/Python_vs_Windows/diag/27277187492-1/index.html

https://claude.ai/code/session_018HBS9H3i21Em6tkqAokAet

---
_Generated by [Claude Code](https://claude.ai/code/session_018HBS9H3i21Em6tkqAokAet)_