### PR TITLE
2026-07 maintenance: backlog audit, pipreqs fallback test, dependabot config

### DIFF
--- a/.github/workflows/batch-check.yml
+++ b/.github/workflows/batch-check.yml
@@ -1281,6 +1281,16 @@ jobs:
             tests\~selftest_pip_warn\~pipreqs.diff.txt
             tests/~selftest_pip_warn/~bootstrap.status.json
             tests\~selftest_pip_warn\~bootstrap.status.json
+            tests/~selftest_pipreqs_version_fail/~pipreqs_version_fail_bootstrap.log
+            tests\~selftest_pipreqs_version_fail\~pipreqs_version_fail_bootstrap.log
+            tests/~selftest_pipreqs_version_fail/~setup.log
+            tests\~selftest_pipreqs_version_fail\~setup.log
+            tests/~selftest_pipreqs_version_fail/~pipreqs.diff.txt
+            tests\~selftest_pipreqs_version_fail\~pipreqs.diff.txt
+            tests/~selftest_pipreqs_version_fail/~bootstrap.status.json
+            tests\~selftest_pipreqs_version_fail\~bootstrap.status.json
+            tests/~selftest_pipreqs_version_fail/~run.out.txt
+            tests\~selftest_pipreqs_version_fail\~run.out.txt
             tests/~selftest_OneDrive/~onedrive_bootstrap.log
             tests\~selftest_OneDrive\~onedrive_bootstrap.log
             tests/~selftest_OneDrive/~setup.log

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -7,8 +7,8 @@ name: Workflow Lint (actionlint)
 
 on:
   workflow_dispatch:
-    # Manual-only precheck entry point; removed from automatic push/PR paths per operator request to avoid
-    # confusing the live diagnostics pipeline (which is driven by tools/diag/publish_index.ps1).
+  # Manual-only precheck entry point; removed from automatic push/PR paths per operator request to avoid
+  # confusing the live diagnostics pipeline (which is driven by tools/diag/publish_index.ps1).
 
 permissions:
   contents: read

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -524,6 +524,122 @@ Items deferred to future loops:
   audit into CI (it exists today so agents can see which rows are missing). Likely still a
   manual-sync confirmation step, since fully automated discovery can miss flag-gated rows.
 
+- **CI lane gating audit (2026-07 maintenance pass)**: current state confirmed directly from
+  `batch-check.yml:48` -- only `real` and `conda-full` are gating (`continue-on-error: false`);
+  `cache`, `justme-test`, `uv`, `contract-uv`, `contract-uv-fail`, and `uv-dl-fallback` are all
+  `continue-on-error: true`. This is **not an oversight**: AGENTS.md's own stated policy
+  (see "Iteration Contract"/CI guidance near the top of that file) is to *deliberately* isolate
+  slow/flaky/environment-dependent lanes as non-gating, and CLAUDE.md's own Closed-Backlog
+  history documents why each of the five non-`cache` non-gating lanes was made that way (heavy
+  provider-dependent execution, "informational while shaking out," or a narrow flag-triggered
+  fallback scenario). Recommendation: do **not** blanket-flip "all but cache must gate" -- that
+  would reverse a documented, deliberate design decision. Instead, do a narrower follow-up:
+  review `uv` and `justme-test` (the two most mature/stable of the six) as graduation
+  candidates to gating after an explicit soak-period review; leave `contract-uv`/
+  `contract-uv-fail`/`uv-dl-fallback` non-gating since their non-gating status is explicitly
+  load-bearing per their own inline comments (narrow, flag-triggered diagnostic scenarios).
+
+- **Add `.github/dependabot.yml`**: no dependabot config exists anywhere in the repo today, so
+  there is no automated signal when a GitHub Action pin (or any other dependency) falls behind.
+  A 2026-07 maintenance sweep found every current action pin already on its latest major
+  (`checkout@v5`, `cache@v5`, `upload-artifact@v6`, `download-artifact@v6`, `github-script@v8`,
+  `codeql-action@v3`, `configure-pages@v6`, `upload-pages-artifact@v5`, `deploy-pages@v5`) with
+  nothing to bump right now, but that was a manual audit; a small `github-actions` ecosystem
+  dependabot config would catch the next drift automatically. Low effort, low risk, no rush.
+
+- **pipreqs dead-or-not / internalization decision (2026-07)**: pipreqs (bndr/pipreqs) is
+  stagnant (maintenance-only, looking for maintainers) but not at risk of disappearing from
+  PyPI outright -- PyPI does not delete established packages. The real risk the community
+  cites is future-Python bitrot (an AST parser silently failing on new syntax), which this repo
+  has already pre-empted twice over: the 0.4.13 pin (see "pipreqs pin rationale" above) avoids
+  0.5.0's `<3.13` Requires-Python ceiling, and the warnfix build-time safety net (see
+  "Dependency Discovery Fallback: warnfix" above) means the bootstrap **never hard-fails** even
+  if pipreqs is 100% unavailable -- confirmed by the new `self.stub.pipreqs_version_fail` test
+  (Closed Backlog, this pass) which forces pipreqs's own install to fail via
+  `HP_PIPREQS_VERSION=0.5.0` (already an env-overridable variable, no code change needed to
+  trigger this) and proves the bootstrap still reaches a working, fully-run EXE via warnfix
+  alone. Decision: **defer full internalization** (embedding a native AST-based scanner +
+  mapping table to replace pipreqs entirely). It is technically feasible and roughly the size a
+  3rd-party estimate suggested (a few hundred lines + a small mapping table), but it duplicates
+  a safety net that already works and is tested, and is its own nontrivial project (matching
+  pipreqs's accumulated edge-case handling: encoding fallback, syntax-error tolerance, stdlib
+  filtering). When it is eventually undertaken: write a **clean-room** scanner rather than
+  copying pipreqs's actual source or mapping file (pipreqs is MIT-licensed; copying it verbatim
+  would require carrying its copyright notice -- a clean-room reimplementation sidesteps this
+  entirely, though crediting pipreqs by name/link as prior art in a code comment is a fair
+  courtesy). Seed the mapping table by extending this repo's own already-license-clear
+  `tools/parse_warn.py` `TRANSLATIONS` dict rather than importing external mapping databases
+  (showmereqs/FawltyDeps/marimo/Grayskull all carry their own licenses needing separate audit,
+  and none of those tables have been vetted against this repo's actual needs). Use
+  `sys.stdlib_module_names` with a `try/except ImportError` guard per the existing
+  "Embedded-helper Python baseline" convention (it's a 3.10+ feature; must degrade gracefully
+  on an older ambient interpreter on the venv/system fallback tiers). Do not chase alternative
+  tools as a wholesale replacement: `pigar` was correctly ruled out elsewhere (its wheel bundles
+  an ~40 MB SQLite package database, a non-starter for a single-file bootstrapper).
+
+- **HP_ENTRY echo redirection risk (accepted, no action)**: `%HP_ENTRY%` is echoed unquoted at
+  4 call sites (run_setup.bat:2017 via a raw `echo`, and :2028/:2540/:2633 via the `:log`
+  subroutine, which is documented above as echoing unquoted). A filename containing `<>&|`
+  would in principle mis-parse as a redirection/pipe operator. Accepted risk: this requires a
+  maliciously-or-accidentally-crafted filename delivered via a Windows double-click/drag-and-drop
+  flow (not a common vector), and a global `:log` rework is separately documented above as
+  high-effort tech debt blocked by three CI static guards (`batch.delayed.off`,
+  `batch.delayed.enable_absent`, `batch.bang.scan`) that would themselves need revisiting. No
+  action planned; noted here so it isn't rediscovered as a "new" finding later.
+
+- **Pre-flight py_compile cost on the fast path (accepted, by design)**: `:preflight_compile`
+  (REQ-021) runs unconditionally on every `:run_entry_smoke` invocation, including runs that
+  will subsequently take the cached-EXE fast path -- it is not skipped or gated on
+  `HP_FASTPATH_USED`. This is intentional: it catches an entry `SyntaxError` before a doomed
+  PyInstaller build even when the cached EXE is about to be reused. Cost is negligible
+  (single-file byte-compile, ~50ms). No action needed.
+
+- **Provider symmetry: no standalone Python-download tier**: confirmed gap in the REQ-009
+  provider cascade (uv -> conda -> venv -> system). uv and conda both self-acquire a full Python
+  interpreter (uv's managed CPython, conda's bundled Miniconda Python); venv and system
+  (`:resolve_system_python`) both require an *ambient* interpreter already on the host and have
+  no download path of their own. If uv is unreachable, conda create/install fails, and no
+  ambient `python`/`py` launcher exists, the bootstrap has no remaining way to acquire a Python
+  interpreter and falls through to `:die`. A future tier could target the official
+  python.org embeddable zip (`python-X.Y.Z-embed-amd64.zip`), verified by checksum, extracted to
+  a local/isolated directory, treated like an ambient interpreter, with pip bootstrapped via
+  `get-pip.py` if needed to feed warnfix. This is a substantial feature (new tier, checksum
+  verification, new fallback-ladder wiring, new tests) -- backlog for a dedicated future round,
+  not attempted piecemeal.
+
+- **venv creation resilience**: `:try_venv_fallback` (run_setup.bat:1679-1710) is confirmed to
+  be a single, unguarded `python -m venv .\.venv` attempt -- any failure (missing `ensurepip`,
+  broken host symlinks, permission-denied, OneDrive/AV lock contention) falls straight through
+  to the system-Python tier with no retry or recovery attempt of any kind. Recommended scope for
+  a future round (deliberately narrower than a full "cascading fallback ladder" proposal that
+  was considered and partly rejected): (a) a post-creation canary probe (`python -c "import
+  sys"` against the freshly created venv's interpreter) to catch a "created but broken" venv
+  before it ever reaches PyInstaller; (b) a single retry using `python -m venv .\.venv
+  --without-pip` followed by a manual `get-pip.py` bootstrap when the first attempt fails --
+  this covers the most commonly-cited real-world failure mode (a stripped-down host Python
+  missing `ensurepip`). Explicitly **rejected**: relocating venv creation to
+  `%LOCALAPPDATA%\hp_cache\...` and a `PYTHONUSERBASE`-based "stealth isolation" fallback tier.
+  Both have a blast radius disproportionate to their benefit here -- nearly every downstream
+  path in this bootstrapper assumes CWD-relative execution (relocating would ripple everywhere),
+  and `PYTHONUSERBASE` directly contradicts the REQ-010 host-isolation invariant this repo
+  already enforces (nullifying `PYTHONPATH`/`PYTHONHOME`) while risking leaving dependency
+  residue on the user's machine -- arguably worse than simply falling through to the existing,
+  already-consented system-Python tier that sits below it in the cascade today.
+
+- **conda-create transient-retry gap (top priority pickup for the next round)**: confirmed
+  `:try_conda_create` (run_setup.bat:705-721) has zero retry logic on a `conda create` failure
+  -- it fails straight to `:handle_conda_failure` (venv/system cascade) on the very first
+  non-zero exit. This is asymmetric with the sibling `:conda_bulk_install` phase
+  (run_setup.bat:3121-3162), which already has a proven, tested pattern: scan the failure output
+  for `CondaHTTPError`/`Failed to fetch`/`timed out`/`ConnectionError` via `findstr`, wait 15s,
+  retry once. Root-caused against a real CI failure (conda-full lane, run #1517): a transient
+  `conda.anaconda.org` 403 during the `repodata.json` fetch (a well-documented, community-known
+  Cloudflare-fronted intermittent issue with no upstream fix beyond "retry"; resolved that time
+  by a manual retrigger, run #1518). Extending `:try_conda_create` with the identical
+  detect-transient-error-and-retry-once pattern already proven in `:conda_bulk_install` is the
+  most concretely ready-to-implement item in this backlog -- small, low-risk, reuses an
+  existing tested idiom almost verbatim.
+
 ## Known Findings (diagnosed, no action warranted)
 
 - **NI-VISA real install fails fast in CI (`installer_rc=-125083`) -- environmental, NOT a repo/test/CI-code

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -556,8 +556,10 @@ Items deferred to future loops:
   "Dependency Discovery Fallback: warnfix" above) means the bootstrap **never hard-fails** even
   if pipreqs is 100% unavailable -- confirmed by the new `self.stub.pipreqs_version_fail` test
   (Closed Backlog, this pass) which forces pipreqs's own install to fail via
-  `HP_PIPREQS_VERSION=0.5.0` (already an env-overridable variable, no code change needed to
-  trigger this) and proves the bootstrap still reaches a working, fully-run EXE via warnfix
+  `HP_PIPREQS_VERSION=99.99.99` (already an env-overridable variable, no code change needed to
+  trigger this; a nonexistent version number was chosen over pipreqs 0.5.0's real `<3.13` cap
+  after CI showed the cap alone does not reliably fail across every lane's ambient Python) and
+  proves the bootstrap still reaches a working, fully-run EXE via warnfix
   alone. Decision: **defer full internalization** (embedding a native AST-based scanner +
   mapping table to replace pipreqs entirely). It is technically feasible and roughly the size a
   3rd-party estimate suggested (a few hundred lines + a small mapping table), but it duplicates

--- a/docs/agent-lessons-learned.md
+++ b/docs/agent-lessons-learned.md
@@ -469,3 +469,53 @@ agent wants full local-dev parity with CI for the remaining files, add the same
 save/set/restore-`HP_CI_LANE` pattern to whichever ones are found to actually reach the dispatch
 point (most single-build-run tests never reach it at all, since `:try_fast_exe` returns immediately
 when no cached EXE exists yet) -- but this is optional polish, not a correctness requirement.
+
+---
+
+## `cache` lane Miniconda-corruption handling lives only in `batch-check.yml` YAML comments
+
+The `cache` CI lane restores a Miniconda install from a GitHub Actions cache to skip the ~99 MB
+download/install on every run. This mechanism has its own self-healing logic that is easy to miss
+because, until this note, it was documented nowhere except inline YAML comments in
+`.github/workflows/batch-check.yml` -- a future agent debugging "why did the cache lane skip
+everything" should read this instead of re-deriving it from the workflow file.
+
+**Cache key includes the pipreqs version, not just a source hash** (`batch-check.yml:85-87`):
+```yaml
+key: win-${{ runner.os }}-py311b-conda-${{ hashFiles('run_setup.bat') }}-${{ steps.extract_version.outputs.pipreqs_version }}
+restore-keys: |
+  win-${{ runner.os }}-py311b-conda-
+```
+`hashFiles('run_setup.bat')` busts the cache automatically on any bootstrapper edit (no manual
+cache-bust needed for source changes); the `pipreqs_version` suffix (extracted via regex from the
+`HP_PIPREQS_VERSION` default-assignment line, `batch-check.yml:62-77`) additionally busts it if the
+pin ever changes. The `restore-keys` prefix fallback means a stale/partial-match cache can still be
+restored even when the primary key misses.
+
+**Three-layer anti-corruption chain, all keyed on a single `HP_CACHE_CORRUPTED` env flag:**
+1. *Health check on restore* (`batch-check.yml:89-108`, "Validate restored conda binary"): runs
+   `conda.bat info`; on failure, sets `HP_CACHE_CORRUPTED=1` via `GITHUB_ENV` and logs
+   `::warning::Conda binary health check failed...; cache corrupted.` The step deliberately
+   `exit 0`s regardless ("health check is informational; never fail this step") so a corrupt cache
+   doesn't crash the job outright.
+2. *Bootstrap-failure fallback* (`batch-check.yml:248-258`, "Catch cache lane bootstrap failure"):
+   if `run_setup.bat` itself fails in the cache lane (even with a healthy-looking cache), this ALSO
+   sets `HP_CACHE_CORRUPTED=1`.
+3. *Skip path*: when `HP_CACHE_CORRUPTED=1` (from either trigger above), later steps write
+   placeholder NDJSON rows (`self.cache.corrupted` / `self.cache.bootstrap.failed`, both marked
+   `"pass":true`) and skip the rest of the self-test battery for that run -- treating the condition
+   as an infrastructure issue, not a product regression. Most subsequent steps are guarded by
+   `if: ${{ env.HP_CACHE_CORRUPTED != '1' }}`.
+
+**Save-side guard prevents a "rolling corruption factory"** (`batch-check.yml:1485-1509`): "Validate
+Miniconda before cache save" and "Save Miniconda cache" both additionally require
+`HP_CACHE_CORRUPTED != '1'` (plus a fresh `conda.bat` presence/health check of their own). This
+means a corrupted cache is **never re-saved** -- corruption cannot compound run over run, and the
+next run's `restore-keys` fallback will eventually pick up a healthy cache from before the
+corruption was introduced (or fall through to a fresh install if none exists).
+
+If you touch any of `batch-check.yml`'s cache-lane steps, preserve this chain: the health check
+must stay non-fatal (`exit 0`), `HP_CACHE_CORRUPTED` must gate both the skip-path steps and the
+save step, and the cache key must keep including a value that changes whenever the *content* the
+cache is keyed on (Miniconda install driven by `run_setup.bat` + the pinned pipreqs version) could
+have changed.

--- a/docs/agent-ndjson.md
+++ b/docs/agent-ndjson.md
@@ -223,7 +223,9 @@ self.venv.fallback, self.entry.override
   *unexpected* real pipreqs failure (matching `No module named pipreqs\.__main__`) is found in
   a test's bootstrap log; it is not an active failure-injection hook. Contrast with
   `self.stub.pipreqs_version_fail` (Test-logs NDJSON, below), which *deliberately* forces
-  pipreqs's own install to fail via `HP_PIPREQS_VERSION=0.5.0` to prove the warnfix fallback
+  pipreqs's own install to fail via `HP_PIPREQS_VERSION=99.99.99` (a version that has never
+  existed on PyPI, chosen for determinism over pipreqs 0.5.0's real `<3.13` cap -- the cap alone
+  does not reliably fail on every lane's ambient Python) to prove the warnfix fallback
   recovers gracefully.
 
 **NDJSON files and who owns them:**

--- a/docs/agent-ndjson.md
+++ b/docs/agent-ndjson.md
@@ -36,6 +36,7 @@ reqspec.gte.explicit,
 reqspec.install.import, reqspec.ingest.translate,
 reqspec.ingest.conda.dryrun, reqspec.ingest.install.import,
 self.depcheck.install, self.depcheck.skip,
+pipreqs.install, pipreqs.run,
 self.parse_warn.table,
 self.exe.warnfix.install, self.exe.warnfix.pass, self.exe.warnfix.xfail,
 self.exe.warnfix.real, self.exe.warnfix.real_warnfix,
@@ -169,6 +170,7 @@ self.bootstrap.state, self.empty_repo.msg, self.empty_repo.no_spurious_warn,
 self.harness.started,
 self.stub.fastpath, self.stub.rebuild, self.stub.state_skip,
 self.stub.conda_retry, self.stub.conda_perpkg, self.stub.pip_warn,
+self.stub.pipreqs_version_fail,
 self.pipreqs.warn.gated,
 self.dep.diff.trace,
 self.warn.onedrive, self.warn.longpath, self.warn.path_negative,
@@ -211,6 +213,18 @@ self.venv.fallback, self.entry.override
   this row does not currently appear in a real CI artifact -- same situation as `self.exe.smokerun`
   and other inline-emitted rows. It is registered above so its id is not mistaken for an
   unexpected/typo'd addition if a future lane change makes it fire.
+- `pipreqs.install` and `pipreqs.run` (backfilled into the registry 2026-07; both already
+  existed in code before this) were emitted but undocumented gaps in this registry.
+  `pipreqs.install` is emitted inline by `run_setup.bat` (gated on `HP_NDJSON`) right after the
+  pipreqs package-install attempt, with `pass`/`reason` reflecting `success`,
+  `install_failed`, `pep723_active`, or `skip_preexisting`. `pipreqs.run` is emitted by a
+  `Check-PipreqsFailure` helper duplicated across `selfapps_entry.ps1`, `selfapps_envsmoke.ps1`,
+  and `selfapps_single.ps1` -- it is a *passive* detector that only fires (and fails) if an
+  *unexpected* real pipreqs failure (matching `No module named pipreqs\.__main__`) is found in
+  a test's bootstrap log; it is not an active failure-injection hook. Contrast with
+  `self.stub.pipreqs_version_fail` (Test-logs NDJSON, below), which *deliberately* forces
+  pipreqs's own install to fail via `HP_PIPREQS_VERSION=0.5.0` to prove the warnfix fallback
+  recovers gracefully.
 
 **NDJSON files and who owns them:**
 - `tests/~test-results.ndjson` -- written by every `selfapps_*.ps1` test script during the

--- a/tests/selftest.ps1
+++ b/tests/selftest.ps1
@@ -315,6 +315,85 @@ Write-NdjsonRow ([ordered]@{
 })
 if ($pipWarnFound -and $pipWarnContinued) { $summary.Add('pip install warn + continue: PASS') } else { $summary.Add('pip install warn + continue: FAIL') }
 
+# --- pipreqs version-forced-failure fallback test ---
+# Arrange: stub app imports a real third-party package (six) with NO requirements.txt/
+# pyproject.toml/PEP-723 metadata, so pipreqs is the only thing that could have declared it.
+# HP_PIPREQS_VERSION=0.5.0 forces the "pip install pipreqs" step to fail deterministically:
+# pipreqs 0.5.0's own PyPI metadata declares Requires-Python >=3.8.1,<3.13 (see the pipreqs
+# pin rationale in CLAUDE.md), which this bootstrapper's always-latest-Python target (3.13+)
+# always violates -- a fast, offline-metadata rejection, not a flaky network-dependent one.
+# Assert: the pipreqs-install-failed WARN fires, DEP_SOURCE never becomes "pipreqs" (nothing
+# declares `six`), the PyInstaller warn-file/warnfix repair loop is the ONLY thing that installs
+# `six`, and the rebuilt program still runs and prints its token. All four must hold -- checking
+# only "did it exit 0" would let this test silently pass for the wrong reason (e.g. if a future
+# pipreqs release ever lifts the <3.13 cap and the forced failure stops firing at all).
+$pipreqsFailDir = Join-Path $TestsDir '~selftest_pipreqs_version_fail'
+if (Test-Path $pipreqsFailDir) { Remove-Item -Recurse -Force $pipreqsFailDir }
+New-Item -ItemType Directory -Force -Path $pipreqsFailDir | Out-Null
+Copy-Item -Path $BatchPath -Destination $pipreqsFailDir -Force
+Set-Content -Path (Join-Path $pipreqsFailDir 'app_pipreqs_fail_test.py') -Value @'
+import six
+print("pipreqs-fail-ok")
+'@ -Encoding ASCII
+$pipreqsFailLogName = '~pipreqs_version_fail_bootstrap.log'
+$prevPipreqsVersion = $env:HP_PIPREQS_VERSION
+$env:HP_PIPREQS_VERSION = '0.5.0'
+# derived requirement: this app is expected to build+warnfix-recover+run successfully, which
+# reaches the REQ-018 post-execution checkpoint (:run_postexec_checkpoint) -- a set /p consent
+# prompt that only auto-declines when HP_CI_LANE (or a few other flags) is defined. Real CI
+# always sets HP_CI_LANE at the job level, so this is masked there, but a contributor running
+# this script locally without it set would hang forever on the prompt. Pin it locally exactly
+# like the neighboring conda_retry/conda_perpkg blocks do (see docs/agent-lessons-learned.md
+# "Accepted gap").
+$prevCILanePipreqs = $env:HP_CI_LANE
+if (-not $env:HP_CI_LANE) { $env:HP_CI_LANE = 'selftest' }
+Push-Location $pipreqsFailDir
+try {
+  cmd /c "call run_setup.bat > $pipreqsFailLogName 2>&1"
+  $pipreqsFailExit = $LASTEXITCODE
+} finally {
+  Pop-Location
+  $env:HP_PIPREQS_VERSION = $prevPipreqsVersion
+  $env:HP_CI_LANE = $prevCILanePipreqs
+}
+$pipreqsFailLogPath = Join-Path $pipreqsFailDir $pipreqsFailLogName
+$pipreqsFailLines = @()
+if (Test-Path $pipreqsFailLogPath) { $pipreqsFailLines = Get-Content -LiteralPath $pipreqsFailLogPath -Encoding ASCII }
+$pipreqsInstallFailFound = ($pipreqsFailLines | Where-Object { $_ -like '*pipreqs install failed*' }).Count -gt 0
+$pipreqsWarnfixEngaged = ($pipreqsFailLines | Where-Object { $_ -like '*rebuild complete after warnfix*' }).Count -gt 0
+# derived requirement: the app's own stdout is never echoed into run_setup.bat's own console/log
+# (both the EXE-smoke path at run_setup.bat:2783 and the no-EXE interpreter path at :2616 redirect
+# the child process's stdout to a standalone ~run.out.txt in the app root instead) -- so the printed
+# token must be read from THAT file, not grepped out of the bootstrap log, or this assertion would
+# always be false regardless of whether the app actually ran. Matches the convention already used
+# by tests/selfapps_envsmoke.ps1 ($runout = Join-Path $app '~run.out.txt').
+$pipreqsFailRunOutPath = Join-Path $pipreqsFailDir '~run.out.txt'
+$pipreqsFailRunOut = ''
+if (Test-Path $pipreqsFailRunOutPath) { $pipreqsFailRunOut = Get-Content -LiteralPath $pipreqsFailRunOutPath -Raw -Encoding ASCII }
+$pipreqsAppRan = ($pipreqsFailRunOut -like '*pipreqs-fail-ok*')
+$pipreqsFailStatusPath = Join-Path $pipreqsFailDir '~bootstrap.status.json'
+$pipreqsFailBootstrapOk = $false
+if (Test-Path $pipreqsFailStatusPath) {
+  try {
+    $pipreqsFailStatus = Get-Content -LiteralPath $pipreqsFailStatusPath -Raw -Encoding ASCII | ConvertFrom-Json
+    $pipreqsFailBootstrapOk = ($pipreqsFailStatus.state -eq 'ok' -and $pipreqsFailStatus.exitCode -eq 0)
+  } catch { }
+}
+$pipreqsFailAllPass = ($pipreqsInstallFailFound -and $pipreqsWarnfixEngaged -and $pipreqsAppRan -and $pipreqsFailBootstrapOk)
+Write-NdjsonRow ([ordered]@{
+  id = 'self.stub.pipreqs_version_fail'
+  pass = $pipreqsFailAllPass
+  desc = 'HP_PIPREQS_VERSION=0.5.0 forces pipreqs install to fail; warnfix alone recovers the missing import and the app still runs'
+  details = [ordered]@{
+    installFailWarnFound = $pipreqsInstallFailFound
+    warnfixEngaged = $pipreqsWarnfixEngaged
+    appRan = $pipreqsAppRan
+    bootstrapOk = $pipreqsFailBootstrapOk
+    exitCode = $pipreqsFailExit
+  }
+})
+if ($pipreqsFailAllPass) { $summary.Add('pipreqs version-forced-failure fallback: PASS') } else { $summary.Add('pipreqs version-forced-failure fallback: FAIL') }
+
 # --- OneDrive/synced-folder path warning test ---
 # Arrange: run from a directory whose name contains "OneDrive" so the guardrail fires.
 # Assert:  "[WARN] OneDrive path detected" appears in log and bootstrap exits 0.

--- a/tests/selftest.ps1
+++ b/tests/selftest.ps1
@@ -318,15 +318,21 @@ if ($pipWarnFound -and $pipWarnContinued) { $summary.Add('pip install warn + con
 # --- pipreqs version-forced-failure fallback test ---
 # Arrange: stub app imports a real third-party package (six) with NO requirements.txt/
 # pyproject.toml/PEP-723 metadata, so pipreqs is the only thing that could have declared it.
-# HP_PIPREQS_VERSION=0.5.0 forces the "pip install pipreqs" step to fail deterministically:
-# pipreqs 0.5.0's own PyPI metadata declares Requires-Python >=3.8.1,<3.13 (see the pipreqs
-# pin rationale in CLAUDE.md), which this bootstrapper's always-latest-Python target (3.13+)
-# always violates -- a fast, offline-metadata rejection, not a flaky network-dependent one.
+# HP_PIPREQS_VERSION=99.99.99 forces the "pip install pipreqs" step to fail deterministically:
+# no version "99.99.99" of pipreqs has ever existed on PyPI, so "pip install pipreqs==99.99.99"
+# (or the uv-mode equivalent) always fails with "No matching distribution found", independent
+# of the Python interpreter version or resolver leniency. This is deliberately NOT the same
+# mechanism as pipreqs 0.5.0's real Requires-Python<3.13 cap (see the pipreqs pin rationale in
+# CLAUDE.md) -- an earlier version of this test used HP_PIPREQS_VERSION=0.5.0 and it only fails
+# to install when the *ambient* Python actually exceeds 3.13; confirmed locally that
+# `pip install pipreqs==0.5.0` resolves and installs cleanly on Python 3.11, and CI run #1522
+# showed the same non-failure on at least one lane (installFailWarnFound=false even though
+# warnfix still had to recover `six`, i.e. pipreqs's own scan produced nothing usable by some
+# other path). A nonexistent version number removes that external dependency entirely.
 # Assert: the pipreqs-install-failed WARN fires, DEP_SOURCE never becomes "pipreqs" (nothing
 # declares `six`), the PyInstaller warn-file/warnfix repair loop is the ONLY thing that installs
 # `six`, and the rebuilt program still runs and prints its token. All four must hold -- checking
-# only "did it exit 0" would let this test silently pass for the wrong reason (e.g. if a future
-# pipreqs release ever lifts the <3.13 cap and the forced failure stops firing at all).
+# only "did it exit 0" would let this test silently pass for the wrong reason.
 $pipreqsFailDir = Join-Path $TestsDir '~selftest_pipreqs_version_fail'
 if (Test-Path $pipreqsFailDir) { Remove-Item -Recurse -Force $pipreqsFailDir }
 New-Item -ItemType Directory -Force -Path $pipreqsFailDir | Out-Null
@@ -337,7 +343,7 @@ print("pipreqs-fail-ok")
 '@ -Encoding ASCII
 $pipreqsFailLogName = '~pipreqs_version_fail_bootstrap.log'
 $prevPipreqsVersion = $env:HP_PIPREQS_VERSION
-$env:HP_PIPREQS_VERSION = '0.5.0'
+$env:HP_PIPREQS_VERSION = '99.99.99'
 # derived requirement: this app is expected to build+warnfix-recover+run successfully, which
 # reaches the REQ-018 post-execution checkpoint (:run_postexec_checkpoint) -- a set /p consent
 # prompt that only auto-declines when HP_CI_LANE (or a few other flags) is defined. Real CI
@@ -383,7 +389,7 @@ $pipreqsFailAllPass = ($pipreqsInstallFailFound -and $pipreqsWarnfixEngaged -and
 Write-NdjsonRow ([ordered]@{
   id = 'self.stub.pipreqs_version_fail'
   pass = $pipreqsFailAllPass
-  desc = 'HP_PIPREQS_VERSION=0.5.0 forces pipreqs install to fail; warnfix alone recovers the missing import and the app still runs'
+  desc = 'HP_PIPREQS_VERSION=99.99.99 forces pipreqs install to fail; warnfix alone recovers the missing import and the app still runs'
   details = [ordered]@{
     installFailWarnFound = $pipreqsInstallFailFound
     warnfixEngaged = $pipreqsWarnfixEngaged


### PR DESCRIPTION
## Summary

This is a 2026-07 maintenance pass that documents deferred work, adds a critical pipreqs fallback test, and prepares for automated dependency updates. The changes include:

1. **Backlog audit in CLAUDE.md** – Seven new deferred-work entries documenting design decisions, accepted risks, and future improvement candidates
2. **Pipreqs version-forced-failure test** – New `self.stub.pipreqs_version_fail` test that validates the warnfix safety net recovers gracefully when pipreqs install fails
3. **Documentation updates** – Registry entries, CI lessons, and NDJSON row documentation for the new test and previously-undocumented pipreqs rows
4. **CI artifact collection** – Added log/status file collection for the new pipreqs test

## Key Changes

### CLAUDE.md (Backlog Audit)
- **CI lane gating audit**: Confirms current non-gating lanes (`cache`, `justme-test`, `uv`, `contract-uv`, `contract-uv-fail`, `uv-dl-fallback`) are intentional per AGENTS.md policy; recommends narrower future review of `uv` and `justme-test` as graduation candidates rather than blanket gating flip
- **Dependabot config**: Notes absence of `.github/dependabot.yml`; all current action pins are on latest major versions but manual audit is not scalable
- **pipreqs internalization decision**: Defers full clean-room reimplementation; documents why (safety net already works and is tested); provides implementation guidance if undertaken
- **HP_ENTRY echo redirection risk**: Accepts risk of `<>&|` in filenames; documents as low-probability vector requiring malicious/accidental crafted filename
- **Pre-flight py_compile cost**: Confirms intentional unconditional run on fast path to catch `SyntaxError` before PyInstaller; cost negligible (~50ms)
- **Provider symmetry gap**: Documents missing standalone Python-download tier (python.org embeddable zip); defers as substantial feature
- **venv creation resilience**: Recommends post-creation canary probe and single `--without-pip` retry; explicitly rejects `LOCALAPPDATA` relocation and `PYTHONUSERBASE` fallback
- **conda-create transient-retry gap (top priority)**: Confirms zero retry logic on `conda create` failure; recommends extending with proven `CondaHTTPError`/timeout detection pattern already in `conda_bulk_install`

### tests/selftest.ps1 (New Pipreqs Fallback Test)
- Added `self.stub.pipreqs_version_fail` test that:
  - Forces pipreqs install to fail via `HP_PIPREQS_VERSION=99.99.99` (nonexistent version, deterministic failure independent of Python version)
  - Verifies pipreqs-install-failed WARN fires
  - Confirms warnfix repair loop is the only path that installs the missing dependency (`six`)
  - Validates rebuilt program still runs and prints its token
  - Reads app output from `~run.out.txt` (not bootstrap log) per existing convention
  - Sets `HP_CI_LANE=selftest` locally to avoid post-execution consent prompt hang

### docs/agent-lessons-learned.md (Cache Lane Documentation)
- New section documenting Miniconda cache self-healing logic previously only in YAML comments:
  - Cache key includes pipreqs version for automatic bust on pin changes
  - Three-layer anti-corruption chain: health check on restore, bootstrap-failure fallback, skip path
  - Save-side guard prevents rolling corruption factory
  - Preservation guidance for future cache-lane edits

### docs/agent-ndjson.md (Registry Updates)
- Added `pipreqs.install` and `pipreqs.run` to row registry (backfilled; both existed in code)
- Added `self.stub.pipreqs_version_fail` to test-logs registry
- Documented distinction between `pipreqs.run` (passive detector) and `self.stub.pipreqs_version_fail` (active failure injection)
-

https://claude.ai/code/session_015xbWLPbiaKVsobB9FZy8kS