### PR TITLE
docs: add SmartScreen / security warning guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ This repository serves as a proof of concept of this new approach.
 - **Windows 10 (1809+)** or newer.
 - **One Folder per Program:** Create a unique folder for your project (e.g., `universal_paperclip_optimizer` or `solve_world_hunger_v2`).
 - **Avoid Conflicts:** To ensure environment integrity, do not mix independent programs in the same folder. Each program should have its own dedicated folder and its own copy of `run_setup.bat`.
+- **First run on Windows:** Windows may show "Windows protected your PC" -- click **More info** -> **Run anyway**. If "Run anyway" is absent: right-click the batch -> **Properties** -> check **Unblock** -> **OK** -> run again.
 - **Setup:** Put your `.py` files and `run_setup.bat` in that folder, then double-click the `.bat`.
 - **Environment Locking:** On the first run, `run_setup.bat` creates or respects a `runtime.txt` to "pin" the Python version. It applies similar logic for dependencies found in `requirements.txt`, `pyproject.toml`, or PEP 723 headers.
 

--- a/run_setup.bat
+++ b/run_setup.bat
@@ -9,6 +9,23 @@
 :: RECOVERY: If a future Python version breaks auto-detection, install a Python version matching the
 ::   'Last Verified' metadata above, then run 'set PVW_PYTHON_EXE=C:\path\to\python.exe' in your
 ::   terminal before running this script to bypass the broken detection.
+:: ============================================================
+:: FIRST-TIME WINDOWS USERS: SmartScreen / Security Warning
+:: ============================================================
+:: When you double-click this file, Windows may show:
+::   "Windows protected your PC"
+:: This is normal for any .bat file downloaded from the internet.
+::
+:: TO RUN:  Click "More info"  then  "Run anyway"
+::
+:: IF "Run anyway" is not shown:
+::   1. Close this dialog
+::   2. Right-click run_setup.bat in File Explorer
+::   3. Click "Properties"
+::   4. At the bottom, check the "Unblock" checkbox
+::   5. Click "OK"
+::   6. Double-click run_setup.bat again
+:: ============================================================
 @echo off
 setlocal DisableDelayedExpansion
 set "DEP_SOURCE=unknown"


### PR DESCRIPTION
## Summary

Documentation/UX fix to help first-time Windows users past the SmartScreen "Windows protected your PC" dialog. No code or CI changes.

### Change 1 — `run_setup.bat` header
Added an ASCII comment block immediately after the existing header metadata and **before** `@echo off`, so it's visible to anyone opening the file in Notepad or an editor. It explains the SmartScreen warning and both paths to run: **More info -> Run anyway**, and the **Properties -> Unblock** fallback.

### Change 2 — `README.md` TL;DR
Added one bullet before the **Setup:** bullet covering the same SmartScreen guidance (arrows written as ASCII `->` per the repo's ASCII-only rule).

## Testing
- `python tools/check_delimiters.py run_setup.bat` -> No delimiter issues found.

No selftest scenario added: SmartScreen is OS-enforced on downloaded files and cannot be reproduced in CI.

https://claude.ai/code/session_01MQaC6E7FAKDVFTngQuegy8

---
_Generated by [Claude Code](https://claude.ai/code/session_01MQaC6E7FAKDVFTngQuegy8)_