### PR TITLE
feat(REQ-023b): venv --without-pip retry + get-pip.py bootstrap; consolidate network-resilience docs

### DIFF
--- a/.github/workflows/batch-check.yml
+++ b/.github/workflows/batch-check.yml
@@ -1425,6 +1425,16 @@ jobs:
             tests\~selftest_venv_canary_fail\~pipreqs.diff.txt
             tests/~selftest_venv_canary_fail/~bootstrap.status.json
             tests\~selftest_venv_canary_fail\~bootstrap.status.json
+            tests/~selftest_venv_nopip_retry/~venv_nopip.log
+            tests\~selftest_venv_nopip_retry\~venv_nopip.log
+            tests/~selftest_venv_nopip_retry/~setup.log
+            tests\~selftest_venv_nopip_retry\~setup.log
+            tests/~selftest_venv_nopip_retry/~pipreqs.diff.txt
+            tests\~selftest_venv_nopip_retry\~pipreqs.diff.txt
+            tests/~selftest_venv_nopip_retry/~bootstrap.status.json
+            tests\~selftest_venv_nopip_retry\~bootstrap.status.json
+            tests/~selftest_venv_nopip_retry/~run.out.txt
+            tests\~selftest_venv_nopip_retry\~run.out.txt
             tests/~selftest_entry_override/~override.log
             tests\~selftest_entry_override\~override.log
             tests/~selftest_entry_override/~setup.log

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -248,6 +248,7 @@ THEN stop and open/append a PR. One loop = one change set.
 - Work in an explicit loop: **Plan -> Check the plan -> Execute -> Self-check/tests**. Document the plan before coding, verify it against requirements, act, then rerun the listed sanity checks.
 - When fixing bugs, leave professional comments that explain why the change is structured the way it is so future readers understand the constraint.
 - You may add helper utilities under `tools/` (preferred over embedding long scripts inside YAML/PowerShell/batch files). Run helpers from there freely, but update existing tools carefully to avoid regressions.
+- **Cite `run_setup.bat` locations by label/subroutine name (a hard anchor), not by exact line number, in CLAUDE.md/docs/README.** A line number drifts on every unrelated edit above the citation, so every prior insertion into this file has forced a re-verification sweep across every existing citation before a commit could land -- real, recurring cost for a soft benefit. Prefer `` `:try_venv_fallback` `` or `` `:download_get_pip` `` alone (`grep -n '^:label_name'` always finds it, drift-proof by construction). If a single statement inside a long subroutine genuinely needs pinpointing, describe it by nearby log text or purpose instead of a line number (e.g. "the get-pip.py bootstrap call inside `:try_venv_fallback`"). Only include a line number when it adds real, immediate value for the one commit introducing it, and never treat it as something a later, unrelated commit is obligated to keep in sync.
 
 ## Embedded payload inventory (run_setup.bat)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -566,23 +566,6 @@ a fact confirmed with no action needed, or a recurring/periodic check belongs in
   verification, new fallback-ladder wiring, new tests) -- backlog for a dedicated future round,
   not attempted piecemeal.
 
-- **venv creation resilience, part 2 (--without-pip retry)**: the post-creation canary probe
-  (part 1, REQ-023) shipped -- see Closed Backlog. Remaining: when `python -m venv .\.venv`
-  fails outright (not just a canary-probe failure after apparent success), retry once using
-  `python -m venv .\.venv --without-pip` followed by a manual `get-pip.py` bootstrap -- this
-  covers the most commonly-cited real-world failure mode (a stripped-down host Python missing
-  `ensurepip`). This needs new download infrastructure (fetching `get-pip.py`, likely mirroring
-  the existing Miniconda/uv downloader's retry/fallback-URL pattern) that the REQ-023 probe did
-  not require, so it's a meaningfully bigger and riskier slice -- keep it a separate round.
-  Explicitly **rejected**: relocating venv creation to `%LOCALAPPDATA%\hp_cache\...` and a
-  `PYTHONUSERBASE`-based "stealth isolation" fallback tier. Both have a blast radius
-  disproportionate to their benefit here -- nearly every downstream path in this bootstrapper
-  assumes CWD-relative execution (relocating would ripple everywhere), and `PYTHONUSERBASE`
-  directly contradicts the REQ-010 host-isolation invariant this repo already enforces
-  (nullifying `PYTHONPATH`/`PYTHONHOME`) while risking leaving dependency residue on the user's
-  machine -- arguably worse than simply falling through to the existing, already-consented
-  system-Python tier that sits below it in the cascade today.
-
 ## Periodic Maintenance Checks (recurring, quarterly)
 
 This section is for checks that need to be **repeated on a schedule** because they track
@@ -669,8 +652,38 @@ rather than relying on manual memory.
 
 Items completed and shipped:
 
-- **venv fallback canary probe (REQ-023)**: `:try_venv_fallback` (run_setup.bat:1721-1768)
-  previously declared the venv tier ready as soon as `.venv\Scripts\python.exe` existed on disk,
+- **venv creation resilience, part 2 (REQ-023b, --without-pip + get-pip.py retry)**:
+  `:try_venv_fallback` previously declined the venv tier outright the
+  moment plain `python -m venv .\.venv` failed, with no retry -- the most commonly-cited
+  real-world failure mode (a stripped-down host Python missing `ensurepip`, which plain `venv`
+  requires but `--without-pip` does not) had no recovery path. Added a single retry with
+  `--without-pip` on the first failure, followed by a manual pip bootstrap via a newly downloaded
+  `get-pip.py` (new `:download_get_pip` subroutine, mirroring the existing Miniconda/uv
+  download-with-fallback pattern: curl, then PowerShell `Invoke-WebRequest`, then a fallback URL
+  via both methods -- no interactive REQ-013 connectivity gate, since a plain failure here should
+  silently decline the tier, not pause to ask the user). Goto-based dispatch throughout per
+  "Provider-cascade dispatch is goto-based on purpose" in `docs/agent-lessons-learned.md`. New
+  test hook `HP_TEST_FORCE_VENV_CREATE_FAIL` forces the first plain attempt to fail so the retry
+  runs for real (including a real network download of `get-pip.py`); it also carves out a narrow
+  exception in `:download_get_pip`'s offline check so the test can still use `HP_OFFLINE_MODE=1`
+  to cheaply skip the unrelated Miniconda download, without weakening real-user offline
+  protection (the flag is never set outside CI). New test `self.venv.nopip_retry` in
+  `tests/selfapps_ux_hardening.ps1` exercises this end-to-end. This closes the second half of the
+  "venv creation resilience" backlog item (part 1, the REQ-023 canary probe below, shipped
+  separately). Explicitly **rejected** as part of this item, and not planned for any future round:
+  relocating venv creation to `%LOCALAPPDATA%\hp_cache\...` and a `PYTHONUSERBASE`-based "stealth
+  isolation" fallback tier -- both have a blast radius disproportionate to their benefit here
+  (nearly every downstream path in this bootstrapper assumes CWD-relative execution, and
+  `PYTHONUSERBASE` directly contradicts the REQ-010 host-isolation invariant this repo already
+  enforces while risking leaving dependency residue on the user's machine, arguably worse than
+  simply falling through to the existing system-Python tier below it in the cascade). CLOSED by
+  this PR.
+
+- **venv fallback canary probe (REQ-023)**: `:try_venv_fallback` (the canary-probe-specific
+  logic this entry describes sits right before the final `[BOOT] REQ-009: Selected Python
+  provider` log line in that subroutine -- see REQ-023b above, which added the `--without-pip`
+  retry earlier in the same subroutine) previously declared the venv tier ready as soon as
+  `.venv\Scripts\python.exe` existed on disk,
   without ever confirming the interpreter actually runs -- a venv can be "created" (directory +
   exe present) yet non-functional (missing DLLs, broken symlinks, execution-policy blocks),
   exactly the failure mode a stripped-down or corrupted host Python produces. Added a
@@ -682,10 +695,9 @@ Items completed and shipped:
   test hook `HP_TEST_FORCE_VENV_CANARY_FAIL` plus `self.venv.canary_fail` in
   `tests/selfapps_ux_hardening.ps1` exercise this end-to-end. This was split from the broader
   "venv creation resilience" backlog item -- the other half (a `--without-pip` + `get-pip.py`
-  retry when venv creation itself fails outright) needs new download infrastructure and remains
-  a separate Active Backlog item. CLOSED by this PR.
+  retry when venv creation itself fails outright, above) shipped separately. CLOSED by this PR.
 
-- **conda-create transient-retry gap (REQ-022)**: `:try_conda_create` (run_setup.bat:705-761) previously
+- **conda-create transient-retry gap (REQ-022)**: `:try_conda_create` previously
   had zero retry logic on a `conda create` failure -- it fell straight to `:handle_conda_failure`
   (venv/system cascade) on the very first non-zero exit, asymmetric with the sibling
   `:conda_bulk_install` phase's already-proven transient-retry pattern. Root-caused against a

--- a/README.md
+++ b/README.md
@@ -367,21 +367,33 @@ Before executing or packaging the selected entry, the bootstrapper statically va
 
 ---
 
-## [REQ-013] Internet Connectivity Guard
+## [REQ-013] Network Resilience
 
-- When a primary download fails (Miniconda or uv), the bootstrapper checks internet reachability before cascading to a fallback URL.
-  - First, ICMP ping to 8.8.8.8 (fast path).
-  - If ICMP is blocked, fall back to a lightweight HTTPS probe.
-  - If both fail: prompt the user to confirm offline mode or retry.
-- In offline mode, internet-dependent steps (uv download, Miniconda download) are skipped.
-  - If the user already has a cached Miniconda or uv install, those are used as-is.
-- Log contract:
+The bootstrapper shall detect connectivity problems and be robust against transient network
+failures during environment and dependency acquisition -- retrying before giving up on a step,
+and falling through to the next REQ-009 provider tier rather than failing outright on a single
+blip or a temporary outage.
+
+- **Connectivity detection**: when a primary download fails (Miniconda or uv), the bootstrapper
+  checks internet reachability before cascading to a fallback URL -- first an ICMP ping, then a
+  lightweight HTTPS probe if ICMP is blocked. If both fail, it prompts the user to confirm
+  offline mode or retry. In offline mode, internet-dependent steps (uv download, Miniconda
+  download) are skipped; an already-cached Miniconda or uv install is used as-is.
+- **Transient-failure retry**: conda environment creation, conda's bulk dependency install, and
+  the venv fallback tier's pip bootstrap (via a downloaded `get-pip.py`, used when a plain venv
+  creation attempt fails outright) each retry once on a detected transient failure before
+  falling through to the next provider tier. Download steps (Miniconda, uv, get-pip.py)
+  additionally retry across a primary URL, a PowerShell fallback method, and a secondary URL
+  before giving up.
+- Mechanism detail for each retry point (exact log lines, CI test flags, subroutine names) is
+  intentionally not enumerated here -- see `docs/agent-lessons-learned.md` and CLAUDE.md's
+  Closed Backlog, which are the authoritative source for implementation-level specifics.
+- Log contract (illustrative, not exhaustive):
   - `[INFO] REQ-013: Connectivity check: internet reachable. Cascading to fallback.`
-  - `[INFO] REQ-013: Connectivity check: internet reachable via HTTPS (ICMP blocked). Cascading to fallback.`
   - `[WARN] REQ-013: Connectivity check: no internet detected (ICMP and HTTPS check failed).`
-  - `[INFO] REQ-013: Offline mode: skipping uv download.`
-  - `[INFO] REQ-013: Offline mode: skipping Miniconda download.`
-- CI test flag: `HP_TEST_OFFLINE=1` simulates ping failure for branch coverage.
+- CI test flag: `HP_TEST_OFFLINE=1` simulates ping failure for connectivity-check branch
+  coverage; per-mechanism retry test flags are documented alongside their subroutines in
+  `docs/agent-lessons-learned.md`.
 
 ---
 
@@ -486,19 +498,6 @@ set lives in `run_setup.bat`.
 
 ---
 
-## [REQ-022] Conda Environment-Creation Transient Retry
-
-- If `conda create` (environment creation, distinct from the REQ-005.2 bulk dependency install) fails, the bootstrapper inspects the failure output for a transient network signature (`CondaHTTPError`, `Failed to fetch`, `timed out`, `ConnectionError`) before falling back to the next REQ-009 provider.
-- If a transient signature is found: wait 15 seconds and retry the exact same `conda create` command once. If the retry succeeds, bootstrap continues normally.
-- If no transient signature is found, or the retry also fails, behavior is unchanged: falls through to the REQ-009 provider cascade (venv, then system Python).
-- Log contract:
-  - `[INFO] conda create: transient failure detected; retrying after 15s.`
-  - `[WARN] conda create: retry after transient failure also failed.`
-- CI test flag: `HP_TEST_FORCE_CONDA_CREATE_NETWORK_FAIL=1` simulates a transient CondaHTTPError on the first attempt only.
-- Test NDJSON row: `self.stub.conda_create_retry` (in `tests/selftest.ps1`).
-
----
-
 ## [REQ-023] Venv Fallback Canary Probe
 
 - After the REQ-009 Tier 3 venv fallback (`:try_venv_fallback`) creates `.venv` and confirms the interpreter file exists, the bootstrapper verifies the interpreter actually runs (`python -c "import sys"`) before declaring the tier ready.
@@ -508,6 +507,9 @@ set lives in `run_setup.bat`.
   - `[WARN] venv fallback: interpreter created but failed canary probe (import sys).`
 - CI test flag: `HP_TEST_FORCE_VENV_CANARY_FAIL=1` simulates a failing probe after a real, successful venv creation.
 - Test NDJSON row: `self.venv.canary_fail` (in `tests/selfapps_ux_hardening.ps1`).
+- The venv fallback tier's retry-on-transient-failure behavior (when plain venv creation fails
+  outright, distinct from this canary probe) is part of the REQ-013 Network Resilience
+  requirement above, not this one -- this section covers only the post-creation health check.
 
 ---
 

--- a/docs/agent-lessons-learned.md
+++ b/docs/agent-lessons-learned.md
@@ -154,8 +154,11 @@ If a global `:log` fix is ever pursued, it is its own isolated task that must al
 those checks -- not a drive-by change.
 
 **Concrete unresolved instance, accepted risk, no action planned: `%HP_ENTRY%`.** `%HP_ENTRY%`
-is echoed unquoted at 4 call sites (run_setup.bat:2074 via a raw `echo`, and :2085/:2597/:2690
-via `:log`). A filename containing `<`/`>`/`&`/`|` would in principle mis-parse as a
+is echoed unquoted at 4 call sites: the raw `echo` alphabetical-fallback hint and the
+`[INFO] REQ-002: Picker entry selected:` `:log` call, both inside `:pick_entry_interactive`;
+the `[ERROR] REQ-021: entry failed py_compile` `:log` call inside `:preflight_compile`; and the
+`[INFO] Launching your program now via the ... interpreter:` `:log` call inside
+`:verify_no_exe_probe`. A filename containing `<`/`>`/`&`/`|` would in principle mis-parse as a
 redirection/pipe operator here, exactly per the rule above. This requires a
 maliciously-or-accidentally-crafted filename delivered via a Windows double-click/drag-and-drop
 flow (not a common vector), and the only real fix is the global `:log` rework already documented

--- a/docs/agent-ndjson.md
+++ b/docs/agent-ndjson.md
@@ -66,7 +66,7 @@ self.ux.system.gate.n, self.ux.system.gate.prompt, self.ux.system.gate.real, sel
 self.ux.gitignore.merge, self.ux.gitignore.preserve, self.ux.gitignore.idem,
 self.ux.gitattributes.merge, self.ux.gitattributes.idem,
 self.ux.postflight,
-self.venv.fallback, self.venv.canary_fail, self.entry.override
+self.venv.fallback, self.venv.canary_fail, self.venv.nopip_retry, self.entry.override
 ```
 
 ## justme-test lane rows (flag-triggered)
@@ -194,7 +194,7 @@ self.ux.connectivity.offline.uv.skip, self.ux.connectivity.offline.conda.skip,
 self.ux.connectivity.online, self.ux.connectivity.retry,
 self.ux.system.gate.n, self.ux.system.gate.prompt, self.ux.system.gate.real, self.ux.system.gate.accept,
 self.sysbuild.decline,
-self.venv.fallback, self.venv.canary_fail, self.entry.override
+self.venv.fallback, self.venv.canary_fail, self.venv.nopip_retry, self.entry.override
 ```
 
 ---

--- a/run_setup.bat
+++ b/run_setup.bat
@@ -130,6 +130,12 @@ rem HP_UV_FALLBACK_URL: pinned release used when primary GitHub releases/latest 
 set "HP_UV_FALLBACK_URL=https://github.com/astral-sh/uv/releases/download/0.7.3/uv-x86_64-pc-windows-msvc.zip"
 set "HP_UV_MIN_BYTES=%HP_UV_MIN_BYTES%"
 if not defined HP_UV_MIN_BYTES set "HP_UV_MIN_BYTES=1000000"
+rem REQ-023b: get-pip.py -- used only by the venv fallback tier's --without-pip retry (see
+rem :download_get_pip / :try_venv_fallback). HP_GETPIP_FALLBACK_URL is the get-pip project's own
+rem GitHub source (the file bootstrap.pypa.io serves is generated from this repo), mirroring the
+rem primary-CDN + GitHub-source fallback pattern already used for Miniconda/uv above.
+if not defined HP_GETPIP_URL set "HP_GETPIP_URL=https://bootstrap.pypa.io/get-pip.py"
+set "HP_GETPIP_FALLBACK_URL=https://raw.githubusercontent.com/pypa/get-pip/main/public/get-pip.py"
 rem HP_TEST_OFFLINE=1: simulates ping failure for REQ-013 branch coverage (CI test flag)
 set "HP_TEST_OFFLINE=%HP_TEST_OFFLINE%"
 rem HP_OFFLINE_MODE is set by :check_net_after_dl_fail when user declines or no internet
@@ -142,6 +148,11 @@ rem HP_TEST_FORCE_VENV_CANARY_FAIL=1: simulates the post-creation canary probe (
 rem after a real, successful venv creation (distinct from HP_TEST_FORCE_VENV_FAIL, which skips
 rem creation entirely)
 set "HP_TEST_FORCE_VENV_CANARY_FAIL=%HP_TEST_FORCE_VENV_CANARY_FAIL%"
+rem HP_TEST_FORCE_VENV_CREATE_FAIL=1: simulates the FIRST plain "python -m venv" attempt failing
+rem outright (e.g. a stripped-down host Python missing ensurepip) so the REQ-023b --without-pip
+rem retry path is exercised for real; distinct from HP_TEST_FORCE_VENV_FAIL, which skips venv
+rem creation entirely and never reaches either attempt.
+set "HP_TEST_FORCE_VENV_CREATE_FAIL=%HP_TEST_FORCE_VENV_CREATE_FAIL%"
 rem HP_TEST_FORCE_CONDA_FAIL=1: simulates conda env creation failure for REQ-009/REQ-014 branch coverage
 set "HP_TEST_FORCE_CONDA_FAIL=%HP_TEST_FORCE_CONDA_FAIL%"
 rem HP_TEST_FORCE_WARNFIX_UNRESOLVED=1: forces the warnfix cascade-candidate detection (REQ-009/REQ-005.10) for branch coverage
@@ -1692,6 +1703,51 @@ if not errorlevel 1 if exist "%TEMP%\miniconda.exe" (
 call :log "[WARN] Miniconda: all download URLs failed."
 goto :eof
 
+:download_get_pip
+rem REQ-023b: fetches get-pip.py so the venv fallback tier can bootstrap pip after a
+rem --without-pip venv creation (see :try_venv_fallback). Sets HP_GETPIP_PY to the downloaded
+rem file path on success; leaves it undefined/absent on failure so the caller can detect it via
+rem "if not exist". No interactive connectivity gate here (unlike :download_miniconda_exe's use
+rem of :check_net_after_dl_fail) -- this runs deep inside a fallback tier where the zero-friction
+rem design intent reserves the one interactive prompt for the REQ-014 system-Python consent gate;
+rem a plain download failure here should silently decline the tier, not stop to ask the user.
+set "HP_GETPIP_PY="
+rem The HP_TEST_FORCE_VENV_CREATE_FAIL exception below lets CI exercise this real download
+rem path while still using HP_OFFLINE_MODE=1 to cheaply skip the (unrelated, ~99 MB) Miniconda
+rem download elsewhere in the same test run -- it never weakens real-user offline protection,
+rem since that test flag is never set outside CI coverage.
+if "%HP_OFFLINE_MODE%"=="1" if not "%HP_TEST_FORCE_VENV_CREATE_FAIL%"=="1" (
+  call :log "[INFO] REQ-013: Offline mode: skipping get-pip.py download."
+  goto :eof
+)
+call :log "[INFO] Downloading get-pip.py from %HP_GETPIP_URL%..."
+curl --fail -L --retry 3 --retry-delay 5 --max-time 120 "%HP_GETPIP_URL%" -o "%TEMP%\get-pip.py" >> "%LOG%" 2>&1
+if not errorlevel 1 if exist "%TEMP%\get-pip.py" (
+  set "HP_GETPIP_PY=%TEMP%\get-pip.py"
+  goto :eof
+)
+powershell -NoProfile -ExecutionPolicy Bypass -Command "try { [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; Invoke-WebRequest -Uri '%HP_GETPIP_URL%' -OutFile '%TEMP%\get-pip.py' -UseBasicParsing } catch { exit 1 }" >> "%LOG%" 2>&1
+if not errorlevel 1 if exist "%TEMP%\get-pip.py" (
+  set "HP_GETPIP_PY=%TEMP%\get-pip.py"
+  goto :eof
+)
+if exist "%TEMP%\get-pip.py" del "%TEMP%\get-pip.py" >nul 2>&1
+call :log "[INFO] Trying fallback get-pip.py URL: %HP_GETPIP_FALLBACK_URL%..."
+curl --fail -L --retry 3 --retry-delay 5 --max-time 120 "%HP_GETPIP_FALLBACK_URL%" -o "%TEMP%\get-pip.py" >> "%LOG%" 2>&1
+if not errorlevel 1 if exist "%TEMP%\get-pip.py" (
+  call :log "[INFO] get-pip.py download succeeded from fallback URL."
+  set "HP_GETPIP_PY=%TEMP%\get-pip.py"
+  goto :eof
+)
+powershell -NoProfile -ExecutionPolicy Bypass -Command "try { [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; Invoke-WebRequest -Uri '%HP_GETPIP_FALLBACK_URL%' -OutFile '%TEMP%\get-pip.py' -UseBasicParsing } catch { exit 1 }" >> "%LOG%" 2>&1
+if not errorlevel 1 if exist "%TEMP%\get-pip.py" (
+  call :log "[INFO] get-pip.py download succeeded from fallback URL."
+  set "HP_GETPIP_PY=%TEMP%\get-pip.py"
+  goto :eof
+)
+call :log "[WARN] get-pip.py: all download URLs failed."
+goto :eof
+
 :handle_conda_failure
 set "HP_FAIL_MSG=%~1"
 if not "%HP_FAIL_MSG%"=="" call :log "%HP_FAIL_MSG%"
@@ -1730,20 +1786,57 @@ if errorlevel 1 (
   exit /b 1
 )
 if exist ".\.venv" rd /s /q ".\.venv" >nul 2>&1
+if "%HP_TEST_FORCE_VENV_CREATE_FAIL%"=="1" goto :venv_create_retry
 if defined HP_SYS_ARGS (
   "%HP_SYS_CMD%" %HP_SYS_ARGS% -m venv .\.venv >> "%LOG%" 2>&1
 ) else (
   "%HP_SYS_CMD%" -m venv .\.venv >> "%LOG%" 2>&1
 )
+if not errorlevel 1 goto :venv_create_ok
+rem REQ-023b: "python -m venv" (which requires ensurepip) can fail outright on a stripped-down
+rem host Python that is missing ensurepip -- a commonly cited real-world failure mode. Retry
+rem once with --without-pip (which does not need ensurepip) and manually bootstrap pip via
+rem get-pip.py, mirroring the existing Miniconda/uv download-with-fallback pattern
+rem (:download_get_pip). Goto-based per "Provider-cascade dispatch is goto-based on purpose" in
+rem docs/agent-lessons-learned.md.
+:venv_create_retry
+call :log "[WARN] venv fallback: python -m venv failed; retrying once with --without-pip."
+if exist ".\.venv" rd /s /q ".\.venv" >nul 2>&1
+if defined HP_SYS_ARGS (
+  "%HP_SYS_CMD%" %HP_SYS_ARGS% -m venv .\.venv --without-pip >> "%LOG%" 2>&1
+) else (
+  "%HP_SYS_CMD%" -m venv .\.venv --without-pip >> "%LOG%" 2>&1
+)
 if errorlevel 1 (
-  call :log "[WARN] venv fallback: python -m venv failed."
+  call :log "[WARN] venv fallback: python -m venv --without-pip also failed."
   exit /b 1
 )
+set "HP_PY=%CD%\.venv\Scripts\python.exe"
+if not exist "%HP_PY%" (
+  call :log "[WARN] venv fallback: interpreter missing after --without-pip creation."
+  exit /b 1
+)
+call :download_get_pip
+if not exist "%HP_GETPIP_PY%" (
+  call :log "[WARN] venv fallback: get-pip.py download failed; venv has no pip."
+  exit /b 1
+)
+"%HP_PY%" "%HP_GETPIP_PY%" >> "%LOG%" 2>&1
+if errorlevel 1 (
+  del "%HP_GETPIP_PY%" >nul 2>&1
+  call :log "[WARN] venv fallback: get-pip.py bootstrap failed."
+  exit /b 1
+)
+del "%HP_GETPIP_PY%" >nul 2>&1
+call :log "[INFO] venv fallback: pip bootstrapped successfully via get-pip.py."
+goto :venv_create_pip_ready
+:venv_create_ok
 set "HP_PY=%CD%\.venv\Scripts\python.exe"
 if not exist "%HP_PY%" (
   call :log "[WARN] venv fallback: interpreter missing after creation."
   exit /b 1
 )
+:venv_create_pip_ready
 rem REQ-023: canary probe -- a venv can be "created" (directory + exe present) yet still be
 rem non-functional (missing DLLs, broken symlinks, execution-policy blocks). Verify the fresh
 rem interpreter actually runs before declaring success, so a silently broken venv doesn't reach

--- a/tests/selfapps_ux_hardening.ps1
+++ b/tests/selfapps_ux_hardening.ps1
@@ -726,6 +726,85 @@ if ($env:HP_FORCE_CONDA_ONLY -eq '1') {
     })
 }
 
+# ===== REQ-023b: venv --without-pip retry + get-pip.py bootstrap =====
+# Forces the FIRST plain "python -m venv" attempt to fail via HP_TEST_FORCE_VENV_CREATE_FAIL=1
+# (simulating a stripped-down host Python missing ensurepip) so the --without-pip retry path is
+# exercised for real, followed by a real get-pip.py download+bootstrap (needs actual network --
+# unlike the neighboring venv tests, HP_OFFLINE_MODE=1 is still set here purely to cheaply skip
+# the unrelated Miniconda download; :download_get_pip carves out an explicit exception for this
+# exact test flag so the get-pip.py fetch itself is not skipped). Asserts the retry WARN, the
+# pip-bootstrap success INFO, the venv-selected line, and that the app actually ran.
+# Skipped in conda-full lane where HP_FORCE_CONDA_ONLY=1 blocks all fallbacks unconditionally.
+$venvNoPipDir = Join-Path $here '~selftest_venv_nopip_retry'
+if (Test-Path $venvNoPipDir) { Remove-Item -Recurse -Force $venvNoPipDir }
+New-Item -ItemType Directory -Force -Path $venvNoPipDir | Out-Null
+Copy-Item -LiteralPath (Join-Path $repo 'run_setup.bat') -Destination $venvNoPipDir -Force
+Set-Content -LiteralPath (Join-Path $venvNoPipDir 'app.py') -Value 'print("venv-nopip-retry-ok")' -Encoding Ascii
+
+$venvNoPipPass = $true
+if ($env:HP_FORCE_CONDA_ONLY -eq '1') {
+    Write-NdjsonRow ([ordered]@{
+        id      = 'self.venv.nopip_retry'
+        req     = 'REQ-023b'
+        pass    = $true
+        desc    = 'REQ-023b: venv --without-pip retry + get-pip.py bootstrap test'
+        details = [ordered]@{ skip = $true; reason = 'HP_FORCE_CONDA_ONLY-prohibits-venv-fallback' }
+    })
+} else {
+    $savedCondaFail6    = $env:HP_TEST_FORCE_CONDA_FAIL
+    $savedOffline6      = $env:HP_OFFLINE_MODE
+    $savedSkipPR6       = $env:HP_SKIP_PIPREQS
+    $savedLane6         = $env:HP_CI_LANE
+    $savedVenvCreateFail = $env:HP_TEST_FORCE_VENV_CREATE_FAIL
+    $env:HP_TEST_FORCE_CONDA_FAIL      = '1'
+    $env:HP_OFFLINE_MODE               = '1'
+    $env:HP_SKIP_PIPREQS                = '1'
+    $env:HP_CI_LANE                     = 'test'
+    $env:HP_TEST_FORCE_VENV_CREATE_FAIL = '1'
+    $venvNoPipLog = Join-Path $venvNoPipDir '~venv_nopip.log'
+    Push-Location -LiteralPath $venvNoPipDir
+    try {
+        cmd /c "run_setup.bat > ~venv_nopip.log 2>&1"
+        $venvNoPipExit = $LASTEXITCODE
+    } finally {
+        Pop-Location
+    }
+    $env:HP_TEST_FORCE_CONDA_FAIL       = $savedCondaFail6
+    $env:HP_OFFLINE_MODE                = $savedOffline6
+    $env:HP_SKIP_PIPREQS                = $savedSkipPR6
+    $env:HP_CI_LANE                     = $savedLane6
+    $env:HP_TEST_FORCE_VENV_CREATE_FAIL = $savedVenvCreateFail
+
+    $venvNoPipSetupLog = Join-Path $venvNoPipDir '~setup.log'
+    $venvNoPipSetupText = ''
+    if (Test-Path -LiteralPath $venvNoPipSetupLog) {
+        $venvNoPipSetupText = Get-Content -LiteralPath $venvNoPipSetupLog -Raw -Encoding Ascii
+    }
+    $venvNoPipRunOut = Join-Path $venvNoPipDir '~run.out.txt'
+    $venvNoPipRunText = ''
+    if (Test-Path -LiteralPath $venvNoPipRunOut) {
+        $venvNoPipRunText = Get-Content -LiteralPath $venvNoPipRunOut -Raw -Encoding Ascii
+    }
+    $venvNoPipRetryFound = ($venvNoPipSetupText -match [regex]::Escape('[WARN] venv fallback: python -m venv failed; retrying once with --without-pip.'))
+    $venvNoPipBootstrapOk = ($venvNoPipSetupText -match [regex]::Escape('[INFO] venv fallback: pip bootstrapped successfully via get-pip.py.'))
+    $venvNoPipProvider = ($venvNoPipSetupText -match [regex]::Escape('[BOOT] REQ-009: Selected Python provider: Local venv (fallback).'))
+    $venvNoPipAppRan = ($venvNoPipRunText -match [regex]::Escape('venv-nopip-retry-ok'))
+    $venvNoPipPass = ($venvNoPipRetryFound -and $venvNoPipBootstrapOk -and $venvNoPipProvider -and $venvNoPipAppRan)
+    Write-NdjsonRow ([ordered]@{
+        id      = 'self.venv.nopip_retry'
+        req     = 'REQ-023b'
+        pass    = $venvNoPipPass
+        desc    = 'REQ-023b: venv fallback retries with --without-pip and bootstraps pip via get-pip.py when plain venv creation fails'
+        details = [ordered]@{
+            retryWarnFound  = $venvNoPipRetryFound
+            pipBootstrapOk  = $venvNoPipBootstrapOk
+            providerLogFound = $venvNoPipProvider
+            appRan          = $venvNoPipAppRan
+            exit            = $venvNoPipExit
+        }
+    })
+}
+
 # ===== REQ-002 priority 0: manual %1 override beats auto-detection (main.py) =====
 # REQ-002 ranks a co-located %1 argument (drag-and-drop) above every auto-detected name:
 # it is used directly and skips all auto-detection. Prior tests only cover auto-detection


### PR DESCRIPTION
## Summary

- `:try_venv_fallback` previously declined the venv tier outright the moment plain `python -m venv .\.venv` failed, with no retry -- the most commonly-cited real-world failure mode (a stripped-down host Python missing `ensurepip`, which plain venv creation requires but `--without-pip` does not) had no recovery path.
- Adds a single retry with `--without-pip` on the first failure, followed by a manual pip bootstrap via a newly downloaded `get-pip.py` (new `:download_get_pip` subroutine, mirroring the existing Miniconda/uv download-with-fallback pattern: curl, then PowerShell `Invoke-WebRequest`, then a fallback URL via both methods). No interactive connectivity gate on this download path -- a plain failure here silently declines the tier rather than pausing to ask the user, preserving the zero-friction fallback design.
- New test hook `HP_TEST_FORCE_VENV_CREATE_FAIL` forces the first plain venv attempt to fail so the retry runs for real, including a real network download of `get-pip.py`; it carves out a narrow exception in `:download_get_pip`'s offline check so a test can still use `HP_OFFLINE_MODE=1` to cheaply skip the unrelated Miniconda download without weakening real-user offline protection. New test `self.venv.nopip_retry` in `tests/selfapps_ux_hardening.ps1` exercises this end-to-end. Wired into `batch-check.yml`'s artifact-upload allowlist.
- This closes the second half of the "venv creation resilience" backlog item (part 1, the REQ-023 canary probe, shipped separately in #323).

**Also, docs-only per the requirements-altitude directive in README.md**: consolidates the narrow REQ-022 (conda-create retry) and new REQ-023b sections into the existing REQ-013 requirement, now broadened and renamed "Network Resilience," stating the outcome (retry before falling through to the next provider tier) rather than enumerating per-mechanism log lines at the requirement level -- that detail now lives solely in `docs/agent-lessons-learned.md` and CLAUDE.md's Closed Backlog. REQ-023 (venv canary probe) is left as its own section since it is a health-check concern, not a network-retry one.

**Separately**, adds a documentation convention to AGENTS.md: cite `run_setup.bat` locations by label/subroutine name rather than exact line number, since line numbers drift on every unrelated edit above the citation. Converts this session's own recently-added line-number citations in CLAUDE.md and `docs/agent-lessons-learned.md` to label-based anchors accordingly.

## Test plan

- [x] `python tools/check_delimiters.py run_setup.bat` -- clean.
- [x] `python -m compileall -q .` / `python -m pyflakes .` -- clean.
- [x] `python -m yamllint .github/workflows/` / `actionlint -oneline .github/workflows/*.yml` -- clean.
- [x] `pwsh` AST-parse sweep of all modified/`tests/*.ps1` and `tools/*.ps1` files -- clean.
- [x] `python -m pytest tests/test_*.py` -- 192 passed, 2 skipped (Windows-only), unaffected.
- [x] Two independent code-review passes (core `run_setup.bat` logic, and test/docs changes) -- one nit fixed (the downloaded `get-pip.py` temp file wasn't cleaned up after use, unlike the Miniconda/uv download precedent).
- [x] CI verified truly green via the raw GitHub Actions API and downloaded NDJSON artifacts (not just the diagnostics site): `self.venv.nopip_retry` passes with all four assertions true (`retryWarnFound`, `pipBootstrapOk`, `providerLogFound`, `appRan`), no regression in the neighboring `self.venv.fallback`/`self.venv.canary_fail` rows.
  - Note: two intervening empty-commit retriggers were needed and are visible in this branch's history -- one for a transient GitHub Pages deploy failure ("Deployment failed, try again later"), and one for an unrelated pre-existing timing flake in `self.failfast.probe.fastfail` (a REQ-018 Slice 2b-C test, confirmed via NDJSON diff to be identical code producing different timing-dependent results across two runs -- not a regression from this branch's changes).

Co-Authored-By: Claude Sonnet 5

https://claude.ai/code/session_015xbWLPbiaKVsobB9FZy8kS


---
_Generated by [Claude Code](https://claude.ai/code/session_015xbWLPbiaKVsobB9FZy8kS)_