### PR TITLE
Widen fail-fast probe classification window 5000ms -> 10000ms

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -652,6 +652,25 @@ rather than relying on manual memory.
 
 Items completed and shipped:
 
+- **Fail-fast probe window widened 5000ms -> 10000ms**: `HP_FAILFAST_PROBE_MS` (the REQ-018
+  Slice 2b-C fail-fast probe's classification window -- see the entry below for the full
+  mechanism) was tuned assuming the window only needs to outlast a failing process's own error
+  handling (effectively instant). It does not: a PyInstaller *onefile* EXE must first extract its
+  bundled runtime to a temp directory and boot an embedded interpreter before any user code (or
+  its failure) can run at all, and that cold-start step alone is commonly 1-3+ seconds even on an
+  idle machine. Root-caused against a real CI flake in `self.failfast.probe.fastfail`: identical
+  code produced `discardedAndRebuilt: true` on one run and `discardedAndRebuilt: false` on the very
+  next run of the same commit -- a pure timing race between cold-start-plus-failure and the
+  classification window, worsened by CI-runner CPU/disk contention or a Defender on-access scan of
+  the freshly-extracted EXE/DLLs. Widening this value is unconditionally low-risk since it is
+  classification-only and never introduces a kill point (see `docs/agent-lessons-learned.md`
+  "Fail-fast probe window vs. the ~30s hard-kill cap are unrelated numbers" for why); the only
+  cost of widening it is a few extra seconds before a genuinely broken cached EXE is recognized
+  and rebuilt. Justifying comment added directly above the `set "HP_FAILFAST_PROBE_MS=10000"`
+  line in `run_setup.bat` so a future reader does not "fix" it back down. Updated the matching
+  static assertion in `tests/harness.ps1` (`batch.failfast.probe`) and all doc mentions of the old
+  default. CLOSED by this PR.
+
 - **venv creation resilience, part 2 (REQ-023b, --without-pip + get-pip.py retry)**:
   `:try_venv_fallback` previously declined the venv tier outright the
   moment plain `python -m venv .\.venv` failed, with no retry -- the most commonly-cited
@@ -717,7 +736,8 @@ Items completed and shipped:
 
 - **REQ-018 Slice 2b-C -- unified run-model, both halves**: shipped in two PRs. The **fail-fast
   probe** (`:compute_interactive_run`, `:run_failfast_probe`, `HP_FAILFAST_PROBE_MS` default
-  5000ms) times out the two previously-untimed user-code launch points (`:try_fast_exe`'s
+  10000ms as of a later widening -- see Closed Backlog entry above) times out the two
+  previously-untimed user-code launch points (`:try_fast_exe`'s
   cached-EXE reuse, `:verify_no_exe_interpreter`'s no-EXE path): an interactive user gets a short
   classification window then an unbounded, never-killed wait so a genuinely long-running app is
   never force-stopped, while a stale/broken cached EXE that fails fast still triggers

--- a/docs/agent-interconnect.md
+++ b/docs/agent-interconnect.md
@@ -424,7 +424,7 @@ call the shared `:run_failfast_probe` subroutine instead, which launches via
 `:emit_from_base64` mechanism -- NOT an inline `-Command` one-liner, deliberately: the two-stage
 wait needs interpolated strings, and `.ps1` file content sidesteps every cmd.exe quote-nesting
 hazard an inline `-Command "..."` string would hit here). The helper does `WaitForExit(HP_FAILFAST_PROBE_MS)`
-(default 5000ms, distinct from the unrelated ~30s hard-kill cap used by `:run_exe_smokerun`/
+(default 10000ms, distinct from the unrelated ~30s hard-kill cap used by `:run_exe_smokerun`/
 `:hidden_import_recover` -- that is a force-kill ceiling for the fresh-build verification run, the
 ONLY run this bootstrapper ever kills; this probe window is purely a classification checkpoint,
 never a ceiling) then, if the process is still running, a SECOND, UNBOUNDED `WaitForExit()` with no

--- a/docs/agent-lessons-learned.md
+++ b/docs/agent-lessons-learned.md
@@ -466,7 +466,7 @@ its body (interpolation, nested quoting, here-strings, or quoting an argument fo
 `ProcessStartInfo`), stop and make it a `.ps1` helper instead of trying to escape around it.
 
 **Fail-fast probe window vs. the ~30s hard-kill cap are unrelated numbers, do not conflate them:**
-`HP_FAILFAST_PROBE_MS` (default 5000ms, `:run_failfast_probe`) is a CLASSIFICATION checkpoint --
+`HP_FAILFAST_PROBE_MS` (default 10000ms, `:run_failfast_probe`) is a CLASSIFICATION checkpoint --
 how long to wait before deciding "this exited fast, treat a non-zero rc as a stale artifact" vs.
 "this is still running, treat it as the user's real program and never touch it again." The ~30s cap
 used by `:run_exe_smokerun`/`:hidden_import_recover` is a FORCE-KILL CEILING for the one run this
@@ -474,6 +474,21 @@ bootstrapper is ever allowed to `Kill()` (the fresh-build verification run). The
 stage (`$p.WaitForExit()`, no argument) is genuinely unbounded and never kills anything -- raising or
 lowering the probe window only changes how quickly a broken cached EXE gets discarded+rebuilt, it
 never introduces a new kill point.
+
+**Why the default is 10000ms, not 5000ms (widened 2026-07):** the original 5000ms default was
+tuned assuming the probe window only needs to outlast a failing process's own error handling
+(instant -- an unhandled exception unwinds in microseconds). It does not: a PyInstaller *onefile*
+EXE must first extract its bundled runtime to a temp directory and boot an embedded interpreter
+before ANY user code (or its failure) can run at all, and that cold-start step alone is commonly
+1-3+ seconds even on an idle machine. Confirmed as the real cause via a CI flake in
+`self.failfast.probe.fastfail` (a test whose whole design is a reliably-fast-failing frozen EXE):
+identical code produced `discardedAndRebuilt: true` on one CI run and `discardedAndRebuilt: false`
+on the very next run of the same commit, with no code change between them -- a pure timing race
+between cold-start-plus-failure and the classification window, worsened by a shared CI runner's
+CPU/disk contention or a Defender on-access scan of the freshly-extracted EXE/DLLs. Widening the
+window is unconditionally safe to do liberally: it is a classification-only value (see above --
+never a kill point), so the only cost of widening it is a few extra seconds before a genuinely
+broken cached EXE is recognized and rebuilt.
 
 **Accepted gap: most `selfapps_*.ps1` files do not locally pin `HP_CI_LANE`/`HP_NONINTERACTIVE`
 around their `run_setup.bat` invocations, so a LOCAL (non-CI) run of one that reaches the fast-path

--- a/run_setup.bat
+++ b/run_setup.bat
@@ -196,14 +196,24 @@ rem HP_TEST_FORCE_INTERACTIVE_PROBE=1: CI-only; forces the fail-fast probe's int
 rem (:try_fast_exe / :verify_no_exe_interpreter) even under HP_CI_LANE, for deterministic branch
 rem coverage of the ALIVE_AT_PROBE state machine. Mirrors HP_TEST_FORCE_PICKER.
 set "HP_TEST_FORCE_INTERACTIVE_PROBE=%HP_TEST_FORCE_INTERACTIVE_PROBE%"
-rem HP_FAILFAST_PROBE_MS: the fail-fast probe's classification window (default 5000ms). This is
+rem HP_FAILFAST_PROBE_MS: the fail-fast probe's classification window (default 10000ms). This is
 rem NOT the same concept as the unrelated ~30s hard-kill cap used by :run_exe_smokerun /
 rem :hidden_import_recover -- that is a force-kill ceiling for the fresh-build verification run
 rem (the only run this bootstrapper ever kills). This probe window only decides how long to wait
 rem before treating a launched process as "still alive / healthy" rather than "failed fast"; once
 rem classified alive, the wait becomes unbounded and the process is never killed.
+rem Widened from the original 5000ms after a real CI flake (self.failfast.probe.fastfail):
+rem what races this window is not the failure itself (a raised exception unwinds and exits in
+rem microseconds) but PyInstaller onefile COLD START -- extracting the bundled runtime to a temp
+rem dir and booting an embedded interpreter before any user code (or its failure) can even run.
+rem That step is commonly 1-3+ seconds on a healthy machine and can be pushed well past 5s under
+rem CI-runner CPU/disk contention or a Defender on-access scan of the freshly-extracted EXE/DLLs.
+rem A real user's own machine sees this same cold-start cost but rarely the added contention, so
+rem widening this is a low-risk, low-cost change: it never introduces a kill (this window only
+rem ever governs classification, never termination -- see above), and the only cost of widening
+rem it is a few extra seconds before a genuinely broken cached EXE is recognized as such.
 set "HP_FAILFAST_PROBE_MS=%HP_FAILFAST_PROBE_MS%"
-if not defined HP_FAILFAST_PROBE_MS set "HP_FAILFAST_PROBE_MS=5000"
+if not defined HP_FAILFAST_PROBE_MS set "HP_FAILFAST_PROBE_MS=10000"
 rem HP_TEST_CHECKPOINT_ANSWER=Y|N: bypasses the REQ-018 post-execution checkpoint prompt for CI
 rem testing (mirrors HP_TEST_SYSBUILD_ANSWER/HP_TEST_SYSCON_ANSWER). Checked before HP_CI_LANE so
 rem an explicit Y reaches the accept branch even in CI.

--- a/tests/harness.ps1
+++ b/tests/harness.ps1
@@ -446,7 +446,7 @@ Write-Result 'batch.smoke.single_verify' 'REQ-018: single-verification pass wire
 $ffInteractiveSub = $AllText -match '(?m)^:compute_interactive_run'
 $ffProbeSub        = $AllText -match '(?m)^:run_failfast_probe'
 $ffTestOverride    = $AllText -match 'HP_TEST_FORCE_INTERACTIVE_PROBE'
-$ffProbeMs         = $AllText -match [regex]::Escape('set "HP_FAILFAST_PROBE_MS=5000"')
+$ffProbeMs         = $AllText -match [regex]::Escape('set "HP_FAILFAST_PROBE_MS=10000"')
 $ffExceededVar     = $AllText -match 'HP_PROBE_EXCEEDED'
 $ffDecoupleGuard   = $AllText -match [regex]::Escape('set "HP_FASTPATH_RUN_FAILED=')
 $hasFailfastProbe = $ffInteractiveSub -and $ffProbeSub -and $ffTestOverride -and $ffProbeMs -and $ffExceededVar -and $ffDecoupleGuard


### PR DESCRIPTION
## Summary

- `HP_FAILFAST_PROBE_MS`'s original 5000ms default assumed the window only needs to outlast a failing process's own error handling (effectively instant -- an unhandled exception unwinds in microseconds). It doesn't: a PyInstaller *onefile* EXE must first extract its bundled runtime to a temp directory and boot an embedded interpreter before any user code (or its failure) can run at all, and that cold-start step alone is commonly 1-3+ seconds even on an idle machine.
- Root-caused against a real CI flake in `self.failfast.probe.fastfail`: identical code produced `discardedAndRebuilt:true` on one run and `discardedAndRebuilt:false` on the very next run of the same commit -- a timing race between cold-start-plus-failure and the classification window, worsened by CI-runner CPU/disk contention or a Defender on-access scan of the freshly-extracted EXE/DLLs.
- Widening this value is unconditionally low-risk: it is classification-only and never introduces a kill point (the second wait stage is unbounded and never calls `Kill()`), so the only cost is a few extra seconds before a genuinely broken cached EXE is recognized and rebuilt.
- Added a justifying comment directly above the `set "HP_FAILFAST_PROBE_MS=10000"` line in `run_setup.bat` so a future reader doesn't "fix" it back down. Updated the matching static assertion in `tests/harness.ps1` and all doc mentions of the old default (`docs/agent-interconnect.md`, `docs/agent-lessons-learned.md`, `CLAUDE.md`), and added a Closed Backlog entry documenting the change.

## Test plan

- [x] `python tools/check_delimiters.py run_setup.bat` -- clean.
- [x] `python -m compileall -q .` / `python -m pyflakes .` -- clean.
- [x] `python -m yamllint .github/workflows/` / `actionlint -oneline .github/workflows/*.yml` -- clean.
- [x] `pwsh` AST-parse sweep of all `tests/*.ps1` and `tools/*.ps1` files -- clean.
- [x] `python -m pytest tests/test_*.py` -- 192 passed, 2 skipped (Windows-only), unaffected.
- [x] Single-value change with an extensively justified comment, plus doc-consistency updates -- reviewed inline rather than via a full code-review pass given the scope.
- [x] CI verified truly green via the raw GitHub Actions API and downloaded NDJSON artifacts (not just the diagnostics site): both `self.failfast.probe.fastfail` (`discardedAndRebuilt: true, noAliveMsg: true`) and `self.failfast.probe.alive` (`notDiscarded: true, exeStillPresent: true`) pass, confirming the widened window fixed the flake without affecting the ALIVE-classification branch.

Co-Authored-By: Claude Sonnet 5

https://claude.ai/code/session_015xbWLPbiaKVsobB9FZy8kS


---
_Generated by [Claude Code](https://claude.ai/code/session_015xbWLPbiaKVsobB9FZy8kS)_