### PR TITLE
Verify user-code exit-code isolation (no action needed); add Pages-deploy retry with backoff

### DIFF
--- a/.github/workflows/batch-check.yml
+++ b/.github/workflows/batch-check.yml
@@ -3105,7 +3105,9 @@ jobs:
     # artifacts are definitely uploaded before the publisher attempts to fetch them,
     # otherwise Pages may ship an empty _iter if publish_diag races ahead.
     needs: [selftest, selftest-gate, model-quick-fix]
-    timeout-minutes: 25
+    # derived requirement: widened from 25 to accommodate the Pages-deploy retry-with-backoff
+    # sequence below (up to a 20-minute wait before the final attempt), plus normal setup time.
+    timeout-minutes: 40
     concurrency:
       # derived requirement: run 19236437263-1 exhausted the runner disk while a prior
       # publish was still active; serialize by ref and bound runtime so hanging jobs
@@ -3972,9 +3974,45 @@ jobs:
         with:
           path: ${{ steps.prep.outputs.SITE }}
 
-      - name: Deploy to GitHub Pages
+      - name: Deploy to GitHub Pages (attempt 1)
         if: ${{ github.event_name != 'pull_request' }}
-        id: deploy
+        id: deploy1
+        continue-on-error: true
+        uses: actions/deploy-pages@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Wait before Pages deploy retry (short backoff)
+        # derived requirement: GitHub Pages deployment backend occasionally returns a transient
+        # "Deployment failed, try again later" error (observed directly in this repo's own CI,
+        # e.g. run 28798318708) that a short wait usually resolves. Mirrors the existing
+        # detect-transient-failure-then-retry pattern already used for conda create/bulk install.
+        if: ${{ github.event_name != 'pull_request' && steps.deploy1.outcome == 'failure' }}
+        shell: bash
+        run: sleep 30
+
+      - name: Deploy to GitHub Pages (attempt 2)
+        if: ${{ github.event_name != 'pull_request' && steps.deploy1.outcome == 'failure' }}
+        id: deploy2
+        continue-on-error: true
+        uses: actions/deploy-pages@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Wait before Pages deploy retry (long backoff)
+        # A second consecutive failure suggests a longer-lived backend issue rather than a
+        # one-off blip; wait substantially longer (20 min) to give it real room to recover
+        # before the final attempt, rather than hammering the API on a short cadence. This job
+        # is non-gating and has concurrency.cancel-in-progress set on this ref (see the job's
+        # concurrency block above), so a sleeping attempt is safely superseded, not wasted, if a
+        # newer push arrives in the meantime.
+        if: ${{ github.event_name != 'pull_request' && steps.deploy1.outcome == 'failure' && steps.deploy2.outcome == 'failure' }}
+        shell: bash
+        run: sleep 1200
+
+      - name: Deploy to GitHub Pages (attempt 3, final)
+        if: ${{ github.event_name != 'pull_request' && steps.deploy1.outcome == 'failure' && steps.deploy2.outcome == 'failure' }}
+        id: deploy3
         uses: actions/deploy-pages@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -504,11 +504,6 @@ a fact confirmed with no action needed, or a recurring/periodic check belongs in
 "Known Findings", `docs/agent-lessons-learned.md`, or "Periodic Maintenance Checks" below instead
 (see those sections' own scope notes).
 
-- **User-code exit-code semantics**: verify the exit code read after running the user's code
-  is purely the user program's (no bootstrapper logic interleaved). If so, a non-zero exit is
-  very likely outside bootstrapper control; confirm such a case routes to warnfix gracefully
-  rather than being reported as a bootstrapper failure. Document the conclusion.
-
 - **CI-side NDJSON row registry check**: consider building the `docs/agent-ndjson.md` row
   audit into CI (it exists today so agents can see which rows are missing). Likely still a
   manual-sync confirmation step, since fully automated discovery can miss flag-gated rows.
@@ -628,6 +623,29 @@ rather than relying on manual memory.
 
 ## Known Findings (diagnosed, no action warranted)
 
+- **User-code exit-code semantics are already correctly isolated from bootstrapper status --
+  verified, no action needed.** Traced the full flow: `HP_SMOKE_RC` is captured directly from
+  `%ERRORLEVEL%` immediately after launching the user's program at every verification call site
+  (`:run_exe_smokerun`'s EXE smoke, `:verify_no_exe_interpreter`'s interpreter run,
+  `:run_failfast_probe`'s interactive probe), via goto-based dispatch (not nested in a
+  parenthesized if/else) with no bootstrapper logic interleaved between launch and capture --
+  confirms it is purely the user program's own exit code. Separately confirmed the
+  bootstrapper's own reported status is entirely decoupled: the terminating `exit /b 0` at the
+  end of the `:success` label (the actual `run_setup.bat` process exit code on a real
+  double-click) and every `call :write_status ok 0 ...` site pass a hardcoded literal `0`,
+  never `%HP_SMOKE_RC%` -- so a crashing/non-zero-exiting user program is never reported as a
+  bootstrapper failure. `~bootstrap.status.json`'s `exitCode` field means "did the
+  bootstrapper's own env/build lifecycle succeed," not "what did the user's program return";
+  the true user-program outcome is surfaced separately via the console
+  `[STATUS] Run Status: SUCCESS/FAILED (Exit Code: N)` line. Also confirmed such a case does
+  not get misrouted into repair logic: the `--hidden-import` auto-recovery loop only engages
+  for a narrow signature (`ModuleNotFoundError` of a module that IS installed in the build
+  interpreter -- see "--hidden-import auto-recovery must stay STRICT" in
+  `docs/agent-lessons-learned.md`); any other user-program failure (a logic bug, an unrelated
+  unhandled exception, etc.) takes no recovery action and is left exactly as observed, correctly
+  not conflated with a packaging/bootstrapper problem. No code change needed; existing behavior
+  already satisfies the intent.
+
 - **NI-VISA real install fails fast in CI (`installer_rc=-125083`) -- environmental, NOT a repo/test/CI-code
   bug.** Diagnosed via the REQ-008 `[VISA]` diagnostic logging (download method / file size / PE check /
   installer exit code, surfaced in the `pyvisa.nivisa.reason` NDJSON details). On the conda-full lane the
@@ -647,6 +665,20 @@ rather than relying on manual memory.
 ## Closed Backlog
 
 Items completed and shipped:
+
+- **Pages-deploy retry with backoff**: the "Deploy to GitHub Pages" step (`publish_diag` job)
+  previously made a single `actions/deploy-pages@v5` attempt with no retry, so a transient
+  backend failure ("Deployment failed, try again later" -- observed directly in this repo's own
+  CI, e.g. run 28798318708) required a manual empty-commit retrigger. Split the single step into
+  up to three attempts: attempt 1, then (only on failure) a 30s wait and attempt 2, then (only
+  if both failed) a 20-minute wait and a final attempt 3 -- escalating rather than flat, on the
+  theory that two consecutive failures signal a longer-lived backend issue worth giving real
+  recovery time rather than hammering on a short cadence. Mirrors this repo's existing
+  detect-transient-failure-then-retry idiom (conda create/bulk install) rather than pulling in a
+  third-party retry-wrapper action. The job's `timeout-minutes` was widened 25 -> 40 to
+  accommodate the worst case. Non-gating and safe to wait long: the job already has
+  `concurrency.cancel-in-progress: true` scoped to the ref, so a sleeping attempt is safely
+  superseded (not wasted runner time) if a newer push lands in the meantime. CLOSED by this PR.
 
 - **Add `.github/dependabot.yml`**: no dependabot config existed anywhere in the repo, so there
   was no automated signal when a GitHub Action pin fell behind (the 2026-07 maintenance sweeps


### PR DESCRIPTION
## Summary

Bundles a docs-only investigation with a small functional change, since the first has no code diff on its own -- saves a CI-wait cycle.

**User-code exit-code semantics (docs only):** traced the full flow and confirmed `HP_SMOKE_RC` is captured directly from `%ERRORLEVEL%` immediately after launching the user's program at every verification call site, via goto-based dispatch with no bootstrapper logic interleaved -- it is purely the user program's own exit code. Separately confirmed the bootstrapper's own reported status is entirely decoupled: the `exit /b 0` at the end of the `:success` label (the real `run_setup.bat` process exit code) and every `write_status ok` call pass a hardcoded literal `0`, never `%HP_SMOKE_RC%`, so a crashing user program is never reported as a bootstrapper failure. Also confirmed such a failure does not get misrouted into the `--hidden-import` recovery loop, which only engages for a narrow `ModuleNotFoundError`-of-an-installed-module signature. No code change needed; moved from Active Backlog to Known Findings with the full trace documented.

**Pages-deploy retry with backoff:** the "Deploy to GitHub Pages" step previously made a single attempt with no retry, so a transient backend failure ("Deployment failed, try again later", observed directly in this repo's own CI) required a manual empty-commit retrigger. Splits it into up to three attempts: attempt 1, then (only on failure) a 30s wait and attempt 2, then (only if both failed) a 20-minute wait and a final attempt 3 -- escalating rather than flat, since two consecutive failures suggest a longer-lived issue worth giving real recovery time rather than hammering on a short cadence. Widened the job's `timeout-minutes` 25 -> 40 to fit the worst case. Non-gating and safe to wait long: the job already has `concurrency.cancel-in-progress` scoped to the ref, so a sleeping attempt is safely superseded if a newer push lands meanwhile.

## Test plan

- [x] `python tools/check_delimiters.py run_setup.bat` -- clean (unaffected, no-op since untouched).
- [x] `python -m compileall -q .` / `python -m pyflakes .` -- clean.
- [x] `python -m yamllint .github/workflows/` / `actionlint -oneline .github/workflows/*.yml` -- clean.
- [x] `python -m pytest tests/test_*.py` -- 192 passed, 2 skipped (Windows-only), unaffected.
- [x] Independent code-review pass on the new multi-step retry YAML: confirmed correct `.outcome` (not `.conclusion`) usage in every condition, correct truth table across all deploy1/deploy2 success/fail combinations, correct handling of the skipped-step case (`'skipped' != 'failure'`), no id collisions, and a comfortable `timeout-minutes: 40` margin (~25-27 min worst case).
- [x] CI verified truly green via the raw GitHub Actions API and downloaded job logs (not just the diagnostics site): all 8 matrix lanes + aggregator + model-quick-fix + publish-diagnostics succeeded on commit `cb529d6`. Confirmed the retry logic's happy path directly from the `publish_diag` job log: only one `Deploy to GitHub Pages` invocation appears (attempt 1 succeeded -- "Created deployment... Reported success!"), proving attempts 2/3 and both backoff-wait steps correctly never ran on a normal deploy.

Co-Authored-By: Claude Sonnet 5

https://claude.ai/code/session_015xbWLPbiaKVsobB9FZy8kS


---
_Generated by [Claude Code](https://claude.ai/code/session_015xbWLPbiaKVsobB9FZy8kS)_