### PR TITLE
test: strengthen self.ux.postflight to verify RUNNING YOUR APP section (REQ-016)

### DIFF
--- a/run_setup.bat
+++ b/run_setup.bat
@@ -2,10 +2,10 @@
 :: Project Home: https://github.com/mixmansoundude/Python_vs_Windows
 :: Description: Automated, zero-config Python environment management for Windows. Standalone and portable.
 :: [VERSION_METADATA]
-:: Last Verified Date: 2026-06-12
+:: Last Verified Date: 2026-06-15
 :: Verified Windows: Windows 10/11
 :: Verified PowerShell: 5.1+
-:: Verified Python: 3.14.5 (CI Latest)
+:: Verified Python: 3.14.6 (CI Latest)
 :: RECOVERY: If a future Python version breaks auto-detection, install a Python version matching the
 ::   'Last Verified' metadata above, then run 'set PVW_PYTHON_EXE=C:\path\to\python.exe' in your
 ::   terminal before running this script to bypass the broken detection.

--- a/tests/selfapps_ux_hardening.ps1
+++ b/tests/selfapps_ux_hardening.ps1
@@ -194,13 +194,23 @@ if (-not (Test-Path -LiteralPath $envsmokeLog)) {
     $envsmokeBootLog = Join-Path $envsmokeDir '~envsmoke_bootstrap.log'
     if (Test-Path -LiteralPath $envsmokeBootLog) {
         $bootText = Get-Content -LiteralPath $envsmokeBootLog -Raw -Encoding Ascii
-        $pfExe    = $bootText -match [regex]::Escape('Your standalone application is ready:')
-        $pfKeep   = $bootText -match [regex]::Escape('KEEP these files')
-        $pfDelete = $bootText -match [regex]::Escape('SAFE TO DELETE')
-        $pfContent = ($pfExe -and $pfKeep -and $pfDelete)
-        $pfDetails.exeSectionFound    = $pfExe
-        $pfDetails.keepSectionFound   = $pfKeep
-        $pfDetails.deleteSectionFound = $pfDelete
+        $pfExe      = $bootText -match [regex]::Escape('Your standalone application is ready:')
+        $pfKeep     = $bootText -match [regex]::Escape('KEEP these files')
+        $pfDelete   = $bootText -match [regex]::Escape('SAFE TO DELETE')
+        # REQ-016 also requires a RUNNING YOUR APP section with two specific beginner-confusion items:
+        # (1) console-window flash advice (open Command Prompt to keep it open)
+        # (2) stdout buffering difference note -- "buffering difference" is on one echo line;
+        #     "stdout" ends the preceding line so we match the single-line phrase here.
+        $pfRunApp    = $bootText -match [regex]::Escape('RUNNING YOUR APP')
+        $pfCmdPrompt = $bootText -match [regex]::Escape('Command Prompt')
+        $pfStdBuf    = $bootText -match [regex]::Escape('buffering difference')
+        $pfContent = ($pfExe -and $pfKeep -and $pfDelete -and $pfRunApp -and $pfCmdPrompt -and $pfStdBuf)
+        $pfDetails.exeSectionFound     = $pfExe
+        $pfDetails.keepSectionFound    = $pfKeep
+        $pfDetails.deleteSectionFound  = $pfDelete
+        $pfDetails.runAppSectionFound  = $pfRunApp
+        $pfDetails.cmdPromptFound      = $pfCmdPrompt
+        $pfDetails.stdBufferingFound   = $pfStdBuf
     } else {
         # Defensive: never false-fail if the stdout capture is absent; fall back to the log line.
         $pfDetails.bootLogMissing = $true
@@ -210,7 +220,7 @@ if (-not (Test-Path -LiteralPath $envsmokeLog)) {
         id      = 'self.ux.postflight'
         req     = 'REQ-016'
         pass    = $pfFound
-        desc    = 'Post-flight briefing: log line plus panel content (EXE + keep + delete sections)'
+        desc    = 'Post-flight briefing: log line plus panel (EXE + keep + delete + RUNNING YOUR APP + Command Prompt + stdout buffering)'
         details = $pfDetails
     })
 }


### PR DESCRIPTION
## Summary

- **Strengthen `self.ux.postflight` test** (`tests/selfapps_ux_hardening.ps1`): the existing test only verified the EXE/keep/delete panel sections. REQ-016 explicitly requires a `RUNNING YOUR APP` section covering two beginner-confusion items — (1) the console-window-flash advice pointing users to open a Command Prompt, and (2) the stdout buffering difference note. Without assertions for these, removing them from the post-flight panel would silently pass CI. Added three new checks:
  - `runAppSectionFound` — `RUNNING YOUR APP` section header present
  - `cmdPromptFound` — `Command Prompt` advice present (confusion #1)
  - `stdBufferingFound` — `buffering difference` text present (confusion #2)

- **Update `[VERSION_METADATA]`** (`run_setup.bat`): Python 3.14.5 → 3.14.6, date 2026-06-12 → 2026-06-15, reflecting the 2026-06-15 CI run that passed on conda-forge Python 3.14.6 (per AGENTS.md maintenance rule).

## Test plan

- [x] All 6 `self.ux.postflight` assertions pass (`logLineFound`, `exeSectionFound`, `keepSectionFound`, `deleteSectionFound`, `runAppSectionFound`, `cmdPromptFound`, `stdBufferingFound`)
- [x] 98/98 conda-full selfapps rows pass (row count non-decreasing)
- [x] CI green on run `27525542938` — "Iterate logs: not needed (all checks passing)"
- [x] `python -m compileall`, `pyflakes`, `check_delimiters.py`, 138 unit tests all pass locally

https://claude.ai/code/session_01HvxKLokL7KhLUYG7GKZdgf

---
_Generated by [Claude Code](https://claude.ai/code/session_01HvxKLokL7KhLUYG7GKZdgf)_