### PR TITLE
test: sync guard for HP_PARSE_WARN embedded payload

### DIFF
--- a/tests/test_parse_warn.py
+++ b/tests/test_parse_warn.py
@@ -3,13 +3,21 @@
 Each TRANSLATIONS entry has at least one assertion; removing any entry causes a
 test failure.  Both PyInstaller 5.x (W: no module named 'foo') and 6.x
 (missing module named foo - imported by bar (top-level|delayed|conditional)) formats are covered.
+
+Also guards that the base64 HP_PARSE_WARN payload embedded in run_setup.bat
+matches this source (mirrors FindEntryPayloadSync in test_find_entry.py).
 """
+import base64
 import os
+import re
 import tempfile
 import unittest
 from pathlib import Path
 
 from tools.parse_warn import parse_warn_file, TRANSLATIONS, SKIP
+
+REPO = Path(__file__).resolve().parent.parent
+PARSE_WARN = REPO / "tools" / "parse_warn.py"
 
 
 def _warn5(mod):
@@ -272,6 +280,19 @@ class ParseWarnFileEdgeCasesTest(unittest.TestCase):
         self.assertIn("importlib.abc", SKIP)
         result = _parse_lines(["W: no module named 'importlib.abc'"])
         self.assertEqual(result, [])
+
+
+class ParseWarnPayloadSync(unittest.TestCase):
+    def test_embedded_base64_matches_source(self):
+        bat = (REPO / "run_setup.bat").read_text(encoding="utf-8", errors="replace")
+        m = re.search(r'set "HP_PARSE_WARN=([A-Za-z0-9+/=]+)"', bat)
+        self.assertIsNotNone(m, "HP_PARSE_WARN payload not found in run_setup.bat")
+        decoded = base64.b64decode(m.group(1)).decode("utf-8")
+        source = PARSE_WARN.read_text(encoding="utf-8")
+        self.assertEqual(
+            decoded, source,
+            "HP_PARSE_WARN base64 is out of sync with tools/parse_warn.py; re-encode it.",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

Adds a sync guard for the `HP_PARSE_WARN` embedded base64 payload in `run_setup.bat`, mirroring the existing `FindEntryPayloadSync` guard in `tests/test_find_entry.py`.

The new `ParseWarnPayloadSync.test_embedded_base64_matches_source` decodes the `HP_PARSE_WARN` base64 from `run_setup.bat` and asserts it equals `tools/parse_warn.py`, so the embedded copy can never silently drift from source.

## Why only this payload

The self-contained bootstrapper embeds many helpers as base64 (`HP_DEP_CHECK`, `HP_ENV_STATE`, `HP_PYPROJ_DEPS`, `HP_CONDARC`, `HP_DETECT_PY`, `HP_PRINT_PYVER`, `HP_PREP_REQUIREMENTS`, `HP_DETECT_VISA`, `HP_FAST_CHECK`, ...). A sync guard only makes sense where **two copies exist that can drift apart** — i.e. a payload that is also checked into `tools/` as a 1:1 source file.

Only two payloads meet that bar:

| Payload | Committed source | Guard |
|---------|------------------|-------|
| `HP_FIND_ENTRY` | `tools/find_entry.py` | existed (`FindEntryPayloadSync`) |
| `HP_PARSE_WARN` | `tools/parse_warn.py` | **added here** |

All other payloads (`HP_DEP_CHECK`, `HP_ENV_STATE`, `HP_PYPROJ_DEPS`, etc.) have **no committed source file** — the base64 is the sole source of truth and is only decoded to a `~*.py` at runtime — so there is nothing to compare against. `HP_FAST_CHECK`'s adjacent `rem` comment block is a partial human summary, not a 1:1 mirror, so it isn't guardable either.

Both committed payloads are currently in sync, so the test passes today.

## Testing

```
python -m pytest tests/test_parse_warn.py -q   # 42 passed
```

Full unit suite: 134 passed, 11 skipped (only unrelated `test_apply_patch.py` errors locally on a missing optional `pydantic` dep).

https://claude.ai/code/session_016wproHgQ24XjDeY34F8keY

---
_Generated by [Claude Code](https://claude.ai/code/session_016wproHgQ24XjDeY34F8keY)_