### PR TITLE
test: strengthen progress-message validation with ordering checks and warnfix progress line

### DIFF
--- a/run_setup.bat
+++ b/run_setup.bat
@@ -2209,6 +2209,7 @@ if "%HP_ENV_MODE%"=="system" (
         )
       )
       if exist "~warnfix_repair_failed.flag" call :log "[WARN] One or more repair attempts failed"
+      call :log "[INFO] Rebuilding standalone executable after warnfix -- this may take a minute or two..."
       "%HP_PY%" -m PyInstaller -y --onefile --clean --log-level WARN %HP_PYI_EXPAT% --name "%ENVNAME%" "%HP_ENTRY%" >> "%LOG%" 2>&1
       call :log "[REPAIR] rebuild complete after warnfix."
       rem REQ-009/REQ-005.10 (slice 1: detect only): flag when this provider could not

--- a/tests/harness.ps1
+++ b/tests/harness.ps1
@@ -361,10 +361,14 @@ $hasProbeDeferred = $probeAfterUv -and $probeGuard
 Write-Result 'batch.conda.probe.deferred' 'Miniconda URL probe deferred to after uv detection (HP_UV_PROVIDING_PYTHON guard present; probe call appears after UV_PYTHON_PREFERENCE)' $hasProbeDeferred @{ probeAfterUv = $probeAfterUv; probeGuard = $probeGuard }
 # derived requirement: operations taking more than ~5s must emit a user-facing progress
 # message before the silent work begins so the script never appears to hang.
-$condaCreateProgress = $AllText.Contains('[INFO] Creating Python environment')
-Write-Result 'batch.progress.conda_create' "Progress message before conda create: user sees 'Creating Python environment' before the slow conda env create step" $condaCreateProgress @{}
-$pyiProgress = $AllText.Contains('[INFO] Building standalone executable')
-Write-Result 'batch.progress.pyi_build' "Progress message before PyInstaller build: user sees 'Building standalone executable' before the slow install+build step" $pyiProgress @{}
+$condaMsgPos  = $AllText.IndexOf('[INFO] Creating Python environment')
+$condaCallPos = $AllText.IndexOf('create -y -n "%ENVNAME%"')
+$condaCreateProgress = ($condaMsgPos -ge 0) -and ($condaCallPos -ge 0) -and ($condaMsgPos -lt $condaCallPos)
+Write-Result 'batch.progress.conda_create' "Progress message before conda create: user sees 'Creating Python environment' before the slow conda env create step" $condaCreateProgress @{ msgIdx = $condaMsgPos; opIdx = $condaCallPos; ordered = $condaCreateProgress }
+$pyiMsgPos  = $AllText.IndexOf('[INFO] Building standalone executable')
+$pyiCallPos = $AllText.IndexOf('-m PyInstaller -y --onefile')
+$pyiProgress = ($pyiMsgPos -ge 0) -and ($pyiCallPos -ge 0) -and ($pyiMsgPos -lt $pyiCallPos)
+Write-Result 'batch.progress.pyi_build' "Progress message before PyInstaller build: user sees 'Building standalone executable' before the slow install+build step" $pyiProgress @{ msgIdx = $pyiMsgPos; opIdx = $pyiCallPos; ordered = $pyiProgress }
 $results = Get-Content -LiteralPath $ResultsPath -Encoding ASCII | ForEach-Object { $_ | ConvertFrom-Json }
 $fail = @($results | Where-Object { -not $_.pass })
 $pass = @($results | Where-Object { $_.pass })

--- a/tests/harness.ps1
+++ b/tests/harness.ps1
@@ -365,10 +365,14 @@ $condaMsgPos  = $AllText.IndexOf('[INFO] Creating Python environment')
 $condaCallPos = $AllText.IndexOf('create -y -n "%ENVNAME%"')
 $condaCreateProgress = ($condaMsgPos -ge 0) -and ($condaCallPos -ge 0) -and ($condaMsgPos -lt $condaCallPos)
 Write-Result 'batch.progress.conda_create' "Progress message before conda create: user sees 'Creating Python environment' before the slow conda env create step" $condaCreateProgress @{ msgIdx = $condaMsgPos; opIdx = $condaCallPos; ordered = $condaCreateProgress }
-$pyiMsgPos  = $AllText.IndexOf('[INFO] Building standalone executable')
-$pyiCallPos = $AllText.IndexOf('-m PyInstaller -y --onefile')
-$pyiProgress = ($pyiMsgPos -ge 0) -and ($pyiCallPos -ge 0) -and ($pyiMsgPos -lt $pyiCallPos)
-Write-Result 'batch.progress.pyi_build' "Progress message before PyInstaller build: user sees 'Building standalone executable' before the slow install+build step" $pyiProgress @{ msgIdx = $pyiMsgPos; opIdx = $pyiCallPos; ordered = $pyiProgress }
+$pyiMsgPos      = $AllText.IndexOf('[INFO] Building standalone executable')
+$pyiCallPos     = $AllText.IndexOf('-m PyInstaller -y --onefile')
+$pyiOrdered     = ($pyiMsgPos -ge 0) -and ($pyiCallPos -ge 0) -and ($pyiMsgPos -lt $pyiCallPos)
+$warnfixMsgPos  = $AllText.IndexOf('[INFO] Rebuilding standalone executable after warnfix')
+$warnfixCallPos = $AllText.IndexOf('-m PyInstaller -y --onefile', ($pyiCallPos + 1))
+$warnfixOrdered = ($warnfixMsgPos -ge 0) -and ($warnfixCallPos -ge 0) -and ($warnfixMsgPos -lt $warnfixCallPos)
+$pyiProgress = $pyiOrdered -and $warnfixOrdered
+Write-Result 'batch.progress.pyi_build' "Progress message before PyInstaller build: user sees 'Building standalone executable' before the slow install+build step; warnfix rebuild also has its own progress message" $pyiProgress @{ msgIdx = $pyiMsgPos; opIdx = $pyiCallPos; ordered = $pyiOrdered; warnfixMsgIdx = $warnfixMsgPos; warnfixOpIdx = $warnfixCallPos; warnfixOrdered = $warnfixOrdered }
 $results = Get-Content -LiteralPath $ResultsPath -Encoding ASCII | ForEach-Object { $_ | ConvertFrom-Json }
 $fail = @($results | Where-Object { -not $_.pass })
 $pass = @($results | Where-Object { $_.pass })


### PR DESCRIPTION
## Summary

- `tests/harness.ps1`: replaces `Contains()`-based presence checks for `batch.progress.conda_create` and `batch.progress.pyi_build` with `IndexOf()`-based ordering checks (same pattern as the adjacent `batch.conda.probe.deferred` check) — harness now fails if either progress message is moved below its associated long-running operation
- `tests/harness.ps1`: populates `Write-Result` details with `msgIdx`/`opIdx`/`ordered` instead of empty `@{}` so CI failures include actionable ordering diagnostics
- `run_setup.bat`: emits an `[INFO]` progress message immediately before the warnfix PyInstaller rebuild (the second silent `PyInstaller -y --onefile` invocation) so users see activity during that pass

No NDJSON rows added or removed. No existing output wording changed. No unrelated code touched.

## Test plan

- [ ] `batch.progress.conda_create` fails if `[INFO] Creating Python environment` is moved below `create -y -n "%ENVNAME%"` in `run_setup.bat`
- [ ] `batch.progress.pyi_build` fails if `[INFO] Building standalone executable` is moved below `-m PyInstaller -y --onefile` in `run_setup.bat`
- [ ] CI failure details include `msgIdx`, `opIdx`, `ordered` fields instead of an empty object
- [ ] Warnfix rebuild path prints `[INFO] Rebuilding standalone executable after warnfix` before the second PyInstaller invocation
- [ ] Sanity checks pass: `python -m compileall -q .`, `python -m pyflakes .`, `python tools/check_delimiters.py run_setup.bat`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HTn91KR3v5CgiLBUcJYGV3

---
_Generated by [Claude Code](https://claude.ai/code/session_01HTn91KR3v5CgiLBUcJYGV3)_