### PR TITLE
feat(REQ-018): fail-fast probe for the two untimed user-code launches (Slice 2b-C)

### DIFF
--- a/.github/workflows/batch-check.yml
+++ b/.github/workflows/batch-check.yml
@@ -438,6 +438,12 @@ jobs:
         run: |
           & tests\selfapps_exefastpath.ps1
 
+      - name: "Self-test: fail-fast probe -- fast-failure discard and alive-past-probe no-discard (real/conda-full only)"
+        if: ${{ matrix.mode == 'real' || matrix.mode == 'conda-full' }}
+        shell: pwsh
+        run: |
+          & tests\selfapps_failfast_probe.ps1
+
       - name: "Self-test: super-user skip hooks (conda-full only)"
         if: ${{ matrix.mode == 'conda-full' }}
         shell: pwsh

--- a/docs/agent-interconnect.md
+++ b/docs/agent-interconnect.md
@@ -135,7 +135,7 @@ produce different log lines. Future agents must not confuse them:
 
 | Fast path | Trigger | Log line | Lane |
 |-----------|---------|----------|------|
-| EXE fast path (`:try_fast_exe`) | `dist\<ENVNAME>.exe` exists AND `HP_FAST_CHECK` token = "fresh" | `[INFO] Fast path: reusing dist\<ENVNAME>.exe` | All lanes |
+| EXE fast path (`:try_fast_exe`) | `dist\<ENVNAME>.exe` exists AND `HP_FAST_CHECK` token = "fresh" | `[INFO] Fast path: reusing dist\<ENVNAME>.exe` (non-interactive/CI -- `HP_INTERACTIVE_RUN` unset) or `[INFO] Launching your program now via the cached standalone EXE (PyInstaller build): dist\<ENVNAME>.exe` (interactive -- see "Fail-fast probe (Slice 2b-C)" below) | All lanes |
 | Env-state fast path (`:env_state_fast_path`) | `~env.state.json` valid, conda env python.exe present | `[INFO] Env-state fast path: reusing conda env <ENVNAME>.` | conda mode only; skipped when HP_UV_PROVIDING_PYTHON=1 |
 | uv venv reuse | `.uv_env\Scripts\python.exe` exists AND `import pip` succeeds | `[INFO] uv: reusing existing .uv_env` | uv mode only |
 
@@ -145,9 +145,12 @@ The env-state check (line 507) and uv venv reuse (line 544) are therefore only r
 the EXE fast path does NOT fire (first run, or sources changed).
 
 **`self.fastpath` test** (`selfapps_envsmoke.ps1` second run): matches `'Fast path: reusing'`
-which appears in the EXE fast path log line. This works in ALL lanes (uv and conda) because
-the EXE fast path is completely provider-independent. The test correctly validates the EXE
-fast path, not the env-state or uv venv fast path.
+which appears in the EXE fast path log line ONLY on the non-interactive branch (real CI always
+sets `HP_CI_LANE` at the job level, so this holds in every CI lane regardless of whether the
+individual test file pins it locally -- see the "Accepted gap" entry in
+`docs/agent-lessons-learned.md`). This works in ALL lanes (uv and conda) because the EXE fast
+path is completely provider-independent. The test correctly validates the EXE fast path, not
+the env-state or uv venv fast path.
 
 ### ~dependency_installed.txt: pip freeze output and its consumers
 
@@ -398,8 +401,97 @@ strings and run artifacts:
   `:run_exe_smokerun` exits at the skip check BEFORE the vocab line, and
   `:verify_no_exe_interpreter` exits on `HP_SKIP_ENTRY_SMOKE`, so `'Running entry script smoke test'`
   is never emitted -> `$noUserCode` holds.
-- **Deferred to 2b-C (unified run-model):** run-timing / fail-fast probe / interactive checkpoint
-  for BOTH the no-EXE interpreter run AND the fast-path EXE run (lines 243/2077, still untimed). The
-  `~run.out.txt` capture happens on the INITIAL EXE smoke run, before any hidden-import recovery, so
+- **Shipped in 2b-C: fail-fast probe for the two previously-untimed runs** (`:try_fast_exe`'s cached
+  EXE reuse and `:verify_no_exe_interpreter`). See the dedicated "Fail-fast probe (Slice 2b-C)"
+  section below for the full mechanism, state variables, and the interconnects that touching either
+  call site must respect (CWD-per-call-site, the `HP_FASTPATH_USED`/`HP_SMOKE_RC` decoupling fix,
+  and the shared `:run_failfast_probe` subroutine both now route through).
+- The `~run.out.txt` capture happens on the INITIAL EXE smoke run, before any hidden-import recovery, so
   after a recovery rebuild it reflects the pre-recovery run (diagnostic-only; token tests do not hit
-  recovery).
+  recovery). The fail-fast probe's own capture (interactive branch of `:try_fast_exe` /
+  `:verify_no_exe_interpreter`) is a SEPARATE write of the same two files, pre-truncated at the start
+  of `:run_failfast_probe` -- see the dedicated section below for why that pre-truncation matters.
+
+## Fail-fast probe (Slice 2b-C): shared state machine for the two untimed launch points
+
+`:try_fast_exe` (cached EXE reuse) and `:verify_no_exe_interpreter` (no-EXE interpreter run) both
+launch user code with NO timeout at all in CI/automation (unchanged, plain `cmd` redirect). For a
+real interactive double-click user (`HP_INTERACTIVE_RUN` set -- see `:compute_interactive_run`,
+mirrors `:pick_entry_interactive`'s `NOINPUT`/`HP_NONINTERACTIVE`/`HP_CI_LANE` signals, plus
+`HP_TEST_FORCE_INTERACTIVE_PROBE=1` to force the branch under `HP_CI_LANE` for CI coverage), both
+call the shared `:run_failfast_probe` subroutine instead, which launches via
+`~failfast_probe.ps1` (`HP_FAILFAST_PROBE`, a base64 embedded helper emitted through the existing
+`:emit_from_base64` mechanism -- NOT an inline `-Command` one-liner, deliberately: the two-stage
+wait needs interpolated strings, and `.ps1` file content sidesteps every cmd.exe quote-nesting
+hazard an inline `-Command "..."` string would hit here). The helper does `WaitForExit(HP_FAILFAST_PROBE_MS)`
+(default 5000ms, distinct from the unrelated ~30s hard-kill cap used by `:run_exe_smokerun`/
+`:hidden_import_recover` -- that is a force-kill ceiling for the fresh-build verification run, the
+ONLY run this bootstrapper ever kills; this probe window is purely a classification checkpoint,
+never a ceiling) then, if the process is still running, a SECOND, UNBOUNDED `WaitForExit()` with no
+`Kill()` call anywhere.
+
+**Touch either call site, must understand the other, plus the top-of-file success gate:**
+- Both callers set `HP_PROBE_EXE` / `HP_PROBE_ARGS` (raw, UNQUOTED -- the helper quotes it via
+  `'"' + $rawArgs + '"'`, which only works correctly for a SINGLE path argument; do not repurpose
+  `HP_PROBE_ARGS` for a multi-token command line) / `HP_PROBE_CWD` before calling
+  `:run_failfast_probe <site>`. **CWD is preserved per call site exactly as before this slice**:
+  `:try_fast_exe` runs from the app root (`%CD%`, no `pushd dist`) and `:verify_no_exe_interpreter`
+  also runs from the app root -- neither adopts `:run_exe_smokerun`'s `pushd dist` CWD (load-bearing
+  for `selfapps_exedata_fail`'s CWD-relative `config.json` check; see the paragraph above). If you
+  ever unify these CWDs, re-verify that xfail test.
+- `:run_failfast_probe` always leaves `HP_SMOKE_RC` set to the true final exit code (whether the
+  process exited fast or only after the unbounded continuation) and `HP_PROBE_EXCEEDED` set (`1`)
+  iff the probe window was crossed. `:try_fast_exe`'s discard-and-rebuild block is gated on
+  `if not "%HP_SMOKE_RC%"=="0" if not defined HP_PROBE_EXCEEDED` -- once a process is classified
+  alive/healthy at the probe, a LATER non-zero exit is presumed to be the user's own program outcome
+  (not proof of a stale artifact) and the cached EXE is kept, never discarded.
+- **The silent-success bug this closed:** the top-of-file fast-path caller (`run_setup.bat`, near
+  the very top, before provider selection) used to gate its `goto :success` shortcut on
+  `HP_FASTPATH_USED` alone, with no check of the run's outcome -- harmless before this slice because
+  any non-zero `HP_SMOKE_RC` always cleared `HP_FASTPATH_USED` too (inside `:try_fast_exe`'s old
+  unconditional discard). Once the probe's "don't discard past the probe window" rule could leave
+  `HP_FASTPATH_USED` set through a real later failure, that same shortcut would have silently
+  reported full bootstrap success while hiding the failure. Fixed by computing
+  `HP_FASTPATH_RUN_FAILED` (true only when `HP_SMOKE_RC` is DEFINED and non-"0" -- empty/undefined
+  `HP_SMOKE_RC` still means "no real failure observed," e.g. the REQ-012
+  `HP_SKIP_EXE_SMOKERUN` skip-without-running case, which must still take the zero-friction path)
+  and branching the log message on it before `write_status`/`goto :success`; `HP_BOOTSTRAP_STATE`
+  stays `ok` either way (env/build genuinely succeeded; a runtime bug in the user's own code is not
+  something a rebuild could fix -- matches the "User-code exit-code semantics" item in
+  `CLAUDE.md`'s Active Backlog), but the console/log now always shows the true
+  `[STATUS] Run Status: ...` outcome first. This second call site was recomputed with the exact
+  same `HP_FASTPATH_RUN_FAILED` guard (see the next bullet).
+- **Both `:try_fast_exe` call sites now carry this guard, not just the top-of-file one.** The
+  second call site (inside `:run_entry_smoke`'s build gate, `if defined HP_FASTPATH_USED (...)`
+  just before the PyInstaller build block) recomputes `HP_FASTPATH_RUN_FAILED` fresh as its own
+  top-level statement and branches the same way. It is normally unreachable with a real failure
+  today -- any first-call success or post-probe-failure outcome already took `goto :success`
+  before this point -- but a future provider-cascade re-entry (`:after_env_mode_selection`) could
+  reach it with `HP_FASTPATH_USED` still set from a probe-classified alive-then-failed run, and
+  this closes that gap defensively rather than leaving a second, unguarded copy of the same logic.
+- **cmd.exe parse-time-expansion hazard, avoided via goto, not if/else, at both call sites.** An
+  earlier revision of this slice launched the process and read `set "HP_SMOKE_RC=%ERRORLEVEL%"`
+  (plus the immediate SUCCESS/FAILED branch) INSIDE the non-interactive `else ( ... )` clause of
+  the `if defined HP_INTERACTIVE_RUN (...) else (...)` dispatch. cmd.exe expands every `%VAR%` in
+  a parenthesized block ONCE, at parse time, using values from before the block started -- so
+  `%ERRORLEVEL%` (and every in-block `%HP_SMOKE_RC%` read) silently froze to whatever it was right
+  before the dispatch began (almost always `"0"`), meaning a genuinely broken cached EXE was NEVER
+  discarded in the legacy/CI branch. Both `:try_fast_exe` and `:verify_no_exe_interpreter` now use
+  `if defined HP_INTERACTIVE_RUN goto :<label>_probe` instead, so each branch's statements are
+  parsed and executed as fresh top-level lines -- see
+  `docs/agent-lessons-learned.md` "Provider-cascade dispatch is goto-based on purpose" for the same
+  pattern used elsewhere in this file, and do not reintroduce a parenthesized if/else around a
+  launch+`%ERRORLEVEL%`-capture sequence at either call site.
+- `:try_fast_exe`'s legacy (non-interactive) branch also gained a `[STATUS] Run Status:
+  SUCCESS/FAILED` line for parity (it previously never emitted `[STATUS]` telemetry at all, unlike
+  `:verify_no_exe_interpreter` and `:run_exe_smokerun`) -- purely additive, does not change any
+  branch/goto target, so it does not affect CI determinism for `self.fastpath` /
+  `self.exe.fastpath.graceful`.
+- NDJSON row `self.failfast.probe` (gated on `HP_NDJSON`, same convention as `self.exe.smokerun`)
+  carries `details.site` (`'fastpath'|'interpreter'`) so one schema covers both call sites.
+- Test coverage: `tests/selfapps_failfast_probe.ps1` (`self.failfast.probe.fastfail`,
+  `self.failfast.probe.alive`), forced via `HP_TEST_FORCE_INTERACTIVE_PROBE=1` under
+  `HP_CI_LANE=test` (mirrors the `HP_TEST_FORCE_PICKER` pattern) since CI is otherwise always
+  non-interactive. `tests/harness.ps1`'s `batch.failfast.probe` statically guards the interactivity
+  subroutine, the shared probe subroutine, the test override, the default probe window, the
+  `HP_PROBE_EXCEEDED` state var, and the decoupling fix.

--- a/docs/agent-lessons-learned.md
+++ b/docs/agent-lessons-learned.md
@@ -168,6 +168,23 @@ labels means each `set`/read happens on a freshly parsed line. **If you refactor
 into nested `( ... )` blocks, re-verify every `%VAR%` you read was not `set` earlier in the
 same block** -- prefer keeping the goto-dispatch shape.
 
+**Second confirmed instance (Slice 2b-C, `:try_fast_exe` / `:verify_no_exe_interpreter`):** an
+earlier revision of the fail-fast probe dispatch launched a process and read
+`set "HP_SMOKE_RC=%ERRORLEVEL%"` (plus the immediate SUCCESS/FAILED `[STATUS]` branch) INSIDE the
+non-interactive `else ( ... )` clause of an `if defined HP_INTERACTIVE_RUN (...) else (...)`
+block -- this is the exact same bug class as the drag-and-drop empty-filename bug and the cascade
+gotcha above, just with `%ERRORLEVEL%` as the frozen variable instead of `%MAIN_FILE%`. It froze
+silently (no error, no crash) to whatever the errorlevel was right before the dispatch began
+(almost always `"0"`, since the preceding line is usually a successful `set`), so a genuinely
+broken cached EXE was NEVER discarded via the non-interactive branch in CI. Fixed the same way as
+the cascade: `if defined HP_INTERACTIVE_RUN goto :<label>_probe` instead of a parenthesized
+if/else, so the launch + `%ERRORLEVEL%` capture + STATUS branch are all top-level lines, each
+parsed fresh. **Any time a diff wraps a previously-top-level "launch a process, read
+`%ERRORLEVEL%`" sequence inside a NEW `if (...) ( ... ) else ( ... )` block for ANY reason
+(feature-flagging, dispatch, refactor), stop and check whether the read is safe** -- this is easy
+to introduce by accident precisely because the surrounding lines look unchanged and the bug
+produces no error, only a silently wrong captured exit code.
+
 Two more cascade gotchas worth remembering:
 - `if defined HP_CASCADE_TRIED_UV` / `if not defined CONDA_BAT` are **runtime** checks (safe
   inside blocks); `%HP_CASCADE_TRIED_UV%` / `%CONDA_BAT%` are parse-time (not safe). The
@@ -400,3 +417,55 @@ on the latest managed CPython, but fallback paths can still hand them an older a
 interpreter. Target modern CPython, guard modern *stdlib features* with `try/except`, and
 keep the file's *syntax* parse-compatible with older interpreters (no `match`/`case`, no
 evaluated `X | Y` unions). See "Embedded-helper Python baseline" above.
+
+**PowerShell helpers apply too, and the choice of inline `-Command` vs. embedded `.ps1` file
+matters more than it looks (Slice 2b-C, `HP_FAILFAST_PROBE`):** `:run_exe_smokerun`'s inline
+`powershell -Command "..."` one-liners work because they carefully avoid ANY literal `"` character
+inside the command body (all internal PowerShell string literals use single quotes, and the final
+captured value is a bare expression like `$p.ExitCode`, never a double-quoted interpolated string).
+The fail-fast probe needed to build a properly-quoted single argument for
+`ProcessStartInfo.Arguments` (`$si.Arguments = '"' + $rawArgs + '"'`, so a script path containing
+spaces still parses as one argument) -- and the `'"'` literal (a single-quoted PowerShell string
+whose CONTENT is one double-quote character) is itself a literal `"` character sitting in the
+command text cmd.exe has to tokenize. **The root cause is any literal `"` appearing anywhere in
+the `-Command` body, not specifically interpolation** -- a literal `"` embedded inside an
+already-double-quoted `-Command "..."` argument breaks cmd.exe's naive quote-toggle tokenization
+of that argument (cmd does not understand PowerShell's quoting rules; it just flips an
+in-quotes/out-of-quotes flag on every literal `"` it sees, with no concept of nesting or of
+"this quote is inside a single-quoted PowerShell string"). String interpolation
+(`"$exceeded|$($p.ExitCode)"`) would trip the SAME hazard if used inline, since it also requires a
+double-quoted PowerShell string, but avoiding interpolation alone (e.g. via `+` concatenation)
+would NOT have been sufficient here -- the `Arguments` quoting step needed a literal `"` character
+regardless of interpolation vs. concatenation. **Fix: emit a standalone `.ps1` file via the
+existing `:emit_from_base64` mechanism (exactly like `HP_FAST_CHECK`/`~fast_check.ps1`) and invoke
+it with `-File` instead of `-Command`.** A real file has no cmd.exe quote-parsing exposure at all
+-- write normal, readable PowerShell inside it, quotes and interpolation both included freely.
+Rule of thumb: if an inline `-Command` one-liner would need ANY literal `"` character anywhere in
+its body (interpolation, nested quoting, here-strings, or quoting an argument for
+`ProcessStartInfo`), stop and make it a `.ps1` helper instead of trying to escape around it.
+
+**Fail-fast probe window vs. the ~30s hard-kill cap are unrelated numbers, do not conflate them:**
+`HP_FAILFAST_PROBE_MS` (default 5000ms, `:run_failfast_probe`) is a CLASSIFICATION checkpoint --
+how long to wait before deciding "this exited fast, treat a non-zero rc as a stale artifact" vs.
+"this is still running, treat it as the user's real program and never touch it again." The ~30s cap
+used by `:run_exe_smokerun`/`:hidden_import_recover` is a FORCE-KILL CEILING for the one run this
+bootstrapper is ever allowed to `Kill()` (the fresh-build verification run). The probe's second wait
+stage (`$p.WaitForExit()`, no argument) is genuinely unbounded and never kills anything -- raising or
+lowering the probe window only changes how quickly a broken cached EXE gets discarded+rebuilt, it
+never introduces a new kill point.
+
+**Accepted gap: most `selfapps_*.ps1` files do not locally pin `HP_CI_LANE`/`HP_NONINTERACTIVE`
+around their `run_setup.bat` invocations, so a LOCAL (non-CI) run of one that reaches the fast-path
+reuse or no-EXE interpreter dispatch point would take the new interactive fail-fast-probe branch
+instead of the plain/legacy branch.** This is a deliberate, low-priority trade-off, not an oversight:
+real CI always sets `HP_CI_LANE` at the GitHub Actions job level (`batch-check.yml`,
+`HP_CI_LANE: ${{ matrix.mode }}`), and every subprocess (including a PS test script's own
+`cmd /c run_setup.bat` child) inherits it automatically -- so CI determinism for `self.fastpath` /
+`self.exe.fastpath.graceful` / envsmoke's fast-path assertions is unaffected regardless of what any
+individual test file does. Only `tests/selfapps_sysbuild.ps1`, `tests/selfapps_ux_hardening.ps1`,
+and the new `tests/selfapps_failfast_probe.ps1` explicitly set `$env:HP_CI_LANE` locally (needed
+because those specifically drive consent gates / force the new branch on purpose). If a future
+agent wants full local-dev parity with CI for the remaining files, add the same
+save/set/restore-`HP_CI_LANE` pattern to whichever ones are found to actually reach the dispatch
+point (most single-build-run tests never reach it at all, since `:try_fast_exe` returns immediately
+when no cached EXE exists yet) -- but this is optional polish, not a correctness requirement.

--- a/docs/agent-ndjson.md
+++ b/docs/agent-ndjson.md
@@ -23,6 +23,7 @@ self.exe.build, self.exe.run,
 self.exe.smokerun.xfail, self.exe.smokerun.exedata.xfail, self.exe.smokerun.exedyn.xfail,
 self.exe.fastpath.graceful, self.skiphooks.combined,
 self.fastpath,
+self.failfast.probe.fastfail, self.failfast.probe.alive, self.failfast.probe,
 self.entry.entry1, self.entry.entryA, self.entry.entryB, self.entry.entryC, self.entry.entryD,
 self.entry.helper.invoke.absent, self.entry.results, self.entry.spaced-path, self.entry.picker,
 self.entry.req011.crossdir, self.entry.req011.sameDir, self.isolation.req010.pythonpath,
@@ -161,6 +162,7 @@ batch.preflight.compile,
 batch.req007.provider_build,
 batch.smoke.telemetry,
 batch.smoke.single_verify,
+batch.failfast.probe,
 self.bootstrap.state, self.empty_repo.msg, self.empty_repo.no_spurious_warn,
 self.harness.started,
 self.stub.fastpath, self.stub.rebuild, self.stub.state_skip,
@@ -200,6 +202,13 @@ self.venv.fallback, self.entry.override
 - Rows gated by `pyFileCount` (e.g. `entry.single.direct`) will be absent whenever the
   bootstrapper repo itself is the test target (pyFiles != 1 in the main repo).
 - Check the CI step log for `[INFO] ... skipped:` messages before assuming a test regressed.
+- `self.failfast.probe` (bare row, distinct from `self.failfast.probe.fastfail`/`.alive`) is
+  emitted inline by `run_setup.bat`'s `:run_failfast_probe`, gated on `HP_NDJSON`. The current CI
+  lane that forces the interactive branch (`HP_TEST_FORCE_INTERACTIVE_PROBE=1`, in
+  `selfapps_failfast_probe.ps1`) unsets or never populates `HP_NDJSON` for that sub-bootstrap, so
+  this row does not currently appear in a real CI artifact -- same situation as `self.exe.smokerun`
+  and other inline-emitted rows. It is registered above so its id is not mistaken for an
+  unexpected/typo'd addition if a future lane change makes it fire.
 
 **NDJSON files and who owns them:**
 - `tests/~test-results.ndjson` -- written by every `selfapps_*.ps1` test script during the

--- a/run_setup.bat
+++ b/run_setup.bat
@@ -177,6 +177,18 @@ set "HP_NIVISA_WAIT_SECS=%HP_NIVISA_WAIT_SECS%"
 rem HP_TEST_FORCE_CONDA_BULK_FAIL=1: simulate a non-transient conda bulk-install failure so the
 rem REQ-005.3 per-package fallback fires (CI branch coverage). Consumed once in :conda_bulk_install.
 set "HP_TEST_FORCE_CONDA_BULK_FAIL=%HP_TEST_FORCE_CONDA_BULK_FAIL%"
+rem HP_TEST_FORCE_INTERACTIVE_PROBE=1: CI-only; forces the fail-fast probe's interactive branch
+rem (:try_fast_exe / :verify_no_exe_interpreter) even under HP_CI_LANE, for deterministic branch
+rem coverage of the ALIVE_AT_PROBE state machine. Mirrors HP_TEST_FORCE_PICKER.
+set "HP_TEST_FORCE_INTERACTIVE_PROBE=%HP_TEST_FORCE_INTERACTIVE_PROBE%"
+rem HP_FAILFAST_PROBE_MS: the fail-fast probe's classification window (default 5000ms). This is
+rem NOT the same concept as the unrelated ~30s hard-kill cap used by :run_exe_smokerun /
+rem :hidden_import_recover -- that is a force-kill ceiling for the fresh-build verification run
+rem (the only run this bootstrapper ever kills). This probe window only decides how long to wait
+rem before treating a launched process as "still alive / healthy" rather than "failed fast"; once
+rem classified alive, the wait becomes unbounded and the process is never killed.
+set "HP_FAILFAST_PROBE_MS=%HP_FAILFAST_PROBE_MS%"
+if not defined HP_FAILFAST_PROBE_MS set "HP_FAILFAST_PROBE_MS=5000"
 
 rem derived requirement: CI's conda-only lane must surface conda regressions instead of masking them with opt-in fallbacks.
 if "%HP_FORCE_CONDA_ONLY%"=="1" (
@@ -231,6 +243,10 @@ if not "%~1"=="" if /i not "%~dp1"=="%~dp0" (
 set "HP_CONDA_PROBE_STATUS=skipped"
 set "HP_CONDA_PROBE_REASON=not-requested"
 
+rem Slice 2b-C: compute the shared interactivity determination once, before the very first
+rem :try_fast_exe call below, so both untimed user-code launch points dispatch consistently.
+call :compute_interactive_run
+
 rem --- Very top EXE fast path: reuse dist\%ENVNAME%.exe when sources are unchanged ---
 set "HP_FASTPATH_USED="
 rem REQ-016: start clean so an inherited env var can never trigger a false "EXE
@@ -239,12 +255,34 @@ set "HP_EXE_VERIFY_FAILED="
 rem REQ-012: HP_EXE_SKIPPED records that EXE verification was skipped by request
 rem (HP_SKIP_EXE_SMOKERUN) -- distinct from "failed" -- for the post-flight note.
 set "HP_EXE_SKIPPED="
+rem Slice 2b-C: start clean so an inherited HP_SMOKE_RC (e.g. from a parent shell/CI wrapper)
+rem can never be misread as "the just-attempted run failed" below -- :try_fast_exe's own
+rem REQ-012 HP_SKIP_EXE_SMOKERUN early-return leaves HP_SMOKE_RC untouched by design (no run
+rem happened), and the HP_FASTPATH_RUN_FAILED check right after this call relies on that
+rem meaning "empty", not "whatever happened to be inherited."
+set "HP_SMOKE_RC="
 if not "%PYCOUNT%"=="0" (
   call :try_fast_exe
 )
+rem Slice 2b-C: HP_FASTPATH_USED alone is no longer proof of a clean run -- the interactive
+rem fail-fast probe can leave it set even when the reused EXE later exited non-zero (it is
+rem classified alive/healthy at the probe and is never discarded/rebuilt for a later failure;
+rem see :try_fast_exe). Decouple "keep the cached EXE, skip the rebuild" from "declare full
+rem success" so that outcome is never silently swallowed: HP_SMOKE_RC is empty when the run
+rem never happened or was skipped by request (REQ-012, HP_EXE_SKIPPED) -- still the
+rem zero-friction path -- and is a real non-zero value only for a genuine post-probe failure.
+set "HP_FASTPATH_RUN_FAILED="
+if defined HP_SMOKE_RC if not "%HP_SMOKE_RC%"=="0" set "HP_FASTPATH_RUN_FAILED=1"
 if defined HP_FASTPATH_USED (
-  rem derived requirement: if the EXE fast path succeeds, treat bootstrap as complete without touching Conda/venv.
-  call :log "[INFO] Fast path: skipping PyInstaller rebuild for existing dist\%ENVNAME%.exe"
+  if defined HP_FASTPATH_RUN_FAILED (
+    rem :run_failfast_probe already logged "[STATUS] Run Status: FAILED (Exit Code: ...)"
+    rem for this exact run (it always fires before returning here) -- add only the extra
+    rem context, not a duplicate STATUS line.
+    call :log "[WARN] dist\%ENVNAME%.exe (standalone EXE, PyInstaller build) ran to completion and exited non-zero after passing the fail-fast probe; treated as your program's own result, not a rebuild trigger."
+  ) else (
+    rem derived requirement: if the EXE fast path succeeds, treat bootstrap as complete without touching Conda/venv.
+    call :log "[INFO] Fast path: skipping PyInstaller rebuild for existing dist\%ENVNAME%.exe"
+  )
   if /I "%HP_BOOTSTRAP_STATE%"=="ok" (
     call :write_status ok 0 %PYCOUNT%
   ) else (
@@ -252,6 +290,7 @@ if defined HP_FASTPATH_USED (
   )
   goto :success
 )
+set "HP_FASTPATH_RUN_FAILED="
 
 if "%PYCOUNT%"=="0" (
   rem derived requirement: CI observed the Miniconda probe firing before the
@@ -2040,6 +2079,87 @@ call :log "[BOOT] REQ-002: Entry selected: %HP_CRUMB%"
 rem If we also need an absolute path for execution, set HP_ENTRY elsewhere
 rem and keep the echo outside any ( ... ) block.
 exit /b 0
+:compute_interactive_run
+rem Slice 2b-C: single interactivity determination shared by the fail-fast probe at both
+rem untimed user-code launch points (:try_fast_exe, :verify_no_exe_interpreter). Mirrors
+rem :pick_entry_interactive's three non-interactivity signals (NOINPUT, HP_NONINTERACTIVE,
+rem HP_CI_LANE) so a real double-click user gets the new probe with zero flags required,
+rem while every CI/automation signal keeps today's plain-redirect behavior byte-for-byte
+rem unchanged (self.fastpath / self.exe.fastpath.graceful stay deterministic).
+rem HP_TEST_FORCE_INTERACTIVE_PROBE=1 forces the probe branch under HP_CI_LANE for
+rem dedicated, deterministic CI coverage of the new state machine (mirrors HP_TEST_FORCE_PICKER).
+set "HP_INTERACTIVE_RUN=1"
+if defined NOINPUT set "HP_INTERACTIVE_RUN="
+if defined HP_NONINTERACTIVE set "HP_INTERACTIVE_RUN="
+if defined HP_CI_LANE if not defined HP_TEST_FORCE_INTERACTIVE_PROBE set "HP_INTERACTIVE_RUN="
+exit /b 0
+:run_failfast_probe
+rem Slice 2b-C: shared fail-fast probe for the two untimed user-code launch points. Reuses
+rem :run_exe_smokerun's ProcessStartInfo + ReadToEndAsync pattern (preserves ~run.out.txt /
+rem ~run.err.txt for existing consumers -- envsmoke's 'smoke-ok' token, spaced-path dist\
+rem token capture) but replaces the single 30s-cap-then-Kill() wait with a two-stage wait
+rem inside ~failfast_probe.ps1 (HP_FAILFAST_PROBE): WaitForExit(HP_FAILFAST_PROBE_MS)
+rem classifies a fast exit vs. still-running; if still running, a SECOND, UNBOUNDED
+rem WaitForExit() follows and the process is NEVER killed -- this is the only difference
+rem from :run_exe_smokerun, which stays the sole place in this file allowed to force-kill
+rem (the fresh-build verification run). Caller sets HP_PROBE_EXE / HP_PROBE_ARGS (raw,
+rem unquoted -- the helper quotes it) / HP_PROBE_CWD before calling; %1 is a short site tag
+rem ('fastpath'|'interpreter') used only for the NDJSON row and log text. Always leaves
+rem HP_SMOKE_RC set to the true final exit code and HP_PROBE_EXCEEDED set (1) iff the probe
+rem window was exceeded -- the caller decides what that means (:try_fast_exe discards a
+rem cached EXE only when NOT exceeded; :verify_no_exe_interpreter has no cached artifact and
+rem just reports the final outcome either way).
+set "HP_PROBE_SITE=%~1"
+set "HP_PROBE_EXCEEDED="
+set "HP_SMOKE_RC="
+set "HP_PROBE_PS=~failfast_probe.ps1"
+if exist "%HP_PROBE_PS%" del "%HP_PROBE_PS%" >nul 2>&1
+rem pre-truncate: the helper only writes these once, at process exit, so without this an
+rem unbounded ALIVE-AT-PROBE wait would leave stale prior-run content lingering for its
+rem full duration with no indication it is stale.
+if exist "~run.out.txt" del "~run.out.txt" >nul 2>&1
+if exist "~run.err.txt" del "~run.err.txt" >nul 2>&1
+call :emit_from_base64 "%HP_PROBE_PS%" HP_FAILFAST_PROBE
+if errorlevel 1 (
+  rem Extremely rare (disk/permission failure writing a work file); mirror :try_fast_exe's own
+  rem emit-failure convention of skipping gracefully rather than hand-rolling an unsafe manual
+  rem launch here (HP_PROBE_ARGS is intentionally unquoted raw text -- only the .ps1 helper
+  rem quotes it safely; a direct cmd invocation would mis-tokenize an entry path with spaces).
+  rem HP_SMOKE_RC stays unset; the safety net below turns that into -1 so callers still see a
+  rem defined, non-zero, non-"exceeded" outcome (:try_fast_exe's discard-and-rebuild fires).
+  call :log "[WARN] Fail-fast probe: could not emit ~failfast_probe.ps1; treating as a failed run."
+) else (
+  for /f "usebackq delims=" %%X in (`powershell -NoProfile -ExecutionPolicy Bypass -File "%HP_PROBE_PS%"`) do (
+    for /f "tokens=1,2 delims=|" %%A in ("%%X") do (
+      set "HP_PROBE_EXCEEDED=%%A"
+      set "HP_SMOKE_RC=%%B"
+    )
+  )
+  if exist "%HP_PROBE_PS%" del "%HP_PROBE_PS%" >nul 2>&1
+)
+if "%HP_PROBE_EXCEEDED%"=="0" set "HP_PROBE_EXCEEDED="
+if not defined HP_SMOKE_RC set "HP_SMOKE_RC=-1"
+call :log "[INFO] Entry smoke exit=%HP_SMOKE_RC%"
+if defined HP_PROBE_EXCEEDED (
+  call :log "[INFO] Fail-fast probe: still running after %HP_FAILFAST_PROBE_MS%ms; this is your program's real run, not a rebuild trigger. If it has a GUI it may have opened minimized or on another window; if it is a background/console app with no window, that is expected. The bootstrapper is waiting for it to finish so it can report the final result -- it will not force-stop it."
+)
+if "%HP_SMOKE_RC%"=="0" (
+  call :log "[STATUS] Run Status: SUCCESS (Exit Code: 0)"
+) else (
+  call :log "[STATUS] Run Status: FAILED (Exit Code: %HP_SMOKE_RC%)"
+)
+if defined HP_NDJSON (
+  powershell -NoProfile -ExecutionPolicy Bypass -Command ^
+    "$c=[int]'%HP_SMOKE_RC%';$ex=[bool]'%HP_PROBE_EXCEEDED%';" ^
+    "$r=[ordered]@{id='self.failfast.probe';pass=($c -eq 0);details=[ordered]@{site='%HP_PROBE_SITE%';exitCode=$c;probeExceeded=$ex;probeMs=[int]'%HP_FAILFAST_PROBE_MS%'}}|ConvertTo-Json -Compress -Depth 8;" ^
+    "Add-Content -Path '%HP_NDJSON%' -Value $r -Encoding ASCII" >> "%LOG%" 2>&1
+)
+set "HP_PROBE_EXE="
+set "HP_PROBE_ARGS="
+set "HP_PROBE_CWD="
+set "HP_PROBE_SITE="
+set "HP_PROBE_PS="
+exit /b 0
 :try_fast_exe
 set "HP_FASTPATH_USED="
 set "HP_FAST_EXE="
@@ -2072,17 +2192,55 @@ if defined HP_SKIP_EXE_SMOKERUN (
   set "HP_EXE_SKIPPED=1"
   exit /b 0
 )
+set "HP_PROBE_EXCEEDED="
+rem Slice 2b-C: goto-based dispatch, NOT a parenthesized if/else block, is deliberate here --
+rem see docs/agent-lessons-learned.md "Provider-cascade dispatch is goto-based on purpose".
+rem cmd.exe expands every %VAR% in a parenthesized ( ... ) block ONCE, at parse time, using
+rem values from BEFORE the block started -- an earlier revision of this code launched the EXE
+rem and read "set HP_SMOKE_RC=%ERRORLEVEL%" inside the else-branch's own parens, which silently
+rem froze %ERRORLEVEL% (and every in-block %HP_SMOKE_RC% read) to whatever it was right before
+rem the if/else began (almost always "0"), so a genuinely broken cached EXE was NEVER discarded
+rem in the legacy/CI branch. Each branch below is reached via goto so its statements are parsed
+rem and executed as fresh top-level lines, exactly like the rest of this file's %ERRORLEVEL%
+rem capture sites.
+if defined HP_INTERACTIVE_RUN goto :try_fast_exe_probe
 call :log "[INFO] Fast path: reusing %HP_FAST_EXE%"
 >> "%LOG%" echo Fast path command: "%HP_FAST_EXE%" ^> "~run.out.txt" 2^> "~run.err.txt"
 "%HP_FAST_EXE%" 1> "~run.out.txt" 2> "~run.err.txt"
 set "HP_SMOKE_RC=%ERRORLEVEL%"
 call :log "[INFO] Entry smoke exit=%HP_SMOKE_RC%"
+if "%HP_SMOKE_RC%"=="0" (
+  call :log "[STATUS] Run Status: SUCCESS (Exit Code: 0)"
+) else (
+  call :log "[STATUS] Run Status: FAILED (Exit Code: %HP_SMOKE_RC%)"
+)
+goto :try_fast_exe_discard_check
+:try_fast_exe_probe
+rem Interactive fail-fast probe -- a real double-click user is told explicitly what is about
+rem to launch and never sees a hard kill here; a genuinely stale/broken cached EXE that fails
+rem within the probe window is still discarded+rebuilt below exactly as before. CI/automation
+rem (HP_INTERACTIVE_RUN unset) takes the branch above instead, byte-for-byte unchanged, so
+rem self.fastpath / self.exe.fastpath.graceful stay deterministic.
+call :log "[INFO] Launching your program now via the cached standalone EXE (PyInstaller build): %HP_FAST_EXE%"
+rem Resolve to an absolute path -- HP_FAST_EXE is relative (dist\%ENVNAME%.exe). .NET
+rem Process.Start's FileName resolution is a different mechanism from cmd.exe's own relative
+rem launch, so keep this unambiguous rather than relying on the child process inheriting the
+rem right CWD to resolve it, in case a future change alters how/where this is invoked from.
+set "HP_PROBE_EXE=%CD%\%HP_FAST_EXE%"
+set "HP_PROBE_ARGS="
+set "HP_PROBE_CWD=%CD%"
+call :run_failfast_probe fastpath
+:try_fast_exe_discard_check
 rem REQ-007: a reused EXE that exits non-zero must NOT abort the bootstrapper. The cached
 rem EXE may be stale or carry an unbundled runtime dependency (DLL/data file) the fast-path
 rem freshness check cannot see. Drop the fast path and fall through to a full rebuild, which
 rem routes any persistent failure through :run_exe_smokerun's graceful handling + banner.
-if not "%HP_SMOKE_RC%"=="0" (
-  call :log "[WARN] Fast path EXE exited %HP_SMOKE_RC%; discarding cached EXE and rebuilding."
+rem Slice 2b-C: this discard only fires when the probe was NOT exceeded (a fast, genuine
+rem failure). Once a process is classified alive/healthy at the probe, a LATER non-zero exit
+rem is presumed to be the user's own program outcome, not proof of a stale artifact -- a
+rem rebuild would not fix a runtime bug in the user's own code, so the cached EXE is kept.
+if not "%HP_SMOKE_RC%"=="0" if not defined HP_PROBE_EXCEEDED (
+  call :log "[WARN] Fast path standalone EXE (PyInstaller build) exited %HP_SMOKE_RC%; discarding cached EXE and rebuilding."
   rem Delete the broken EXE so the next :try_fast_exe call does not re-detect it as
   rem "fresh" and run the known-bad binary again; the rebuild below recreates it.
   if exist "%HP_FAST_EXE%" del "%HP_FAST_EXE%" >nul 2>&1
@@ -2158,11 +2316,26 @@ rem interpreter, so it is gated on explicit consent (CI auto-declines); all othe
 set "HP_BUILD_OK=1"
 if /i "%HP_ENV_MODE%"=="system" call :system_build_consent_gate
 if /i "%HP_ENV_MODE%"=="system" if errorlevel 1 set "HP_BUILD_OK="
+rem Slice 2b-C: recompute the same HP_FASTPATH_RUN_FAILED check the top-of-file gate uses
+rem (this is :try_fast_exe's SECOND call site, inside :run_entry_smoke; the first call's own
+rem HP_FASTPATH_RUN_FAILED does not reach here -- any first-call success or post-probe-failure
+rem outcome already took goto :success before this point, so this recomputation is normally a
+rem no-op today, but keeps this call site from silently reopening the same "HP_FASTPATH_USED
+rem alone is not proof of a clean run" gap the top-of-file gate closed, should a future change
+rem (e.g. a provider-cascade re-entry) ever reach here with HP_FASTPATH_USED still set from a
+rem probe-classified alive-then-failed run). Computed as a top-level statement, not inside the
+rem block below, for the same parse-time-expansion reason documented in :try_fast_exe.
+set "HP_FASTPATH_RUN_FAILED="
+if defined HP_SMOKE_RC if not "%HP_SMOKE_RC%"=="0" set "HP_FASTPATH_RUN_FAILED=1"
 if not defined HP_BUILD_OK (
   call :log "[INFO] REQ-007: system-Python EXE build not consented; skipping PyInstaller packaging. The environment and dependencies are installed; run the app directly via the prepared Python."
 ) else (
   if defined HP_FASTPATH_USED (
-    call :log "[INFO] Fast path: skipping PyInstaller rebuild for existing dist\%ENVNAME%.exe"
+    if defined HP_FASTPATH_RUN_FAILED (
+      call :log "[WARN] dist\%ENVNAME%.exe (standalone EXE, PyInstaller build) ran to completion and exited non-zero after passing the fail-fast probe; treated as your program's own result, not a rebuild trigger."
+    ) else (
+      call :log "[INFO] Fast path: skipping PyInstaller rebuild for existing dist\%ENVNAME%.exe"
+    )
   ) else (
     rem derived requirement: PyInstaller install + build can take a minute or more; emit a
     rem user-facing message before the silent operation so the script never looks hung.
@@ -2332,18 +2505,21 @@ exit /b 1
 :verify_no_exe_interpreter
 rem REQ-018 (2b-A.2): single-verification fallback for the NO-EXE path. When no EXE was built or
 rem run (system-Python build declined, or build skipped), run the entry once via the interpreter --
-rem in those providers there is no EXE deliverable, so this IS the user's run, not a throwaway. It
-rem is kept UNTIMED on purpose: hard-killing it at ~30s would terminate a long-running app
-rem (GUI / server / loop) for system-mode users with no recourse. Slice 2b-C unifies the
-rem run-timing / fail-fast probe / interactive checkpoint for BOTH this interpreter run and the
-rem fast-path EXE run. Skipped when user code must not run (REQ-012) or already ran (fast path, or
-rem an EXE smoke verified the build). Emits the same "Entry smoke" vocabulary + [STATUS] readout.
+rem in those providers there is no EXE deliverable, so this IS the user's run, not a throwaway.
+rem Skipped when user code must not run (REQ-012) or already ran (fast path, or an EXE smoke
+rem verified the build). Emits the same "Entry smoke" vocabulary + [STATUS] readout.
 if defined HP_SKIP_ENTRY_SMOKE exit /b 0
 if defined HP_FASTPATH_USED exit /b 0
 rem skip only when an EXE smoke actually verified the build; if the EXE exists but its smoke was
 rem skipped by request (HP_SKIP_EXE_SMOKERUN without HP_SKIP_ENTRY_SMOKE), still verify via the
 rem interpreter so that REQ-012 "skip the EXE run" does not silently skip all verification.
 if exist "dist\%ENVNAME%.exe" if not defined HP_EXE_SKIPPED exit /b 0
+set "HP_PROBE_EXCEEDED="
+rem Slice 2b-C: goto-based dispatch, not a parenthesized if/else block -- see the identical
+rem rationale comment in :try_fast_exe (cmd.exe freezes every %VAR% in a ( ... ) block to its
+rem pre-block value at parse time; launching the interpreter and reading %ERRORLEVEL% inside
+rem the same parens would silently corrupt HP_SMOKE_RC for the legacy/CI branch).
+if defined HP_INTERACTIVE_RUN goto :verify_no_exe_probe
 call :log "[INFO] Running entry script smoke test via %HP_ENV_MODE% interpreter."
 rem derived requirement: execute the smoke command inline so cmd, not our logging, owns redirection parsing.
 >> "%LOG%" echo Smoke command: "%HP_PY%" "%HP_ENTRY%" ^> "~run.out.txt" 2^> "~run.err.txt"
@@ -2355,6 +2531,19 @@ if "%HP_SMOKE_RC%"=="0" (
 ) else (
   call :log "[STATUS] Run Status: FAILED (Exit Code: %HP_SMOKE_RC%)"
 )
+exit /b 0
+:verify_no_exe_probe
+rem Kept UNTIMED past the short probe window on purpose: a long-running app (GUI / server /
+rem loop) for system-mode users has no recourse if killed, so once the probe window
+rem (HP_FAILFAST_PROBE_MS) is crossed the wait becomes unbounded and the process is never
+rem force-stopped. There is no cached artifact at this call site, so the probe only adds an
+rem early, honest heads-up log line; the final outcome is reported either way once the
+rem interpreter actually exits.
+call :log "[INFO] Launching your program now via the %HP_ENV_MODE% interpreter: %HP_PY% %HP_ENTRY%"
+set "HP_PROBE_EXE=%HP_PY%"
+set "HP_PROBE_ARGS=%HP_ENTRY%"
+set "HP_PROBE_CWD=%CD%"
+call :run_failfast_probe interpreter
 exit /b 0
 :warnfix_cascade_detect
 rem REQ-009/REQ-005.10 (slice 1: detect only). After the warnfix rebuild, re-parse the
@@ -2476,7 +2665,7 @@ rem REQ-016: tightly-scoped heads-up before a launch that is force-stopped at ~3
 rem user does not mistake a verification run for finished setup and start real work in it
 rem (which would be lost when the run is killed). Called only where a 30s kill actually
 rem happens -- the EXE smoke and hidden-import recovery -- not at the untimed entry smoke.
-call :log "[WARN] Verifying the built program now: it is force-stopped after about 30 seconds even if running perfectly, so do not start real work in it yet or any unsaved work will be lost."
+call :log "[WARN] Verifying the built standalone EXE (PyInstaller) now: it is force-stopped after about 30 seconds even if running perfectly, so do not start real work in it yet or any unsaved work will be lost."
 exit /b 0
 :run_exe_smokerun
 if not exist "dist\%ENVNAME%.exe" (
@@ -2578,7 +2767,7 @@ call :log "[HINT][HIDDEN_IMPORT] Hidden import likely missing: %HP_HINT_MOD%"
 call :log "[HINT][HIDDEN_IMPORT] Consider adding: --hidden-import=%HP_HINT_MOD%"
 if defined HINT_JSON powershell -NoProfile -ExecutionPolicy Bypass -Command "Write-Host ([PSCustomObject]@{hint_type='HIDDEN_IMPORT';module=$env:HP_HINT_MOD}|ConvertTo-Json -Compress)"
 :hint_packaging
-call :log "[HINT][RUNTIME_MISMATCH] EXE behavior differs from Python runtime (possible packaging issue)"
+call :log "[HINT][RUNTIME_MISMATCH] Standalone EXE behavior differs from the Python runtime (possible PyInstaller packaging issue in the EXE, not your environment or dependencies)"
 if defined HINT_JSON powershell -NoProfile -ExecutionPolicy Bypass -Command "Write-Host ([PSCustomObject]@{hint_type='RUNTIME_MISMATCH'}|ConvertTo-Json -Compress)"
 if exist "%HP_HINT_FILE%" del "%HP_HINT_FILE%" >nul 2>&1
 set "HP_HINT_FILE="
@@ -2655,6 +2844,38 @@ rem $exeTime = (Get-Item -LiteralPath $exe).LastWriteTimeUtc
 rem if ($exeTime -ge $latest) { 'fresh' }
 rem If HP_FAST_CHECK changes, update this decoded comment block to match the base64 payload.
 set "HP_FAST_CHECK=JGV4ZSA9ICRhcmdzWzBdCmlmICgtbm90ICRleGUpIHsgJGV4ZSA9ICRlbnY6SFBfRkFTVF9FWEUgfQokaW5mcmFQYXR0ZXJuID0gJyg/aSkoXnxbL1xcXSkoXC5naXR8XC5naXRodWJ8ZGlzdHxcLnZlbnZ8XC51dl9lbnZ8X19weWNhY2hlX198XC5jb25kYSkoWy9cXF18JCknCiRzb3VyY2VzID0gR2V0LUNoaWxkSXRlbSAtUmVjdXJzZSAtRmlsZSAtRmlsdGVyICcqLnB5JyB8IFdoZXJlLU9iamVjdCB7ICRfLkZ1bGxOYW1lIC1ub3RtYXRjaCAkaW5mcmFQYXR0ZXJuIC1hbmQgJF8uTmFtZSAtbm90bGlrZSAnfioucHknIH0KaWYgKC1ub3QgJHNvdXJjZXMpIHsgZXhpdCAxIH0KJGxhdGVzdCA9ICgkc291cmNlcyB8IFNvcnQtT2JqZWN0IC1Qcm9wZXJ0eSBMYXN0V3JpdGVUaW1lVXRjIC1EZXNjZW5kaW5nIHwgU2VsZWN0LU9iamVjdCAtRmlyc3QgMSkuTGFzdFdyaXRlVGltZVV0YwokZXhlVGltZSA9IChHZXQtSXRlbSAtTGl0ZXJhbFBhdGggJGV4ZSkuTGFzdFdyaXRlVGltZVV0YwppZiAoJGV4ZVRpbWUgLWdlICRsYXRlc3QpIHsgJ2ZyZXNoJyB9Cg=="
+rem HP_FAILFAST_PROBE decoded content (Slice 2b-C):
+rem $exe = $env:HP_PROBE_EXE
+rem $rawArgs = $env:HP_PROBE_ARGS
+rem $workDir = $env:HP_PROBE_CWD
+rem $probeMs = [int]$env:HP_FAILFAST_PROBE_MS
+rem $si = New-Object System.Diagnostics.ProcessStartInfo
+rem $si.FileName = $exe
+rem if ($rawArgs) { $si.Arguments = '"' + $rawArgs + '"' }
+rem $si.WorkingDirectory = $workDir
+rem $si.UseShellExecute = $false
+rem $si.RedirectStandardOutput = $true
+rem $si.RedirectStandardError = $true
+rem $p = [System.Diagnostics.Process]::Start($si)
+rem $so = $p.StandardOutput.ReadToEndAsync()
+rem $se = $p.StandardError.ReadToEndAsync()
+rem $fast = $p.WaitForExit($probeMs)
+rem $exceeded = 0
+rem if (-not $fast) {
+rem     $exceeded = 1
+rem     $p.WaitForExit()
+rem }
+rem $so.Result | Set-Content -Path '~run.out.txt' -Encoding ASCII
+rem $se.Result | Set-Content -Path '~run.err.txt' -Encoding ASCII
+rem "$exceeded|$($p.ExitCode)"
+rem Never calls $p.Kill() -- once the probe window (HP_FAILFAST_PROBE_MS) is exceeded, the second
+rem WaitForExit() is unbounded so a healthy long-running app is never force-stopped. Reads all
+rem inputs from env vars set by the caller (no positional args) to avoid any cmd.exe quoting
+rem hazard; caller must pre-truncate ~run.out.txt/~run.err.txt before invoking (this script only
+rem writes them once, at process exit, so a stale prior run's content would otherwise linger for
+rem the full unbounded-wait duration).
+rem If HP_FAILFAST_PROBE changes, update this decoded comment block to match the base64 payload.
+set "HP_FAILFAST_PROBE=JGV4ZSA9ICRlbnY6SFBfUFJPQkVfRVhFCiRyYXdBcmdzID0gJGVudjpIUF9QUk9CRV9BUkdTCiR3b3JrRGlyID0gJGVudjpIUF9QUk9CRV9DV0QKJHByb2JlTXMgPSBbaW50XSRlbnY6SFBfRkFJTEZBU1RfUFJPQkVfTVMKJHNpID0gTmV3LU9iamVjdCBTeXN0ZW0uRGlhZ25vc3RpY3MuUHJvY2Vzc1N0YXJ0SW5mbwokc2kuRmlsZU5hbWUgPSAkZXhlCmlmICgkcmF3QXJncykgeyAkc2kuQXJndW1lbnRzID0gJyInICsgJHJhd0FyZ3MgKyAnIicgfQokc2kuV29ya2luZ0RpcmVjdG9yeSA9ICR3b3JrRGlyCiRzaS5Vc2VTaGVsbEV4ZWN1dGUgPSAkZmFsc2UKJHNpLlJlZGlyZWN0U3RhbmRhcmRPdXRwdXQgPSAkdHJ1ZQokc2kuUmVkaXJlY3RTdGFuZGFyZEVycm9yID0gJHRydWUKJHAgPSBbU3lzdGVtLkRpYWdub3N0aWNzLlByb2Nlc3NdOjpTdGFydCgkc2kpCiRzbyA9ICRwLlN0YW5kYXJkT3V0cHV0LlJlYWRUb0VuZEFzeW5jKCkKJHNlID0gJHAuU3RhbmRhcmRFcnJvci5SZWFkVG9FbmRBc3luYygpCiRmYXN0ID0gJHAuV2FpdEZvckV4aXQoJHByb2JlTXMpCiRleGNlZWRlZCA9IDAKaWYgKC1ub3QgJGZhc3QpIHsKICAgICRleGNlZWRlZCA9IDEKICAgICRwLldhaXRGb3JFeGl0KCkKfQokc28uUmVzdWx0IHwgU2V0LUNvbnRlbnQgLVBhdGggJ35ydW4ub3V0LnR4dCcgLUVuY29kaW5nIEFTQ0lJCiRzZS5SZXN1bHQgfCBTZXQtQ29udGVudCAtUGF0aCAnfnJ1bi5lcnIudHh0JyAtRW5jb2RpbmcgQVNDSUkKIiRleGNlZWRlZHwkKCRwLkV4aXRDb2RlKSIK"
 :: --- Embedded helper: HP_PREP_REQUIREMENTS (~prep_requirements.py) ---
 :: Purpose:
 ::   - Normalize pip/conda specifiers from requirements.txt

--- a/tests/harness.ps1
+++ b/tests/harness.ps1
@@ -438,6 +438,18 @@ $svExeVocab   = $AllText -match [regex]::Escape('Running entry script smoke test
 $svExeCapture = $AllText -match [regex]::Escape("Set-Content -Path '..\~run.out.txt'")
 $hasSingleVerify = $svNoExeLabel -and $svNoExeCall -and $svOldGone -and $svExeVocab -and $svExeCapture
 Write-Result 'batch.smoke.single_verify' 'REQ-018: single-verification pass wired (no-EXE interpreter subroutine + EXE smoke captures ~run.out.txt + unified vocab); legacy post-warnfix interpreter retry removed' $hasSingleVerify @{ noExeLabel=$svNoExeLabel; noExeCall=$svNoExeCall; oldRemoved=$svOldGone; exeVocab=$svExeVocab; exeCapture=$svExeCapture }
+# derived requirement: Slice 2b-C fail-fast probe -- guard against silent removal of the shared
+# interactivity determination, the shared probe subroutine, the CI-safe test-forcing override, and
+# the top-of-file HP_FASTPATH_USED/HP_SMOKE_RC decoupling fix (the "silent success" bug where a
+# fast-path reuse could report full bootstrap success while hiding a real post-probe app failure).
+$ffInteractiveSub = $AllText -match '(?m)^:compute_interactive_run'
+$ffProbeSub        = $AllText -match '(?m)^:run_failfast_probe'
+$ffTestOverride    = $AllText -match 'HP_TEST_FORCE_INTERACTIVE_PROBE'
+$ffProbeMs         = $AllText -match [regex]::Escape('set "HP_FAILFAST_PROBE_MS=5000"')
+$ffExceededVar     = $AllText -match 'HP_PROBE_EXCEEDED'
+$ffDecoupleGuard   = $AllText -match [regex]::Escape('set "HP_FASTPATH_RUN_FAILED=')
+$hasFailfastProbe = $ffInteractiveSub -and $ffProbeSub -and $ffTestOverride -and $ffProbeMs -and $ffExceededVar -and $ffDecoupleGuard
+Write-Result 'batch.failfast.probe' 'REQ-018 (2b-C): fail-fast probe wired (interactivity subroutine + shared probe subroutine + CI-safe test override + default probe window + HP_PROBE_EXCEEDED state + HP_FASTPATH_USED/HP_SMOKE_RC decoupling guard)' $hasFailfastProbe @{ interactiveSub=$ffInteractiveSub; probeSub=$ffProbeSub; testOverride=$ffTestOverride; probeMs=$ffProbeMs; exceededVar=$ffExceededVar; decoupleGuard=$ffDecoupleGuard }
 $results = Get-Content -LiteralPath $ResultsPath -Encoding ASCII | ForEach-Object { $_ | ConvertFrom-Json }
 $fail = @($results | Where-Object { -not $_.pass })
 $pass = @($results | Where-Object { $_.pass })

--- a/tests/selfapps_failfast_probe.ps1
+++ b/tests/selfapps_failfast_probe.ps1
@@ -1,0 +1,250 @@
+# ASCII only
+# selfapps_failfast_probe.ps1 - Slice 2b-C fail-fast probe: two untimed user-code launch points
+# (:try_fast_exe, :verify_no_exe_interpreter) now dispatch to a probed launch when HP_INTERACTIVE_RUN
+# is set. HP_TEST_FORCE_INTERACTIVE_PROBE=1 forces that branch under HP_CI_LANE for deterministic
+# CI coverage (mirrors HP_TEST_FORCE_PICKER). Two scenarios, each its own cached-EXE fast-path run:
+#
+#   self.failfast.probe.fastfail - a cached EXE that fails FAST (well under the probe window) is
+#     still discarded and rebuilt, exactly like the pre-existing (non-probed) behavior tested by
+#     selfapps_exefastpath.ps1 -- this proves the probe dispatch does not change that outcome.
+#
+#   self.failfast.probe.alive - a cached EXE that is still running when the probe window elapses is
+#     never discarded even if it LATER exits non-zero (it is the user's own program result, not
+#     proof of a stale artifact); the bootstrap still reports the true outcome via an accurate
+#     [STATUS] Run Status: FAILED line and stays HP_BOOTSTRAP_STATE=ok (a runtime bug in the user's
+#     own code is not something a rebuild could fix). This is the critical decoupling fix for the
+#     "silent success" gap: HP_FASTPATH_USED alone must never be read as proof of a clean run.
+#
+# Lane: real and conda-full only (matches selfapps_exefastpath.ps1).
+param()
+$ErrorActionPreference = 'Continue'
+$here = $PSScriptRoot
+$repo = Split-Path -Path $here -Parent
+$nd   = Join-Path $here '~test-results.ndjson'
+$ciNd = Join-Path $repo 'ci_test_results.ndjson'
+if (-not (Test-Path $nd))   { New-Item -ItemType File -Path $nd   -Force | Out-Null }
+if (-not (Test-Path $ciNd)) { New-Item -ItemType File -Path $ciNd -Force | Out-Null }
+
+function Write-NdjsonRow {
+    param([hashtable]$Row)
+    $lane = [Environment]::GetEnvironmentVariable('HP_CI_LANE')
+    if ($lane -and -not $Row.ContainsKey('lane')) { $Row['lane'] = $lane }
+    $json = $Row | ConvertTo-Json -Compress -Depth 8
+    Add-Content -LiteralPath $nd   -Value $json -Encoding Ascii
+    Add-Content -LiteralPath $ciNd -Value $json -Encoding Ascii
+}
+
+$ndjsonIds = @('self.failfast.probe.fastfail', 'self.failfast.probe.alive')
+
+# Non-Windows skip
+if (-not $IsWindows) {
+    $platform = [System.Environment]::OSVersion.Platform.ToString()
+    foreach ($id in $ndjsonIds) {
+        Write-NdjsonRow ([ordered]@{
+            id      = $id
+            req     = 'REQ-018'
+            pass    = $true
+            desc    = 'Fail-fast probe test skipped on non-Windows host'
+            details = [ordered]@{ skip = $true; platform = $platform; reason = 'non-windows-host' }
+        })
+    }
+    exit 0
+}
+
+$batchPath = Join-Path $repo 'run_setup.bat'
+if (-not (Test-Path $batchPath)) {
+    foreach ($id in $ndjsonIds) {
+        Write-NdjsonRow ([ordered]@{
+            id      = $id
+            req     = 'REQ-018'
+            pass    = $false
+            desc    = 'Fail-fast probe test: run_setup.bat not found'
+            details = [ordered]@{ error = 'run_setup.bat not found at ' + $batchPath }
+        })
+    }
+    exit 1
+}
+
+function Invoke-Bootstrap {
+    param([string]$WorkDir, [string]$LogName)
+    Push-Location -LiteralPath $WorkDir
+    try {
+        cmd /c "call run_setup.bat > $LogName 2>&1"
+        return $LASTEXITCODE
+    } finally {
+        Pop-Location
+    }
+}
+
+# --- Scenario A: fastfail -- cached EXE fails well within the probe window ---
+# Reuses selfapps_exefastpath.ps1's proven failure mechanism (importlib.resources data file that
+# is on disk for the interpreter but never bundled by PyInstaller, so the frozen EXE always exits
+# non-zero immediately regardless of CWD) so run 1's build-smoke fails gracefully and run 2's fast
+# path detects a genuinely broken cached EXE -- the only new variable is forcing the interactive
+# probe branch on run 2.
+$fastfailPass = $false
+$fastfailDetails = [ordered]@{}
+try {
+    $ffDir = Join-Path $here '~selftest_failfastprobe_fastfail'
+    if (Test-Path $ffDir) { Remove-Item -Recurse -Force $ffDir }
+    New-Item -ItemType Directory -Force -Path $ffDir | Out-Null
+    Copy-Item -Path $batchPath -Destination $ffDir -Force
+
+    New-Item -ItemType Directory -Force -Path (Join-Path $ffDir 'mypkg') | Out-Null
+    New-Item -ItemType Directory -Force -Path (Join-Path $ffDir 'mypkg\data') | Out-Null
+    Set-Content -Path (Join-Path $ffDir 'mypkg\__init__.py') -Value '' -Encoding ASCII
+    Set-Content -Path (Join-Path $ffDir 'mypkg\data\info.txt') -Value 'hello-bundled-data' -Encoding ASCII
+    Set-Content -Path (Join-Path $ffDir 'entry.py') -Value @'
+import mypkg  # ensure PyInstaller traces and bundles the package itself
+import importlib.resources as ir
+print((ir.files("mypkg") / "data" / "info.txt").read_text())
+'@ -Encoding ASCII
+
+    $savedSkipPipreqsFf = $env:HP_SKIP_PIPREQS
+    $savedNdjsonFf = $env:HP_NDJSON
+    $savedLaneFf = $env:HP_CI_LANE
+    $savedForceFf = $env:HP_TEST_FORCE_INTERACTIVE_PROBE
+    $env:HP_SKIP_PIPREQS = '1'
+    # Defensive: avoid the reused EXE's expected self.exe.smokerun pass=false row landing in the
+    # gated NDJSON stream (mirrors selfapps_exefastpath.ps1); the fail-fast probe row is asserted
+    # from the log text instead, which does not depend on HP_NDJSON.
+    Remove-Item Env:HP_NDJSON -ErrorAction SilentlyContinue
+    $env:HP_CI_LANE = 'test'
+
+    $ffRun1Exit = Invoke-Bootstrap -WorkDir $ffDir -LogName '~ff_run1.log'
+    $env:HP_TEST_FORCE_INTERACTIVE_PROBE = '1'
+    $ffRun2Exit = Invoke-Bootstrap -WorkDir $ffDir -LogName '~ff_run2.log'
+
+    if ($null -eq $savedSkipPipreqsFf) { Remove-Item Env:HP_SKIP_PIPREQS -ErrorAction SilentlyContinue } else { $env:HP_SKIP_PIPREQS = $savedSkipPipreqsFf }
+    if ($null -ne $savedNdjsonFf) { $env:HP_NDJSON = $savedNdjsonFf }
+    if ($null -eq $savedLaneFf) { Remove-Item Env:HP_CI_LANE -ErrorAction SilentlyContinue } else { $env:HP_CI_LANE = $savedLaneFf }
+    if ($null -eq $savedForceFf) { Remove-Item Env:HP_TEST_FORCE_INTERACTIVE_PROBE -ErrorAction SilentlyContinue } else { $env:HP_TEST_FORCE_INTERACTIVE_PROBE = $savedForceFf }
+
+    $ffRun2LogPath = Join-Path $ffDir '~ff_run2.log'
+    $ffRun2Lines = if (Test-Path $ffRun2LogPath) { Get-Content -LiteralPath $ffRun2LogPath -Encoding ASCII } else { @() }
+    $ffRun2Text = $ffRun2Lines -join "`n"
+
+    $ffLaunchedInteractive = $ffRun2Text -match [regex]::Escape('Launching your program now via the cached standalone EXE')
+    $ffDiscarded = $ffRun2Text -match [regex]::Escape('discarding cached EXE and rebuilding')
+    $ffNoAliveMsg = -not ($ffRun2Text -match [regex]::Escape('Fail-fast probe: still running after'))
+
+    $fastfailPass = ($ffRun1Exit -eq 0) -and ($ffRun2Exit -eq 0) -and $ffLaunchedInteractive -and $ffDiscarded -and $ffNoAliveMsg
+    $fastfailDetails = [ordered]@{
+        run1Exit           = $ffRun1Exit
+        run2Exit           = $ffRun2Exit
+        launchedInteractive = $ffLaunchedInteractive
+        discardedAndRebuilt = $ffDiscarded
+        noAliveMsg          = $ffNoAliveMsg
+        run2Log             = '~ff_run2.log'
+    }
+} catch {
+    $fastfailDetails = [ordered]@{ error = $_.Exception.Message }
+}
+
+Write-NdjsonRow ([ordered]@{
+    id      = 'self.failfast.probe.fastfail'
+    req     = 'REQ-018'
+    pass    = $fastfailPass
+    desc    = 'Fail-fast probe: a cached EXE that fails within the probe window is still discarded and rebuilt'
+    details = $fastfailDetails
+})
+
+# --- Scenario B: alive -- cached EXE is still running when the probe window elapses, then later
+# exits non-zero. The critical assertion is the decoupling fix: the cached EXE must NOT be
+# discarded, and the bootstrap must NOT silently report full success -- it must log the real
+# outcome and keep HP_BOOTSTRAP_STATE=ok (env/build genuinely succeeded; a runtime bug in the
+# user's own code is not proof of a stale artifact and not something a rebuild would fix).
+$alivePass = $false
+$aliveDetails = [ordered]@{}
+try {
+    $alDir = Join-Path $here '~selftest_failfastprobe_alive'
+    if (Test-Path $alDir) { Remove-Item -Recurse -Force $alDir }
+    New-Item -ItemType Directory -Force -Path $alDir | Out-Null
+    Copy-Item -Path $batchPath -Destination $alDir -Force
+
+    # Behaves differently per invocation via an inherited env var read at RUNTIME (not baked in
+    # at PyInstaller build time), so the SAME frozen EXE binary built on run 1 (clean, fast exit)
+    # can be driven into the ALIVE_AT_PROBE state on run 2 without a rebuild in between.
+    Set-Content -Path (Join-Path $alDir 'entry.py') -Value @'
+import os
+import sys
+import time
+
+if os.environ.get("HP_TEST_APP_SHOULD_FAIL") == "1":
+    time.sleep(6)
+    sys.exit(7)
+print("smoke-ok")
+sys.exit(0)
+'@ -Encoding ASCII
+
+    $savedSkipPipreqsAl = $env:HP_SKIP_PIPREQS
+    $savedLaneAl = $env:HP_CI_LANE
+    $savedForceAl = $env:HP_TEST_FORCE_INTERACTIVE_PROBE
+    $savedProbeMsAl = $env:HP_FAILFAST_PROBE_MS
+    $savedShouldFailAl = $env:HP_TEST_APP_SHOULD_FAIL
+    $env:HP_SKIP_PIPREQS = '1'
+    $env:HP_CI_LANE = 'test'
+    # A short probe window with generous margin against the 6s sleep above avoids CI-runner-load
+    # flakiness in either direction (misclassifying a slow-starting-but-fast-exiting run as alive,
+    # or the reverse).
+    $env:HP_FAILFAST_PROBE_MS = '1000'
+
+    $env:HP_TEST_APP_SHOULD_FAIL = '0'
+    $alRun1Exit = Invoke-Bootstrap -WorkDir $alDir -LogName '~al_run1.log'
+
+    $env:HP_TEST_FORCE_INTERACTIVE_PROBE = '1'
+    $env:HP_TEST_APP_SHOULD_FAIL = '1'
+    $alRun2Exit = Invoke-Bootstrap -WorkDir $alDir -LogName '~al_run2.log'
+
+    if ($null -eq $savedSkipPipreqsAl) { Remove-Item Env:HP_SKIP_PIPREQS -ErrorAction SilentlyContinue } else { $env:HP_SKIP_PIPREQS = $savedSkipPipreqsAl }
+    if ($null -eq $savedLaneAl) { Remove-Item Env:HP_CI_LANE -ErrorAction SilentlyContinue } else { $env:HP_CI_LANE = $savedLaneAl }
+    if ($null -eq $savedForceAl) { Remove-Item Env:HP_TEST_FORCE_INTERACTIVE_PROBE -ErrorAction SilentlyContinue } else { $env:HP_TEST_FORCE_INTERACTIVE_PROBE = $savedForceAl }
+    if ($null -eq $savedProbeMsAl) { Remove-Item Env:HP_FAILFAST_PROBE_MS -ErrorAction SilentlyContinue } else { $env:HP_FAILFAST_PROBE_MS = $savedProbeMsAl }
+    if ($null -eq $savedShouldFailAl) { Remove-Item Env:HP_TEST_APP_SHOULD_FAIL -ErrorAction SilentlyContinue } else { $env:HP_TEST_APP_SHOULD_FAIL = $savedShouldFailAl }
+
+    $alRun2LogPath = Join-Path $alDir '~al_run2.log'
+    $alRun2Lines = if (Test-Path $alRun2LogPath) { Get-Content -LiteralPath $alRun2LogPath -Encoding ASCII } else { @() }
+    $alRun2Text = $alRun2Lines -join "`n"
+    $alStatusPath = Join-Path $alDir '~bootstrap.status.json'
+    $alStatusState = $null
+    if (Test-Path $alStatusPath) {
+        try { $alStatusState = (Get-Content -LiteralPath $alStatusPath -Raw | ConvertFrom-Json).state } catch { $alStatusState = $null }
+    }
+    $alExePath = Join-Path $alDir 'dist\env.exe'
+    # ENVNAME normalizes to the workdir folder name; fall back to a wildcard lookup so this does
+    # not depend on guessing run_setup.bat's exact sanitization for this particular folder name.
+    $alExeCandidates = @(Get-ChildItem -Path (Join-Path $alDir 'dist') -Filter '*.exe' -ErrorAction SilentlyContinue)
+
+    $alLaunchedInteractive = $alRun2Text -match [regex]::Escape('Launching your program now via the cached standalone EXE')
+    $alAliveMsg = $alRun2Text -match [regex]::Escape('Fail-fast probe: still running after')
+    $alStatusFailed = $alRun2Text -match [regex]::Escape('Run Status: FAILED (Exit Code: 7)')
+    $alNotDiscarded = -not ($alRun2Text -match [regex]::Escape('discarding cached EXE and rebuilding'))
+    $alExeStillPresent = $alExeCandidates.Count -gt 0
+    $alBootstrapStayedOk = ($alStatusState -eq 'ok')
+
+    $alivePass = ($alRun1Exit -eq 0) -and ($alRun2Exit -eq 0) -and $alLaunchedInteractive -and $alAliveMsg -and $alStatusFailed -and $alNotDiscarded -and $alExeStillPresent -and $alBootstrapStayedOk
+    $aliveDetails = [ordered]@{
+        run1Exit             = $alRun1Exit
+        run2Exit             = $alRun2Exit
+        launchedInteractive  = $alLaunchedInteractive
+        aliveMsgLogged       = $alAliveMsg
+        statusFailedLogged   = $alStatusFailed
+        notDiscarded         = $alNotDiscarded
+        exeStillPresent      = $alExeStillPresent
+        bootstrapState       = $alStatusState
+        run2Log              = '~al_run2.log'
+    }
+} catch {
+    $aliveDetails = [ordered]@{ error = $_.Exception.Message }
+}
+
+Write-NdjsonRow ([ordered]@{
+    id      = 'self.failfast.probe.alive'
+    req     = 'REQ-018'
+    pass    = $alivePass
+    desc    = 'Fail-fast probe: a cached EXE still running past the probe window is never discarded, even if it later exits non-zero; the bootstrap reports the true outcome and stays state=ok'
+    details = $aliveDetails
+})
+
+if (-not ($fastfailPass -and $alivePass)) { exit 1 }
+exit 0


### PR DESCRIPTION
## Summary

- Adds a shared fail-fast probe to the two remaining untimed user-code launch points, `:try_fast_exe` (cached-EXE reuse) and `:verify_no_exe_interpreter` (no-EXE interpreter run), closing out Slice 2b-C of the REQ-018 unified run-model work. A real interactive user (`HP_INTERACTIVE_RUN`, mirroring `:pick_entry_interactive`'s existing signals) gets a short classification window (default 5000ms, `HP_FAILFAST_PROBE_MS`) followed by an unbounded wait that never calls `Kill()`, so a genuinely long-running app (server/GUI) is never hard-killed while a stale/broken cached EXE still triggers a discard-and-rebuild. CI/automation keeps the prior plain-redirect behavior byte-for-byte unchanged (`HP_TEST_FORCE_INTERACTIVE_PROBE=1` forces the new branch under `HP_CI_LANE` for deterministic CI coverage).
- Fixes a silent-success gap the new state machine surfaced: the top-of-file fast-path success shortcut previously trusted `HP_FASTPATH_USED` alone, which could now stay set through a post-probe failure and hide it. `HP_FASTPATH_RUN_FAILED` decouples "keep the cached EXE, skip the rebuild" from "declare full success" at **both** `:try_fast_exe` call sites, so the bootstrap always surfaces the true `[STATUS] Run Status: ...` outcome instead of silently reporting success.
- Closes out the REQ-007 explicit-vocabulary requirement: every remaining user-facing build/verify/failure message about the standalone executable now names "EXE"/"PyInstaller"/"standalone .exe" explicitly.

## Notable fix found during review

An earlier revision of this change wrapped the legacy (non-interactive) launch + `%ERRORLEVEL%` capture inside a new parenthesized `if/else` dispatch block. cmd.exe expands every `%VAR%` in a parenthesized block once, at parse time, using values from *before* the block started -- this silently froze the captured exit code for the default/CI branch, which would have defeated the discard-and-rebuild safety net entirely. Caught by code review before push and fixed with goto-based dispatch (the same pattern this repo already uses for `:provider_cascade`), documented in `docs/agent-lessons-learned.md`.

## Test plan

- [x] `python tools/check_delimiters.py run_setup.bat`
- [x] `python -m compileall -q .` / `python -m pyflakes .`
- [x] PowerShell AST syntax validation (`pwsh`) on `tests/harness.ps1` and the new `tests/selfapps_failfast_probe.ps1`
- [x] `actionlint` / `yamllint` on the modified workflow file
- [x] `python -m pytest tests/test_*.py` (192 passed, 2 skipped -- Windows-only)
- [x] New `tests/selfapps_failfast_probe.ps1` (fast-failure discard scenario + alive-past-probe no-discard scenario) wired into the `real`/`conda-full` CI lanes; new `tests/harness.ps1` static guard `batch.failfast.probe`
- [x] CI run [28591439047](https://github.com/mixmansoundude/Python_vs_Windows/actions/runs/28591439047) green (`conclusion: success`), verified against the diagnostics site's raw NDJSON (not just the summary) -- `self.failfast.probe.fastfail`, `self.failfast.probe.alive`, and `batch.failfast.probe` all pass with real (non-skipped) interactive-branch evidence in both the `real` and `conda-full` lanes; pre-existing `self.fastpath` / `self.exe.fastpath.graceful` regression rows still pass, confirming the legacy/CI branch fix


---
_Generated by [Claude Code](https://claude.ai/code/session_01UVQtbgcCQaSjdKZoWWVo3b)_