### PR TITLE
feat(REQ-023): add venv fallback canary probe

### DIFF
--- a/.github/workflows/batch-check.yml
+++ b/.github/workflows/batch-check.yml
@@ -1417,6 +1417,14 @@ jobs:
             tests\~selftest_venv_fallback\~bootstrap.status.json
             tests/~selftest_venv_fallback/~run.out.txt
             tests\~selftest_venv_fallback\~run.out.txt
+            tests/~selftest_venv_canary_fail/~venv_canary.log
+            tests\~selftest_venv_canary_fail\~venv_canary.log
+            tests/~selftest_venv_canary_fail/~setup.log
+            tests\~selftest_venv_canary_fail\~setup.log
+            tests/~selftest_venv_canary_fail/~pipreqs.diff.txt
+            tests\~selftest_venv_canary_fail\~pipreqs.diff.txt
+            tests/~selftest_venv_canary_fail/~bootstrap.status.json
+            tests\~selftest_venv_canary_fail\~bootstrap.status.json
             tests/~selftest_entry_override/~override.log
             tests\~selftest_entry_override\~override.log
             tests/~selftest_entry_override/~setup.log

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -566,24 +566,22 @@ a fact confirmed with no action needed, or a recurring/periodic check belongs in
   verification, new fallback-ladder wiring, new tests) -- backlog for a dedicated future round,
   not attempted piecemeal.
 
-- **venv creation resilience**: `:try_venv_fallback` (run_setup.bat:1717-1748) is confirmed to
-  be a single, unguarded `python -m venv .\.venv` attempt -- any failure (missing `ensurepip`,
-  broken host symlinks, permission-denied, OneDrive/AV lock contention) falls straight through
-  to the system-Python tier with no retry or recovery attempt of any kind. Recommended scope for
-  a future round (deliberately narrower than a full "cascading fallback ladder" proposal that
-  was considered and partly rejected): (a) a post-creation canary probe (`python -c "import
-  sys"` against the freshly created venv's interpreter) to catch a "created but broken" venv
-  before it ever reaches PyInstaller; (b) a single retry using `python -m venv .\.venv
-  --without-pip` followed by a manual `get-pip.py` bootstrap when the first attempt fails --
-  this covers the most commonly-cited real-world failure mode (a stripped-down host Python
-  missing `ensurepip`). Explicitly **rejected**: relocating venv creation to
-  `%LOCALAPPDATA%\hp_cache\...` and a `PYTHONUSERBASE`-based "stealth isolation" fallback tier.
-  Both have a blast radius disproportionate to their benefit here -- nearly every downstream
-  path in this bootstrapper assumes CWD-relative execution (relocating would ripple everywhere),
-  and `PYTHONUSERBASE` directly contradicts the REQ-010 host-isolation invariant this repo
-  already enforces (nullifying `PYTHONPATH`/`PYTHONHOME`) while risking leaving dependency
-  residue on the user's machine -- arguably worse than simply falling through to the existing,
-  already-consented system-Python tier that sits below it in the cascade today.
+- **venv creation resilience, part 2 (--without-pip retry)**: the post-creation canary probe
+  (part 1, REQ-023) shipped -- see Closed Backlog. Remaining: when `python -m venv .\.venv`
+  fails outright (not just a canary-probe failure after apparent success), retry once using
+  `python -m venv .\.venv --without-pip` followed by a manual `get-pip.py` bootstrap -- this
+  covers the most commonly-cited real-world failure mode (a stripped-down host Python missing
+  `ensurepip`). This needs new download infrastructure (fetching `get-pip.py`, likely mirroring
+  the existing Miniconda/uv downloader's retry/fallback-URL pattern) that the REQ-023 probe did
+  not require, so it's a meaningfully bigger and riskier slice -- keep it a separate round.
+  Explicitly **rejected**: relocating venv creation to `%LOCALAPPDATA%\hp_cache\...` and a
+  `PYTHONUSERBASE`-based "stealth isolation" fallback tier. Both have a blast radius
+  disproportionate to their benefit here -- nearly every downstream path in this bootstrapper
+  assumes CWD-relative execution (relocating would ripple everywhere), and `PYTHONUSERBASE`
+  directly contradicts the REQ-010 host-isolation invariant this repo already enforces
+  (nullifying `PYTHONPATH`/`PYTHONHOME`) while risking leaving dependency residue on the user's
+  machine -- arguably worse than simply falling through to the existing, already-consented
+  system-Python tier that sits below it in the cascade today.
 
 ## Periodic Maintenance Checks (recurring, quarterly)
 
@@ -670,6 +668,22 @@ rather than relying on manual memory.
 ## Closed Backlog
 
 Items completed and shipped:
+
+- **venv fallback canary probe (REQ-023)**: `:try_venv_fallback` (run_setup.bat:1721-1768)
+  previously declared the venv tier ready as soon as `.venv\Scripts\python.exe` existed on disk,
+  without ever confirming the interpreter actually runs -- a venv can be "created" (directory +
+  exe present) yet non-functional (missing DLLs, broken symlinks, execution-policy blocks),
+  exactly the failure mode a stripped-down or corrupted host Python produces. Added a
+  post-creation canary probe (`python -c "import sys"`) right before the tier is declared ready;
+  on failure it logs a WARN and `exit /b 1` exactly like the tier's three existing failure
+  branches already do, falling through to the next REQ-009 provider (system Python) with no new
+  failure-handling path needed. Goto-based dispatch (not nested in a parenthesized if/else) per
+  "Provider-cascade dispatch is goto-based on purpose" in `docs/agent-lessons-learned.md`. New
+  test hook `HP_TEST_FORCE_VENV_CANARY_FAIL` plus `self.venv.canary_fail` in
+  `tests/selfapps_ux_hardening.ps1` exercise this end-to-end. This was split from the broader
+  "venv creation resilience" backlog item -- the other half (a `--without-pip` + `get-pip.py`
+  retry when venv creation itself fails outright) needs new download infrastructure and remains
+  a separate Active Backlog item. CLOSED by this PR.
 
 - **conda-create transient-retry gap (REQ-022)**: `:try_conda_create` (run_setup.bat:705-761) previously
   had zero retry logic on a `conda create` failure -- it fell straight to `:handle_conda_failure`

--- a/README.md
+++ b/README.md
@@ -499,6 +499,18 @@ set lives in `run_setup.bat`.
 
 ---
 
+## [REQ-023] Venv Fallback Canary Probe
+
+- After the REQ-009 Tier 3 venv fallback (`:try_venv_fallback`) creates `.venv` and confirms the interpreter file exists, the bootstrapper verifies the interpreter actually runs (`python -c "import sys"`) before declaring the tier ready.
+- A venv can be "created" (directory and `python.exe` present) yet still be non-functional (missing DLLs, broken symlinks, execution-policy blocks). Without this check, a silently broken venv would reach PyInstaller and fail later with a more confusing error, or be reported as bootstrap success when the environment cannot actually run code.
+- If the probe fails, the venv tier is declined (as if creation itself had failed) and the bootstrap falls through to the next REQ-009 provider (system Python).
+- Log contract:
+  - `[WARN] venv fallback: interpreter created but failed canary probe (import sys).`
+- CI test flag: `HP_TEST_FORCE_VENV_CANARY_FAIL=1` simulates a failing probe after a real, successful venv creation.
+- Test NDJSON row: `self.venv.canary_fail` (in `tests/selfapps_ux_hardening.ps1`).
+
+---
+
 ## Maintenance, Logging, and Lessons Learned
 
 - Update conda base periodically (~30 days), but **skip on first Miniconda install**. Ensure base is configured to conda-forge before updating to avoid prompts.

--- a/docs/agent-lessons-learned.md
+++ b/docs/agent-lessons-learned.md
@@ -154,7 +154,7 @@ If a global `:log` fix is ever pursued, it is its own isolated task that must al
 those checks -- not a drive-by change.
 
 **Concrete unresolved instance, accepted risk, no action planned: `%HP_ENTRY%`.** `%HP_ENTRY%`
-is echoed unquoted at 4 call sites (run_setup.bat:2055 via a raw `echo`, and :2066/:2578/:2671
+is echoed unquoted at 4 call sites (run_setup.bat:2074 via a raw `echo`, and :2085/:2597/:2690
 via `:log`). A filename containing `<`/`>`/`&`/`|` would in principle mis-parse as a
 redirection/pipe operator here, exactly per the rule above. This requires a
 maliciously-or-accidentally-crafted filename delivered via a Windows double-click/drag-and-drop

--- a/docs/agent-ndjson.md
+++ b/docs/agent-ndjson.md
@@ -66,7 +66,7 @@ self.ux.system.gate.n, self.ux.system.gate.prompt, self.ux.system.gate.real, sel
 self.ux.gitignore.merge, self.ux.gitignore.preserve, self.ux.gitignore.idem,
 self.ux.gitattributes.merge, self.ux.gitattributes.idem,
 self.ux.postflight,
-self.venv.fallback, self.entry.override
+self.venv.fallback, self.venv.canary_fail, self.entry.override
 ```
 
 ## justme-test lane rows (flag-triggered)
@@ -194,7 +194,7 @@ self.ux.connectivity.offline.uv.skip, self.ux.connectivity.offline.conda.skip,
 self.ux.connectivity.online, self.ux.connectivity.retry,
 self.ux.system.gate.n, self.ux.system.gate.prompt, self.ux.system.gate.real, self.ux.system.gate.accept,
 self.sysbuild.decline,
-self.venv.fallback, self.entry.override
+self.venv.fallback, self.venv.canary_fail, self.entry.override
 ```
 
 ---

--- a/run_setup.bat
+++ b/run_setup.bat
@@ -138,6 +138,10 @@ rem HP_TEST_FORCE_CONNECTIVITY_CHECK=1: triggers connectivity gate at startup fo
 set "HP_TEST_FORCE_CONNECTIVITY_CHECK=%HP_TEST_FORCE_CONNECTIVITY_CHECK%"
 rem HP_TEST_FORCE_VENV_FAIL=1: simulates venv creation failure for REQ-009/REQ-014 branch coverage
 set "HP_TEST_FORCE_VENV_FAIL=%HP_TEST_FORCE_VENV_FAIL%"
+rem HP_TEST_FORCE_VENV_CANARY_FAIL=1: simulates the post-creation canary probe (REQ-023) failing
+rem after a real, successful venv creation (distinct from HP_TEST_FORCE_VENV_FAIL, which skips
+rem creation entirely)
+set "HP_TEST_FORCE_VENV_CANARY_FAIL=%HP_TEST_FORCE_VENV_CANARY_FAIL%"
 rem HP_TEST_FORCE_CONDA_FAIL=1: simulates conda env creation failure for REQ-009/REQ-014 branch coverage
 set "HP_TEST_FORCE_CONDA_FAIL=%HP_TEST_FORCE_CONDA_FAIL%"
 rem HP_TEST_FORCE_WARNFIX_UNRESOLVED=1: forces the warnfix cascade-candidate detection (REQ-009/REQ-005.10) for branch coverage
@@ -1740,6 +1744,21 @@ if not exist "%HP_PY%" (
   call :log "[WARN] venv fallback: interpreter missing after creation."
   exit /b 1
 )
+rem REQ-023: canary probe -- a venv can be "created" (directory + exe present) yet still be
+rem non-functional (missing DLLs, broken symlinks, execution-policy blocks). Verify the fresh
+rem interpreter actually runs before declaring success, so a silently broken venv doesn't reach
+rem PyInstaller only to fail later with a more confusing error. Goto-based (not nested inside
+rem an if/else block) per "Provider-cascade dispatch is goto-based on purpose" in
+rem docs/agent-lessons-learned.md, so the probe call + %ERRORLEVEL% read is never frozen by
+rem cmd's parse-time %VAR% expansion.
+if "%HP_TEST_FORCE_VENV_CANARY_FAIL%"=="1" goto :venv_canary_fail
+"%HP_PY%" -c "import sys" >nul 2>&1
+if errorlevel 1 goto :venv_canary_fail
+goto :venv_canary_ok
+:venv_canary_fail
+call :log "[WARN] venv fallback: interpreter created but failed canary probe (import sys)."
+exit /b 1
+:venv_canary_ok
 set "HP_ENV_MODE=venv"
 set "HP_BOOTSTRAP_STATE=venv_env"
 set "HP_SKIP_PIPREQS="

--- a/tests/selfapps_ux_hardening.ps1
+++ b/tests/selfapps_ux_hardening.ps1
@@ -653,6 +653,79 @@ if ($env:HP_FORCE_CONDA_ONLY -eq '1') {
     })
 }
 
+# ===== REQ-023: venv canary probe declines a created-but-broken venv =====
+# Forces conda to fail (reaching the venv tier) and forces the post-creation canary probe itself
+# to fail via HP_TEST_FORCE_VENV_CANARY_FAIL=1 (venv creation succeeds normally -- only the
+# "python -c import sys" health check is simulated as failing). Asserts the new WARN fires and
+# venv is correctly NOT selected as the provider, instead of silently declaring a broken venv
+# "ready". HP_TEST_SYSCON_ANSWER=N keeps the downstream system-Python consent gate
+# non-interactive so the run terminates deterministically (declining is expected/correct here --
+# every tier is forced to fail in this scenario on purpose).
+# Skipped in conda-full lane where HP_FORCE_CONDA_ONLY=1 blocks all fallbacks unconditionally.
+$venvCanaryDir = Join-Path $here '~selftest_venv_canary_fail'
+if (Test-Path $venvCanaryDir) { Remove-Item -Recurse -Force $venvCanaryDir }
+New-Item -ItemType Directory -Force -Path $venvCanaryDir | Out-Null
+Copy-Item -LiteralPath (Join-Path $repo 'run_setup.bat') -Destination $venvCanaryDir -Force
+Set-Content -LiteralPath (Join-Path $venvCanaryDir 'app.py') -Value 'print("venv-canary-ok")' -Encoding Ascii
+
+$venvCanaryPass = $true
+if ($env:HP_FORCE_CONDA_ONLY -eq '1') {
+    Write-NdjsonRow ([ordered]@{
+        id      = 'self.venv.canary_fail'
+        req     = 'REQ-023'
+        pass    = $true
+        desc    = 'REQ-023: venv canary probe test'
+        details = [ordered]@{ skip = $true; reason = 'HP_FORCE_CONDA_ONLY-prohibits-venv-fallback' }
+    })
+} else {
+    $savedCondaFail5 = $env:HP_TEST_FORCE_CONDA_FAIL
+    $savedOffline5   = $env:HP_OFFLINE_MODE
+    $savedSkipPR5    = $env:HP_SKIP_PIPREQS
+    $savedLane5      = $env:HP_CI_LANE
+    $savedCanaryFail = $env:HP_TEST_FORCE_VENV_CANARY_FAIL
+    $savedSyscon5    = $env:HP_TEST_SYSCON_ANSWER
+    $env:HP_TEST_FORCE_CONDA_FAIL       = '1'
+    $env:HP_OFFLINE_MODE                = '1'
+    $env:HP_SKIP_PIPREQS                = '1'
+    $env:HP_CI_LANE                     = 'test'
+    $env:HP_TEST_FORCE_VENV_CANARY_FAIL = '1'
+    $env:HP_TEST_SYSCON_ANSWER          = 'N'
+    $venvCanaryLog = Join-Path $venvCanaryDir '~venv_canary.log'
+    Push-Location -LiteralPath $venvCanaryDir
+    try {
+        cmd /c "run_setup.bat > ~venv_canary.log 2>&1"
+        $venvCanaryExit = $LASTEXITCODE
+    } finally {
+        Pop-Location
+    }
+    $env:HP_TEST_FORCE_CONDA_FAIL       = $savedCondaFail5
+    $env:HP_OFFLINE_MODE                = $savedOffline5
+    $env:HP_SKIP_PIPREQS                = $savedSkipPR5
+    $env:HP_CI_LANE                     = $savedLane5
+    $env:HP_TEST_FORCE_VENV_CANARY_FAIL = $savedCanaryFail
+    $env:HP_TEST_SYSCON_ANSWER          = $savedSyscon5
+
+    $venvCanarySetupLog = Join-Path $venvCanaryDir '~setup.log'
+    $venvCanarySetupText = ''
+    if (Test-Path -LiteralPath $venvCanarySetupLog) {
+        $venvCanarySetupText = Get-Content -LiteralPath $venvCanarySetupLog -Raw -Encoding Ascii
+    }
+    $venvCanaryWarnFound = ($venvCanarySetupText -match [regex]::Escape('[WARN] venv fallback: interpreter created but failed canary probe (import sys).'))
+    $venvCanaryNotSelected = -not ($venvCanarySetupText -match [regex]::Escape('[BOOT] REQ-009: Selected Python provider: Local venv (fallback).'))
+    $venvCanaryPass = ($venvCanaryWarnFound -and $venvCanaryNotSelected)
+    Write-NdjsonRow ([ordered]@{
+        id      = 'self.venv.canary_fail'
+        req     = 'REQ-023'
+        pass    = $venvCanaryPass
+        desc    = 'REQ-023: venv canary probe correctly declines a created-but-broken venv instead of selecting it'
+        details = [ordered]@{
+            canaryWarnFound = $venvCanaryWarnFound
+            venvNotSelected = $venvCanaryNotSelected
+            exit            = $venvCanaryExit
+        }
+    })
+}
+
 # ===== REQ-002 priority 0: manual %1 override beats auto-detection (main.py) =====
 # REQ-002 ranks a co-located %1 argument (drag-and-drop) above every auto-detected name:
 # it is used directly and skips all auto-detection. Prior tests only cover auto-detection


### PR DESCRIPTION
## Summary

- `:try_venv_fallback` previously declared the venv tier ready as soon as `python -m venv` exited 0 and `.venv\Scripts\python.exe` existed on disk. A venv can be "created" (directory + exe present) yet still be non-functional (missing DLLs, broken symlinks, execution-policy blocks) -- exactly the failure mode a stripped-down or corrupted host Python produces. That brokenness would previously only surface later as a more confusing PyInstaller or dependency-install failure.
- Adds a post-creation canary probe (`"%HP_PY%" -c "import sys"`) that must succeed before the venv tier is accepted. On failure it logs a WARN and `exit /b 1`, exactly like the tier's three existing failure branches, falling through to the next REQ-009 provider (system Python) with no new failure-handling path needed.
- Goto-based dispatch (not nested in a parenthesized if/else block) per the "Provider-cascade dispatch is goto-based on purpose" pattern in `docs/agent-lessons-learned.md`, so the probe call and `%ERRORLEVEL%` read are never frozen by cmd's parse-time `%VAR%` expansion.
- New test hook `HP_TEST_FORCE_VENV_CANARY_FAIL` (declared in the top-of-file `HP_TEST_*` passthrough block alongside its sibling `HP_TEST_FORCE_VENV_FAIL`) simulates a real venv creation succeeding but the probe failing. New test `self.venv.canary_fail` in `tests/selfapps_ux_hardening.ps1` exercises this end-to-end and asserts the WARN fires and the venv tier is not selected.
- Backfills the `batch-check.yml` test-log upload allowlist for the new test directory, registers the new NDJSON row in `docs/agent-ndjson.md`, documents the feature as README `[REQ-023]`, and moves the item from Active Backlog to Closed Backlog in `CLAUDE.md`.

This was split off from the broader "venv creation resilience" backlog item -- the other half (a `--without-pip` + `get-pip.py` retry when venv creation itself fails outright, needing new download infrastructure) remains a separate Active Backlog item for a future round.

## Test plan

- [x] `python tools/check_delimiters.py run_setup.bat` -- clean.
- [x] `python -m compileall -q .` / `python -m pyflakes .` -- clean.
- [x] `python -m yamllint .github/workflows/` / `actionlint -oneline .github/workflows/*.yml` -- clean.
- [x] `pwsh` AST-parse sweep of all modified/`tests/*.ps1` and `tools/*.ps1` files -- clean.
- [x] `python -m pytest tests/test_*.py` -- 192 passed, 2 skipped (Windows-only), unaffected.
- [x] Two independent code-review passes (core `run_setup.bat` logic, and test/docs changes) -- both clean after fixing two nits (a missing top-of-file test-flag declaration, and stale line-number citations shifted by the insertion).
- [x] CI run for this commit (28789996504): all 8 matrix lanes + aggregator + model-quick-fix + publish-diag succeeded. Verified via the raw downloaded NDJSON artifact (not just the diagnostics site, which has previously shown false-greens): `self.venv.canary_fail` passes (`canaryWarnFound: true, venvNotSelected: true, exit: 0`) with no regression in the neighboring `self.venv.fallback` row (`pass: true`).

Co-Authored-By: Claude Sonnet 5

https://claude.ai/code/session_015xbWLPbiaKVsobB9FZy8kS


---
_Generated by [Claude Code](https://claude.ai/code/session_015xbWLPbiaKVsobB9FZy8kS)_