### PR TITLE
feat: add uv-dl-fallback CI lane for HP_TEST_UV_DL_FALLBACK coverage (REQ-003)

### DIFF
--- a/.github/workflows/batch-check.yml
+++ b/.github/workflows/batch-check.yml
@@ -43,7 +43,9 @@ jobs:
           - mode: contract-uv
           # contract-uv-fail: HP_TEST_UV_FAIL=1 forces uv venv to fail; asserts explicit conda fallback
           - mode: contract-uv-fail
-    continue-on-error: ${{ matrix.mode == 'cache' || matrix.mode == 'justme-test' || matrix.mode == 'uv' || matrix.mode == 'contract-uv' || matrix.mode == 'contract-uv-fail' }}
+          # uv-dl-fallback: HP_TEST_UV_DL_FALLBACK=1 forces primary uv URL to fail; exercises fallback URL (non-gating)
+          - mode: uv-dl-fallback
+    continue-on-error: ${{ matrix.mode == 'cache' || matrix.mode == 'justme-test' || matrix.mode == 'uv' || matrix.mode == 'contract-uv' || matrix.mode == 'contract-uv-fail' || matrix.mode == 'uv-dl-fallback' }}
     runs-on: windows-latest
 
     outputs:
@@ -149,13 +151,20 @@ jobs:
 
       # justme-test only: forces Miniconda DL fallback and completely prevents uv acquisition
       # so the JustMe and Miniconda DL fallback paths are exercised (uv-first would bypass them).
-      # HP_TEST_UV_DL_FALLBACK is NOT set here; the uv DL fallback path needs a dedicated lane.
       - name: Force download fallback path (justme-test only)
         if: ${{ matrix.mode == 'justme-test' }}
         shell: pwsh
         run: |
           'HP_TEST_CONDA_DL_FALLBACK=1' | Out-File -FilePath $env:GITHUB_ENV -Encoding ascii -Append
           'HP_TEST_FORCE_UV_FAIL=1' | Out-File -FilePath $env:GITHUB_ENV -Encoding ascii -Append
+
+      # uv-dl-fallback only: forces the primary uv download URL to fail so the fallback URL is tried.
+      # Does not set HP_FORCE_CONDA_ONLY or HP_TEST_FORCE_UV_FAIL so uv is still the primary provider.
+      - name: Force uv download fallback (uv-dl-fallback only)
+        if: ${{ matrix.mode == 'uv-dl-fallback' }}
+        shell: pwsh
+        run: |
+          'HP_TEST_UV_DL_FALLBACK=1' | Out-File -FilePath $env:GITHUB_ENV -Encoding ascii -Append
 
       - name: Ensure CI fallbacks are off
         shell: pwsh
@@ -320,8 +329,8 @@ jobs:
         run: |
           & tests\selfapps_justme.ps1
 
-      - name: "Self-test: download fallback path (justme-test only)"
-        if: ${{ matrix.mode == 'justme-test' }}
+      - name: "Self-test: download fallback paths (justme-test/uv-dl-fallback)"
+        if: ${{ matrix.mode == 'justme-test' || matrix.mode == 'uv-dl-fallback' }}
         shell: pwsh
         run: |
           & tests\selfapps_dl_fallback.ps1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -497,7 +497,6 @@ Items deferred to future loops:
   added; treat any flag that ENABLES (rather than suppresses/diverts) intended behavior as a bug
   (see docs/agent-lessons-learned.md "Env-var flags are scaffolding").
 
-- **uv DL fallback CI coverage**: `self.dl.uv.fallback` (uv download fallback path -- HP_TEST_UV_DL_FALLBACK=1) has no active CI lane. justme-test now uses HP_TEST_FORCE_UV_FAIL=1 (skips uv entirely before any download) so the secondary uv URL is never exercised in CI. Needs a dedicated non-gating lane that sets HP_TEST_UV_DL_FALLBACK=1 without HP_FORCE_CONDA_ONLY=1 and without HP_TEST_NOT_ELEVATED=1, so uv download path is reached and the fallback URL is tried.
 
 - **User-code exit-code semantics**: verify the exit code read after running the user's code
   is purely the user program's (no bootstrapper logic interleaved). If so, a non-zero exit is
@@ -542,6 +541,14 @@ Items deferred to future loops:
 ## Closed Backlog
 
 Items completed and shipped:
+
+- **uv DL fallback CI coverage**: Added a dedicated non-gating `uv-dl-fallback` lane
+  (`HP_TEST_UV_DL_FALLBACK=1`) that forces the primary uv download URL to fail so the
+  pinned-release fallback URL (`HP_UV_FALLBACK_URL`) is exercised and uv is acquired from it.
+  `self.dl.uv.fallback` now fires as a real test in this lane (verifies `Trying fallback uv URL:`
+  logged and `uv: acquired at ~uv_bin\uv.exe` confirms binary acquired). In `justme-test` it
+  continues to pass with `skip=true` (HP_TEST_FORCE_UV_FAIL bypasses uv before any download).
+  Fixed a duplicate `self.dl.uv.fallback` block in `selfapps_dl_fallback.ps1`. CLOSED by this PR.
 
 - **Miniconda probe deferred to after uv detection**: the probe (CI-only, HP_CI_TEST_CONDA_DL=1)
   was firing before uv acquisition, downloading ~99 MB unnecessarily in all uv-first lanes

--- a/docs/agent-interconnect.md
+++ b/docs/agent-interconnect.md
@@ -100,6 +100,7 @@ ripple across components:
 | cache | not set | yes (uv-first) | maybe (cached) | maybe |
 | justme-test | not set | no (HP_TEST_FORCE_UV_FAIL=1) | via JustMe | yes |
 | contract-uv | not set | yes (forced) | no | no |
+| uv-dl-fallback | not set | yes (HP_TEST_UV_DL_FALLBACK=1 forces primary URL fail, fallback URL used) | no | no |
 
 ### Test files that assume conda is present -- skip=true pattern required
 

--- a/docs/agent-ndjson.md
+++ b/docs/agent-ndjson.md
@@ -69,11 +69,22 @@ self.venv.fallback, self.entry.override
 conda.install.justme
 ```
 
-## dl-fallback lane rows (HP_TEST_CONDA_DL_FALLBACK=1 + HP_TEST_FORCE_UV_FAIL=1, justme-test)
+## dl-fallback lane rows
 
-Note: HP_TEST_UV_DL_FALLBACK is NOT set in justme-test; uv DL fallback path needs a dedicated
-non-gating lane (see Active Backlog in CLAUDE.md). self.dl.uv.fallback passes with skip=true
-in justme-test.
+### justme-test lane (HP_TEST_CONDA_DL_FALLBACK=1 + HP_TEST_FORCE_UV_FAIL=1)
+
+`self.dl.conda.fallback` fires as a real test (Miniconda fallback URL exercised).
+`self.dl.uv.fallback` passes with skip=true (HP_TEST_FORCE_UV_FAIL bypasses uv before download).
+
+```
+self.dl.conda.fallback, self.dl.uv.fallback
+```
+
+### uv-dl-fallback lane (HP_TEST_UV_DL_FALLBACK=1, non-gating)
+
+`self.dl.uv.fallback` fires as a real test (primary uv URL replaced with invalid URL;
+fallback URL is tried and uv is acquired). `self.dl.conda.fallback` passes with skip=true
+(Miniconda DL fallback is not exercised in this lane).
 
 ```
 self.dl.conda.fallback, self.dl.uv.fallback

--- a/tests/selfapps_dl_fallback.ps1
+++ b/tests/selfapps_dl_fallback.ps1
@@ -1,6 +1,10 @@
 # ASCII only
 # selfapps_dl_fallback.ps1 - Verify Miniconda and uv fallback download URLs were tried.
-# Lane: justme-test only (HP_TEST_CONDA_DL_FALLBACK=1, HP_TEST_UV_DL_FALLBACK=1).
+# Lanes:
+#   justme-test    - HP_TEST_CONDA_DL_FALLBACK=1, HP_TEST_FORCE_UV_FAIL=1
+#                    conda fallback: real test; uv fallback: skip (uv acquisition bypassed)
+#   uv-dl-fallback - HP_TEST_UV_DL_FALLBACK=1
+#                    uv fallback: real test; conda fallback: skip (not exercised)
 # Reads ~setup.log and asserts fallback log messages are present.
 param()
 $ErrorActionPreference = 'Continue'
@@ -45,27 +49,40 @@ if (Test-Path -LiteralPath $setupLogPath) {
 }
 if (-not $logText) { $logText = '' }
 
-# Check Miniconda fallback
-$condaFallbackTried     = $logText -match 'Trying fallback Miniconda URL:'
-$condaFallbackSucceeded = $logText -match 'Miniconda download succeeded from fallback URL\.'
-$condaPass = $condaFallbackTried -and $condaFallbackSucceeded
+# Check Miniconda DL fallback.
+# derived requirement: conda DL fallback is only exercised in justme-test (HP_TEST_CONDA_DL_FALLBACK=1).
+# In uv-dl-fallback lane, Miniconda is not the primary provider; skip with explicit reason.
+$condaDlFallbackEnv = [Environment]::GetEnvironmentVariable('HP_TEST_CONDA_DL_FALLBACK')
+if ($condaDlFallbackEnv -eq '1') {
+    $condaFallbackTried     = $logText -match 'Trying fallback Miniconda URL:'
+    $condaFallbackSucceeded = $logText -match 'Miniconda download succeeded from fallback URL\.'
+    $condaPass = $condaFallbackTried -and $condaFallbackSucceeded
+    Write-NdjsonRow ([ordered]@{
+        id      = 'self.dl.conda.fallback'
+        req     = 'REQ-003'
+        pass    = $condaPass
+        desc    = 'Miniconda fallback URL tried and succeeded when primary fails'
+        details = [ordered]@{
+            fallbackTried     = $condaFallbackTried
+            fallbackSucceeded = $condaFallbackSucceeded
+            setupLog          = $setupLogPath
+        }
+    })
+} else {
+    $condaPass = $true
+    Write-NdjsonRow ([ordered]@{
+        id      = 'self.dl.conda.fallback'
+        req     = 'REQ-003'
+        pass    = $true
+        desc    = 'Miniconda fallback URL tried and succeeded when primary fails'
+        details = [ordered]@{ skip = $true; reason = 'HP_TEST_CONDA_DL_FALLBACK-not-set' }
+    })
+}
 
-Write-NdjsonRow ([ordered]@{
-    id      = 'self.dl.conda.fallback'
-    req     = 'REQ-003'
-    pass    = $condaPass
-    desc    = 'Miniconda fallback URL tried and succeeded when primary fails'
-    details = [ordered]@{
-        fallbackTried     = $condaFallbackTried
-        fallbackSucceeded = $condaFallbackSucceeded
-        setupLog          = $setupLogPath
-    }
-})
-
-# Check uv fallback: verify fallback was attempted AND uv binary was ultimately acquired.
-# derived requirement: when HP_TEST_FORCE_UV_FAIL=1, uv acquisition is bypassed before any
-# download attempt so the DL fallback path is never reached. Skip with explicit reason.
-# The uv DL fallback path needs a dedicated lane to be fully exercised (see Active Backlog).
+# Check uv DL fallback: verify the fallback URL was attempted AND uv binary was ultimately acquired.
+# derived requirement: HP_TEST_FORCE_UV_FAIL bypasses uv acquisition before any download attempt
+# so the DL fallback path is never reached in justme-test. Skip with explicit reason there.
+# The real test fires in uv-dl-fallback lane (HP_TEST_UV_DL_FALLBACK=1).
 $uvForcedFail    = $logText -match 'HP_TEST_FORCE_UV_FAIL: simulating uv acquisition failure'
 $uvFallbackTried = $logText -match 'Trying fallback uv URL:'
 $uvAcquired      = $logText -match 'uv: acquired at ~uv_bin\\uv\.exe'
@@ -92,38 +109,6 @@ if ($uvForcedFail) {
         }
     })
 }
-
-# Check uv fallback: verify fallback was attempted AND uv binary was ultimately acquired.
-# derived requirement: when HP_TEST_FORCE_UV_FAIL=1, uv acquisition is bypassed before any
-# download attempt so the DL fallback path is never reached. Skip with explicit reason.
-# The uv DL fallback path needs a dedicated lane to be fully exercised (see Active Backlog).
-$uvForcedFail    = $logText -match 'HP_TEST_FORCE_UV_FAIL: simulating uv acquisition failure'
-$uvFallbackTried = $logText -match 'Trying fallback uv URL:'
-$uvAcquired      = $logText -match 'uv: acquired at ~uv_bin\\uv\.exe'
-if ($uvForcedFail) {
-    $uvPass = $true
-    Write-NdjsonRow ([ordered]@{
-        id      = 'self.dl.uv.fallback'
-        req     = 'REQ-003'
-        pass    = $true
-        desc    = 'uv fallback URL tried and uv binary acquired after fallback'
-        details = [ordered]@{ skip = $true; reason = 'HP_TEST_FORCE_UV_FAIL'; uvForcedFail = $true }
-    })
-} else {
-    $uvPass = $uvFallbackTried -and $uvAcquired
-    Write-NdjsonRow ([ordered]@{
-        id      = 'self.dl.uv.fallback'
-        req     = 'REQ-003'
-        pass    = $uvPass
-        desc    = 'uv fallback URL tried and uv binary acquired after fallback'
-        details = [ordered]@{
-            fallbackTried = $uvFallbackTried
-            uvAcquired    = $uvAcquired
-            setupLog      = $setupLogPath
-        }
-    })
-}
-
 
 if (-not $condaPass -or -not $uvPass) { exit 1 }
 exit 0


### PR DESCRIPTION
## Summary

- Adds a dedicated non-gating `uv-dl-fallback` lane to `batch-check.yml` that sets `HP_TEST_UV_DL_FALLBACK=1`, causing `run_setup.bat` to replace the primary uv download URL with an invalid URL so the fallback pinned URL is genuinely exercised in CI.
- Rewrites `tests/selfapps_dl_fallback.ps1` to remove a duplicate uv-check block (lines 65-94 and 96-125 were identical) and add explicit lane awareness: conda fallback is a real test when `HP_TEST_CONDA_DL_FALLBACK=1` (justme-test); uv fallback is a real test when `HP_TEST_FORCE_UV_FAIL` is NOT set (uv-dl-fallback). Each row now emits `skip=true` appropriately in the other lane.
- Closes the "uv DL fallback CI coverage" Active Backlog item from CLAUDE.md; updates `docs/agent-ndjson.md` with per-lane row documentation, `docs/agent-interconnect.md` with the new lane entry in the lanes table.

## Test plan

- [ ] uv-dl-fallback lane CI job completes (non-gating, `continue-on-error: true`)
- [ ] `self.dl.uv.fallback` row appears on diagnostics site with `pass=true` (not `skip=true`) for uv-dl-fallback lane
- [ ] `self.dl.conda.fallback` row appears with `skip=true` in uv-dl-fallback lane (conda not exercised there)
- [ ] justme-test lane unchanged: `self.dl.conda.fallback` pass=true, `self.dl.uv.fallback` skip=true
- [ ] All other lanes unaffected (real, cache, conda-full, contract-uv*)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018uiqtwJaAoUVSyLJiqKFsW

---
_Generated by [Claude Code](https://claude.ai/code/session_018uiqtwJaAoUVSyLJiqKFsW)_