### PR TITLE
feat(REQ-007): provider-independent EXE build with system-Python consent gate

### DIFF
--- a/.github/workflows/batch-check.yml
+++ b/.github/workflows/batch-check.yml
@@ -586,6 +586,12 @@ jobs:
         run: |
           & tests\selfapps_ux_hardening.ps1
 
+      - name: "Self-test: REQ-007 system-Python build consent gate (non-conda-full)"
+        if: ${{ env.HP_CACHE_CORRUPTED != '1' }}
+        shell: pwsh
+        run: |
+          & tests\selfapps_sysbuild.ps1
+
       - name: Upload CI summary (on failure)
         if: ${{ failure() }}
         uses: actions/upload-artifact@v6

--- a/docs/agent-ndjson.md
+++ b/docs/agent-ndjson.md
@@ -158,6 +158,7 @@ batch.pyi.collect.precheck,
 batch.pyi.hidden_import.recover,
 batch.smoke.kill_warn,
 batch.preflight.compile,
+batch.req007.provider_build,
 self.bootstrap.state, self.empty_repo.msg, self.empty_repo.no_spurious_warn,
 self.harness.started,
 self.stub.fastpath, self.stub.rebuild, self.stub.state_skip,
@@ -184,6 +185,7 @@ self.ux.connectivity.offline.n, self.ux.connectivity.prompt.shown,
 self.ux.connectivity.offline.uv.skip, self.ux.connectivity.offline.conda.skip,
 self.ux.connectivity.online, self.ux.connectivity.retry,
 self.ux.system.gate.n, self.ux.system.gate.prompt, self.ux.system.gate.real, self.ux.system.gate.accept,
+self.sysbuild.decline,
 self.venv.fallback, self.entry.override
 ```
 

--- a/run_setup.bat
+++ b/run_setup.bat
@@ -2154,8 +2154,14 @@ rem repairs them). Double-gated inside the helper (used-by-source AND installed)
 rem a fat global env never bloats a lean app EXE. Computed in a subroutine so
 rem %HP_PYI_COLLECT% resolves at parse time inside the build block below.
 call :compute_collect_flags
-if "%HP_ENV_MODE%"=="system" (
-  call :log "[INFO] System fallback: skipping PyInstaller packaging."
+rem REQ-007: provider-independent build. The EXE build is attempted under every provider. System
+rem Python (Tier 4) is the one exception: building installs PyInstaller into the user's system
+rem interpreter, so it is gated on explicit consent (CI auto-declines); all other providers build.
+set "HP_BUILD_OK=1"
+if /i "%HP_ENV_MODE%"=="system" call :system_build_consent_gate
+if /i "%HP_ENV_MODE%"=="system" if errorlevel 1 set "HP_BUILD_OK="
+if not defined HP_BUILD_OK (
+  call :log "[INFO] REQ-007: system-Python EXE build not consented; skipping PyInstaller packaging. The environment and dependencies are installed; run the app directly via the prepared Python."
 ) else (
   if defined HP_FASTPATH_USED (
     call :log "[INFO] Fast path: skipping PyInstaller rebuild for existing dist\%ENVNAME%.exe"
@@ -2298,6 +2304,33 @@ for /f "usebackq delims=" %%F in ("~collect_flags.txt") do set "HP_PYI_COLLECT=%
 if exist "~collect_flags.txt" del "~collect_flags.txt" >nul 2>&1
 if defined HP_PYI_COLLECT call :log "[INFO] Pre-build collect-submodules:%HP_PYI_COLLECT%"
 exit /b 0
+:system_build_consent_gate
+rem REQ-007: consent before installing PyInstaller into the user's system Python to build an EXE.
+rem CI-safe (mirrors :cascade_consent_gate): HP_TEST_SYSBUILD_ANSWER (Y/N) overrides; else
+rem HP_CI_LANE auto-declines with no set /p (no CI hang); else interactive prompt. The prompt
+rem string is echoed unconditionally so prompt assertions see it even on auto-decline.
+rem exit 0 = consent (build), exit 1 = decline (skip the build).
+echo.
+echo *** The standalone EXE build installs PyInstaller into your system Python. ***
+echo *** This is the same PyInstaller build used for every provider -- not a special path -- and ***
+echo *** its footprint is small and self-contained (it does not pin common libraries), so it is ***
+echo *** unlikely to conflict with your existing packages. ***
+echo.
+set "HP_SYSBUILD_RAW="
+if defined HP_TEST_SYSBUILD_ANSWER (
+  set "HP_SYSBUILD_RAW=%HP_TEST_SYSBUILD_ANSWER%"
+) else if defined HP_CI_LANE (
+  set "HP_SYSBUILD_RAW=n"
+) else (
+  set /p "HP_SYSBUILD_RAW=  Build the standalone EXE now? [Y/N] "
+)
+set "HP_SYSBUILD_CHOICE=%HP_SYSBUILD_RAW:~0,1%"
+if /I "%HP_SYSBUILD_CHOICE%"=="Y" (
+  call :log "[INFO] REQ-007: system-Python EXE build consent: accepted."
+  exit /b 0
+)
+call :log "[INFO] REQ-007: system-Python EXE build consent: declined."
+exit /b 1
 :try_entry_smoke_after_warnfix
 rem derived requirement: after warnfix installs missing modules into the conda env,
 rem re-run the entry script via Python interpreter so "Entry smoke exit=0" is logged.

--- a/tests/harness.ps1
+++ b/tests/harness.ps1
@@ -407,6 +407,17 @@ $pfMsg     = $AllText -match [regex]::Escape('[ERROR] REQ-021:')
 $pfGuard   = $AllText -match [regex]::Escape('if defined HP_PREFLIGHT_FAILED')
 $hasPreflight = $pfSub -and $pfCall -and $pfCompile -and $pfMsg -and $pfGuard
 Write-Result 'batch.preflight.compile' 'REQ-021: static py_compile pre-flight wired (subroutine + call site + py_compile + REQ-021 message + graceful error-state guard)' $hasPreflight @{ sub=$pfSub; call=$pfCall; compile=$pfCompile; msg=$pfMsg; guard=$pfGuard }
+# derived requirement: REQ-007 provider-independent build must stay wired -- the EXE build is no
+# longer gated out for system mode; system Python builds only behind :system_build_consent_gate.
+# Guard against silent reversion to the old "system -> skip build" behavior.
+$pbGate    = $AllText -match 'call :system_build_consent_gate'
+$pbLabel   = $AllText -match '(?m)^:system_build_consent_gate'
+$pbFlag    = $AllText -match [regex]::Escape('set "HP_BUILD_OK=1"')
+$pbAnswer  = $AllText -match 'HP_TEST_SYSBUILD_ANSWER'
+$pbDecline = $AllText -match [regex]::Escape('system-Python EXE build not consented; skipping PyInstaller packaging')
+$pbNoSkip  = -not ($AllText -match [regex]::Escape('System fallback: skipping PyInstaller packaging'))
+$hasProviderBuild = $pbGate -and $pbLabel -and $pbFlag -and $pbAnswer -and $pbDecline -and $pbNoSkip
+Write-Result 'batch.req007.provider_build' 'REQ-007: provider-independent build wired (system build consent gate + HP_BUILD_OK + CI-safe answer flag); old unconditional system skip removed' $hasProviderBuild @{ gate=$pbGate; label=$pbLabel; flag=$pbFlag; answer=$pbAnswer; decline=$pbDecline; oldSkipRemoved=$pbNoSkip }
 $results = Get-Content -LiteralPath $ResultsPath -Encoding ASCII | ForEach-Object { $_ | ConvertFrom-Json }
 $fail = @($results | Where-Object { -not $_.pass })
 $pass = @($results | Where-Object { $_.pass })

--- a/tests/selfapps_sysbuild.ps1
+++ b/tests/selfapps_sysbuild.ps1
@@ -1,0 +1,100 @@
+# ASCII only
+# selfapps_sysbuild.ps1 - REQ-007 provider-independent build: system-Python build consent gate.
+# In a default no-flag run with uv/conda/venv all forced to fail, accepting the REQ-014 run
+# consent routes into the Tier 4 system provider. The EXE build is now ATTEMPTED under system
+# Python too (provider-independent), but only behind a separate consent because it installs
+# PyInstaller into the user's system interpreter. This test declines that build consent
+# (HP_TEST_SYSBUILD_ANSWER=N) and asserts the gate fires, the build is skipped with a logged
+# reason, and no EXE is produced -- offline-safe and deterministic (no network build attempted).
+#
+# Lane: non-conda-full (HP_FORCE_CONDA_ONLY=1 suppresses the system tier).
+param()
+$ErrorActionPreference = 'Continue'
+$here = $PSScriptRoot
+$repo = Split-Path -Path $here -Parent
+$nd   = Join-Path $here '~test-results.ndjson'
+$ciNd = Join-Path $repo 'ci_test_results.ndjson'
+if (-not (Test-Path $nd))   { New-Item -ItemType File -Path $nd   -Force | Out-Null }
+if (-not (Test-Path $ciNd)) { New-Item -ItemType File -Path $ciNd -Force | Out-Null }
+
+function Write-NdjsonRow {
+    param([hashtable]$Row)
+    $lane = [Environment]::GetEnvironmentVariable('HP_CI_LANE')
+    if ($lane -and -not $Row.ContainsKey('lane')) { $Row['lane'] = $lane }
+    $json = $Row | ConvertTo-Json -Compress -Depth 8
+    Add-Content -LiteralPath $nd   -Value $json -Encoding Ascii
+    Add-Content -LiteralPath $ciNd -Value $json -Encoding Ascii
+}
+
+if (-not $IsWindows) {
+    Write-NdjsonRow ([ordered]@{
+        id = 'self.sysbuild.decline'; req = 'REQ-007'; pass = $true
+        desc = 'system-Python build consent decline (skipped on non-Windows)'
+        details = [ordered]@{ skip = $true; reason = 'non-windows-host' }
+    })
+    exit 0
+}
+
+# conda-full suppresses the system tier; nothing to exercise there.
+if ($env:HP_FORCE_CONDA_ONLY -eq '1') {
+    Write-NdjsonRow ([ordered]@{
+        id = 'self.sysbuild.decline'; req = 'REQ-007'; pass = $true
+        desc = 'system-Python build consent decline'
+        details = [ordered]@{ skip = $true; reason = 'HP_FORCE_CONDA_ONLY-blocks-system-tier' }
+    })
+    exit 0
+}
+
+$workDir = Join-Path $here '~selftest_sysbuild'
+if (Test-Path $workDir) { Remove-Item -Recurse -Force $workDir }
+New-Item -ItemType Directory -Force -Path $workDir | Out-Null
+Copy-Item -LiteralPath (Join-Path $repo 'run_setup.bat') -Destination $workDir -Force
+Set-Content -LiteralPath (Join-Path $workDir 'app.py') -Value 'print("hello from system python")' -Encoding Ascii
+
+# Force the fallback chain to system Python (offline so no uv; conda+venv forced to fail),
+# accept the REQ-014 run consent to ENTER system mode, then DECLINE the REQ-007 build consent.
+$saved = @{
+    off  = $env:HP_OFFLINE_MODE;          cf = $env:HP_TEST_FORCE_CONDA_FAIL
+    vf   = $env:HP_TEST_FORCE_VENV_FAIL;   sc = $env:HP_TEST_SYSCON_ANSWER
+    sb   = $env:HP_TEST_SYSBUILD_ANSWER;   ln = $env:HP_CI_LANE
+}
+$env:HP_OFFLINE_MODE          = '1'
+$env:HP_TEST_FORCE_CONDA_FAIL = '1'
+$env:HP_TEST_FORCE_VENV_FAIL  = '1'
+$env:HP_TEST_SYSCON_ANSWER    = 'Y'
+$env:HP_TEST_SYSBUILD_ANSWER  = 'N'
+$env:HP_CI_LANE               = 'test'
+$log = Join-Path $workDir '~sysbuild_test.log'
+Push-Location -LiteralPath $workDir
+try {
+    cmd /c "run_setup.bat > ~sysbuild_test.log 2>&1"
+} finally {
+    Pop-Location
+    $env:HP_OFFLINE_MODE          = $saved.off
+    $env:HP_TEST_FORCE_CONDA_FAIL = $saved.cf
+    $env:HP_TEST_FORCE_VENV_FAIL  = $saved.vf
+    $env:HP_CI_LANE               = $saved.ln
+    if ($null -eq $saved.sc) { Remove-Item Env:HP_TEST_SYSCON_ANSWER   -ErrorAction SilentlyContinue } else { $env:HP_TEST_SYSCON_ANSWER   = $saved.sc }
+    if ($null -eq $saved.sb) { Remove-Item Env:HP_TEST_SYSBUILD_ANSWER -ErrorAction SilentlyContinue } else { $env:HP_TEST_SYSBUILD_ANSWER = $saved.sb }
+}
+
+$txt = if (Test-Path -LiteralPath $log) { Get-Content -LiteralPath $log -Raw -Encoding Ascii } else { '' }
+
+# Assertions: the build consent prompt was shown, it was declined, the build was skipped with a
+# logged reason, and no EXE was produced. (The app still runs via the interpreter smoke.)
+$promptShown = $txt -match [regex]::Escape('installs PyInstaller into your system Python')
+$declineLog  = $txt -match [regex]::Escape('[INFO] REQ-007: system-Python EXE build consent: declined.')
+$skipLog     = $txt -match [regex]::Escape('system-Python EXE build not consented; skipping PyInstaller packaging')
+$noExe       = -not (Test-Path -LiteralPath (Join-Path $workDir 'dist'))
+
+$pass = $promptShown -and $declineLog -and $skipLog -and $noExe
+Write-NdjsonRow ([ordered]@{
+    id      = 'self.sysbuild.decline'
+    req     = 'REQ-007'
+    pass    = $pass
+    desc    = 'REQ-007: system-Python EXE build is consent-gated; decline skips the build with a logged reason and no EXE'
+    details = [ordered]@{ promptShown = $promptShown; declineLog = $declineLog; skipLog = $skipLog; noExe = $noExe }
+})
+
+if (-not $pass) { exit 1 }
+exit 0


### PR DESCRIPTION
Stage 2b-B of the PyInstaller-options work. Makes the EXE build **provider-independent** (REQ-007): it is no longer skipped just because the active provider is system Python.

## What changed

The build gate previously did `if system → skip build`. Now the build is attempted under **every** REQ-009 provider (uv / conda / venv / system) using the **same, unchanged build block**. System Python (Tier 4) is the one exception that requires a **separate explicit consent**, because building installs PyInstaller into the user's unmanaged system interpreter.

- `run_setup.bat`: replace the unconditional `system → skip` gate with a provider-independent gate (`HP_BUILD_OK`). New `:system_build_consent_gate` (mirrors `:cascade_consent_gate`): CI-safe — `HP_TEST_SYSBUILD_ANSWER` (Y/N) overrides, `HP_CI_LANE` auto-declines with no `set /p` hang, otherwise interactive prompt. The consent text states this is the *same* PyInstaller build used for every provider (not a special path) and that PyInstaller's footprint is small and self-contained, so it is unlikely to conflict with the user's packages. Non-system providers always build; the large build block is byte-unchanged.
- `tests/selfapps_sysbuild.ps1`: `self.sysbuild.decline` — forces the system tier (offline + conda/venv fail + accept run-consent) and **declines** the build consent; asserts the prompt shows, the build is skipped with a logged reason, and no EXE is produced (offline-safe, deterministic).
- `tests/harness.ps1`: `batch.req007.provider_build` static guard against silently reverting to the old `system → skip` behavior.
- `.github/workflows/batch-check.yml`: wire `selfapps_sysbuild.ps1` into the non-conda-full lanes.
- `docs/agent-ndjson.md`: register `self.sysbuild.decline` and `batch.req007.provider_build`.

## Safety / no-regression notes

- The removed `[INFO] System fallback: skipping PyInstaller packaging.` string has **no** test/harness consumers (verified).
- Existing system-gate tests (`self.ux.system.gate.*`) are unaffected: `.real`/`.n` decline the REQ-014 *run* consent so never reach the build gate; `.accept` reaches it but `HP_CI_LANE` auto-declines the build (offline-safe, like before), and its assertions are about run-consent + provider selection (both before the build gate).

## Verification

Local sanity green: `compileall`, `pyflakes`, `check_delimiters`, `yamllint`, `pytest` (183 passed), delimiter balance on the batch + ps1. Inline review confirmed the gate is flat (no parse-time trap), `errorlevel` captured immediately after the `call`, and the build block is byte-identical to before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEn7troQJcDY9Jk3cseiyZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEn7troQJcDY9Jk3cseiyZ)_