### PR TITLE
fix: stop double-printing PVW override [DEBUG] lines to console

### DIFF
--- a/run_setup.bat
+++ b/run_setup.bat
@@ -72,15 +72,10 @@ rem --- PVW_ super-user overrides (inherit from calling terminal; logged before 
 rem derived requirement: PVW_ variables let a super-user pre-set values to bypass auto-detection.
 rem Single-line if form avoids parse-time expansion issues in block-form if-statements when a
 rem variable value contains parentheses, such as a path under "C:\Program Files (x86)\...".
-if defined PVW_PYTHON_EXE echo [DEBUG] Using super-user override for PVW_PYTHON_EXE: %PVW_PYTHON_EXE%
 if defined PVW_PYTHON_EXE call :log "[DEBUG] Using super-user override for PVW_PYTHON_EXE: %PVW_PYTHON_EXE%"
-if defined PVW_UV_EXE echo [DEBUG] Using super-user override for PVW_UV_EXE: %PVW_UV_EXE%
 if defined PVW_UV_EXE call :log "[DEBUG] Using super-user override for PVW_UV_EXE: %PVW_UV_EXE%"
-if defined PVW_CONDA_EXE echo [DEBUG] Using super-user override for PVW_CONDA_EXE: %PVW_CONDA_EXE%
 if defined PVW_CONDA_EXE call :log "[DEBUG] Using super-user override for PVW_CONDA_EXE: %PVW_CONDA_EXE%"
-if defined PVW_TARGET_PY echo [DEBUG] Using super-user override for PVW_TARGET_PY: %PVW_TARGET_PY%
 if defined PVW_TARGET_PY call :log "[DEBUG] Using super-user override for PVW_TARGET_PY: %PVW_TARGET_PY%"
-if defined PVW_WORKSPACE echo [DEBUG] Using super-user override for PVW_WORKSPACE: %PVW_WORKSPACE%
 if defined PVW_WORKSPACE call :log "[DEBUG] Using super-user override for PVW_WORKSPACE: %PVW_WORKSPACE%"
 rem --- Path-length guard: warn if script root path approaches the 260-char cmd.exe limit ---
 for /f "usebackq delims=" %%L in (`powershell -NoProfile -ExecutionPolicy Bypass -Command "$env:HP_SCRIPT_ROOT.Length" 2^>nul`) do set "HP_PATH_LEN=%%L"


### PR DESCRIPTION
## Summary

Each `PVW_*` super-user override notice in `run_setup.bat` (lines 75-84) ran **both** a bare `echo [DEBUG] ...` **and** a `call :log "[DEBUG] ..."`. Because `:log` already echoes to the console (`echo %date% %time% %MSG%`) in addition to appending to `~setup.log`, every override that was set printed its `[DEBUG]` line to the console **twice** — once untimestamped (the bare `echo`) and once timestamped (`:log`) — while only the `:log` form was captured in `~setup.log`.

This drops the five redundant bare `echo [DEBUG] ...` lines so that each set override logs exactly **one** timestamped `[DEBUG]` line to both the console and `~setup.log`.

Affects any super-user who sets `PVW_PYTHON_EXE` / `PVW_UV_EXE` / `PVW_CONDA_EXE` / `PVW_TARGET_PY` / `PVW_WORKSPACE`.

## Why this is safe

- `:log` was already being called on these exact lines, so `:log` is reachable here and its behavior is unchanged — the only observable change is the removal of the duplicate untimestamped console line.
- The single-line `if` form (kept) is intentional and preserved, per the existing comment about avoiding block-form parse-time expansion when a path contains parentheses (e.g. `C:\Program Files (x86)`).
- No env var, behavior flag, new test, or NDJSON/docs changes. No test asserts on the removed untimestamped console line (the only `[DEBUG]` references under `tests/` are that suite's own diagnostic output).

## Verification

- `python tools/check_delimiters.py run_setup.bat` — clean
- `python -m compileall -q .` / `python -m pyflakes .` — clean (no `.py` changed; baseline sanity)
- `grep -c "echo \[DEBUG\]" run_setup.bat` → 0 — all `[DEBUG]` emissions now route through `:log`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016jvVn3EDzSmLs6wCNqZKJ7)_