### PR TITLE
Add 3-way NDJSON registry cross-check (doc vs code vs log)

### DIFF
--- a/.github/workflows/batch-check.yml
+++ b/.github/workflows/batch-check.yml
@@ -2824,6 +2824,33 @@ jobs:
             '- No gate summary generated.' | Out-File -Append $env:GITHUB_STEP_SUMMARY
           }
 
+  ndjson-registry-check:
+    name: NDJSON registry cross-check (doc vs code vs log)
+    # derived requirement: advisory only -- cross-checks docs/agent-ndjson.md's row registry
+    # against PowerShell/run_setup.bat emission sites (code) and this run's own observed NDJSON
+    # artifacts (log). continue-on-error keeps this fully non-gating: a finding here is real and
+    # worth fixing, but must never block a PR merge on its own (this tool is new and advisory by
+    # design, matching how other non-mature lanes in this repo graduate to gating only after a
+    # soak period -- see AGENTS.md and CLAUDE.md's CI lane gating maturity notes).
+    needs: [selftest]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Download lane NDJSON artifacts (small files only, not the diag bundles)
+        uses: actions/download-artifact@v6
+        continue-on-error: true
+        with:
+          pattern: ci_test_results-selftest-*
+          path: ${{ runner.temp }}/ndjson-logs
+          merge-multiple: true
+
+      - name: Run NDJSON registry cross-check
+        shell: bash
+        run: python3 tools/check_ndjson_registry.py --repo-root . --log-dir "${{ runner.temp }}/ndjson-logs"
 
   model-quick-fix:
     name: Model quick-fix (inline)

--- a/.github/workflows/batch-check.yml
+++ b/.github/workflows/batch-check.yml
@@ -2846,7 +2846,12 @@ jobs:
         with:
           pattern: ci_test_results-selftest-*
           path: ${{ runner.temp }}/ndjson-logs
-          merge-multiple: true
+          # derived requirement: NOT merge-multiple -- every lane's artifact zips a file with
+          # the identical name (ci_test_results.ndjson), so merging them into one flat directory
+          # makes each download silently overwrite the last, leaving only one lane's rows visible
+          # to the --log-dir scan. Without merge-multiple, each artifact lands in its own
+          # <path>/<artifact-name>/ subdirectory; scan_log_ids() already globs recursively
+          # (Path.rglob), so all lanes' rows are still picked up.
 
       - name: Run NDJSON registry cross-check
         shell: bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -504,9 +504,16 @@ a fact confirmed with no action needed, or a recurring/periodic check belongs in
 "Known Findings", `docs/agent-lessons-learned.md`, or "Periodic Maintenance Checks" below instead
 (see those sections' own scope notes).
 
-- **CI-side NDJSON row registry check**: consider building the `docs/agent-ndjson.md` row
-  audit into CI (it exists today so agents can see which rows are missing). Likely still a
-  manual-sync confirmation step, since fully automated discovery can miss flag-gated rows.
+- **Backfill the 11 real gaps surfaced by the new NDJSON registry check**: the first real
+  run of `tools/check_ndjson_registry.py` (see Closed Backlog) found 11 row IDs genuinely
+  emitted in code but never registered in `docs/agent-ndjson.md` (`conda.url`, `env.mode`,
+  `helper.find_entry.syntax`, `helper.invoke`, `entry.expected`, `entry.helper.ok`,
+  `entry.single.direct`, `envsmoke.run`, `self.cache.corrupted`, `self.exe.smokerun`,
+  `self.warnfix.platform_filter`) and 3 stale registry entries with zero matching emission
+  site anywhere in the repo (`self.heuristics.pytest`, `self.parse_warn.pytest`,
+  `self.pytest.unit` -- likely rows removed from code without a doc update at the time).
+  Deliberately left unfixed in the same PR as the tool itself (verify-the-tool-works vs.
+  fix-every-finding are different tasks); register/remove these in a dedicated follow-up.
 
 - **pipreqs dead-or-not / internalization decision (2026-07)**: pipreqs (bndr/pipreqs) is
   stagnant (maintenance-only, looking for maintainers) but not at risk of disappearing from
@@ -665,6 +672,33 @@ rather than relying on manual memory.
 ## Closed Backlog
 
 Items completed and shipped:
+
+- **CI-side NDJSON row registry check (3-way: doc vs code vs log)**: no automated signal
+  existed that `docs/agent-ndjson.md`'s row registry had drifted from what the code actually
+  emits, despite the file's own AGENT DIRECTIVE asking for in-commit sync. Added
+  `tools/check_ndjson_registry.py` (stdlib-only): parses doc-registered IDs from the fenced
+  code blocks (with brace-expansion for `prefix.{a,b,c}` syntax and parenthetical-annotation
+  stripping), statically scans `tests/*.ps1` and `run_setup.bat` for all three PowerShell
+  emission conventions in use (`id = '...'` hashtable literals, `Write-Result '...'`
+  positional, `-Id '...'` named-parameter), and optionally cross-references against IDs
+  actually observed in a directory of downloaded NDJSON artifacts. Deliberately excludes
+  `tests/dynamic_tests.py` (Python, different emission pattern, and its "Dynamic-tests
+  NDJSON" doc section already documents several rows as "(x many)" per-test-case IDs) --
+  documented as an explicit scope limitation, not silently ignored. Discovered along the way
+  that the doc's own "(x many)" annotation means "same literal id fires multiple times in a
+  loop," not "dynamically-suffixed id family" as first assumed -- verified by tracing actual
+  emission sites (`pr.to_conda`, `dp.pep440`, `emit.extract` are all single literal IDs
+  called repeatedly, not templated); an earlier draft that treated them as wildcards produced
+  a false positive on `emit.extract`, fixed before shipping. Wired into `batch-check.yml` as
+  a new `ndjson-registry-check` job (`needs: [selftest]`, `ubuntu-latest`, downloads only the
+  small `ci_test_results-selftest-*` artifacts -- not the multi-hundred-MB `diag-*` bundles)
+  with job-level `continue-on-error: true`, matching this repo's established non-gating-lane
+  convention so a real finding is visible without blocking merges while the tool is new. Five
+  unit tests in `tests/test_check_ndjson_registry.py` cover brace expansion, all three code
+  emission patterns, log-file parsing, and both pass/fail end-to-end paths via `main()`. First
+  real run against this repo found 11 genuine undocumented rows and 3 stale registry entries
+  (see the new Active Backlog item to backfill them -- deliberately left unfixed in this same
+  PR). CLOSED by this PR.
 
 - **Pages-deploy retry with backoff**: the "Deploy to GitHub Pages" step (`publish_diag` job)
   previously made a single `actions/deploy-pages@v5` attempt with no retry, so a transient

--- a/tests/test_check_ndjson_registry.py
+++ b/tests/test_check_ndjson_registry.py
@@ -1,0 +1,89 @@
+from tools import check_ndjson_registry
+
+
+def test_parse_doc_registry_expands_braces_and_strips_annotations(tmp_path):
+    doc = tmp_path / "agent-ndjson.md"
+    doc.write_text(
+        "## Section\n\n"
+        "```\n"
+        "reqspec.translate.{gte,eq,compat}, self.cascade.exec (uv lane only -- notes; non-gating),\n"
+        "pr.to_conda (x many)\n"
+        "```\n",
+        encoding="utf-8",
+    )
+    ids, many_ids = check_ndjson_registry.parse_doc_registry(doc)
+    assert ids == {
+        "reqspec.translate.gte",
+        "reqspec.translate.eq",
+        "reqspec.translate.compat",
+        "self.cascade.exec",
+        "pr.to_conda",
+    }
+    # "(x many)" is informational only (same id fires many times) -- still a full member of ids.
+    assert many_ids == {"pr.to_conda"}
+
+
+def test_scan_code_ids_covers_all_three_emission_patterns(tmp_path):
+    ps1 = tmp_path / "selfapps_example.ps1"
+    ps1.write_text(
+        "Write-NdjsonRow ([ordered]@{ id = 'self.example.hashtable'; pass = $true })\n"
+        "Write-Result 'batch.example.writeresult' 'desc' $true @{}\n"
+        "Write-EntryRow -Id 'self.example.namedparam' -Expected $x\n",
+        encoding="utf-8",
+    )
+    ids = check_ndjson_registry.scan_code_ids([ps1])
+    assert ids == {
+        "self.example.hashtable",
+        "batch.example.writeresult",
+        "self.example.namedparam",
+    }
+
+
+def test_scan_log_ids_reads_ndjson_lines(tmp_path):
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    (log_dir / "results.ndjson").write_text(
+        '{"id": "self.example.hashtable", "pass": true}\n'
+        '{"id": "batch.example.writeresult", "pass": false}\n'
+        "not-json\n",
+        encoding="utf-8",
+    )
+    ids = check_ndjson_registry.scan_log_ids(log_dir)
+    assert ids == {"self.example.hashtable", "batch.example.writeresult"}
+
+
+def test_main_reports_pass_when_doc_and_code_agree(tmp_path, capsys):
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "agent-ndjson.md").write_text(
+        "```\nself.example.row\n```\n", encoding="utf-8"
+    )
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "tests" / "selfapps_example.ps1").write_text(
+        "Write-NdjsonRow ([ordered]@{ id = 'self.example.row'; pass = $true })\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "run_setup.bat").write_text("rem no rows here\n", encoding="utf-8")
+
+    result = check_ndjson_registry.main(["--repo-root", str(tmp_path)])
+    captured = capsys.readouterr()
+
+    assert result == 0
+    assert "PASS: no doc/code registry mismatches found." in captured.out
+
+
+def test_main_reports_fail_on_undocumented_code_row(tmp_path, capsys):
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "agent-ndjson.md").write_text("```\n```\n", encoding="utf-8")
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "tests" / "selfapps_example.ps1").write_text(
+        "Write-NdjsonRow ([ordered]@{ id = 'self.example.undocumented'; pass = $true })\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "run_setup.bat").write_text("rem no rows here\n", encoding="utf-8")
+
+    result = check_ndjson_registry.main(["--repo-root", str(tmp_path)])
+    captured = capsys.readouterr()
+
+    assert result == 1
+    assert "self.example.undocumented" in captured.out
+    assert "Emitted in code but not registered" in captured.out

--- a/tools/check_ndjson_registry.py
+++ b/tools/check_ndjson_registry.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Cross-checks NDJSON row IDs across three sources: docs/agent-ndjson.md (doc),
+PowerShell Write-NdjsonRow/Write-Result call sites plus run_setup.bat inline
+emissions (code), and observed NDJSON artifacts from a CI run (log, optional).
+
+Advisory tool: reports mismatches, does not attempt to be exhaustive.
+Scope: PowerShell-emitted rows only (tests/*.ps1, tests/harness.ps1,
+run_setup.bat). dynamic_tests.py's Python-side rows are out of scope --
+docs/agent-ndjson.md's own "Dynamic-tests NDJSON" section already
+acknowledges several of those as "(x many)" per-test-case IDs.
+"""
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+DOC_FENCE_RE = re.compile(r'```(?:\w*)\n(.*?)\n```', re.DOTALL)
+BRACE_RE = re.compile(r'([A-Za-z0-9_.\-]*)\{([^{}]+)\}')
+DOC_TOKEN_RE = re.compile(r'([A-Za-z0-9][A-Za-z0-9_.\-]*\.[A-Za-z0-9_.\-]*)(?:\s*\(([^()]*)\))?')
+CODE_HASHTABLE_ID_RE = re.compile(r"""\bid\s*=\s*['"]([A-Za-z0-9][A-Za-z0-9_.\-]*)['"]""")
+CODE_WRITERESULT_ID_RE = re.compile(r"""Write-Result\s+['"]([A-Za-z0-9][A-Za-z0-9_.\-]*)['"]""")
+CODE_NAMEDPARAM_ID_RE = re.compile(r"""-Id\s+['"]([A-Za-z0-9][A-Za-z0-9_.\-]*)['"]""")
+
+
+def expand_braces(text: str) -> str:
+    def _expand(m):
+        prefix, inner = m.group(1), m.group(2)
+        return ', '.join(prefix + v.strip() for v in inner.split(','))
+    prev = None
+    while prev != text:
+        prev = text
+        text = BRACE_RE.sub(_expand, text)
+    return text
+
+
+def parse_doc_registry(doc_path: Path):
+    """Returns (ids, many_ids). many_ids is informational only (rows tagged "(x many)"
+    fire multiple times under one literal id, e.g. once per loop iteration -- confirmed
+    by inspecting their emission sites; it is NOT a dynamic/templated-id wildcard, so it
+    does not need special-case exclusion from the doc/code diff below)."""
+    text = doc_path.read_text(encoding='utf-8')
+    ids = set()
+    many_ids = set()
+    for block in DOC_FENCE_RE.findall(text):
+        block = expand_braces(block)
+        for m in DOC_TOKEN_RE.finditer(block):
+            token, note = m.group(1), m.group(2)
+            token = token.strip().rstrip('.')
+            if not token:
+                continue
+            ids.add(token)
+            if note and 'many' in note.lower():
+                many_ids.add(token)
+    return ids, many_ids
+
+
+def scan_code_ids(paths):
+    ids = set()
+    for p in paths:
+        text = p.read_text(encoding='utf-8', errors='replace')
+        for m in CODE_HASHTABLE_ID_RE.finditer(text):
+            ids.add(m.group(1))
+        for m in CODE_WRITERESULT_ID_RE.finditer(text):
+            ids.add(m.group(1))
+        for m in CODE_NAMEDPARAM_ID_RE.finditer(text):
+            ids.add(m.group(1))
+    return ids
+
+
+def scan_log_ids(log_dir: Path):
+    ids = set()
+    if not log_dir or not log_dir.is_dir():
+        return ids
+    for ndjson_file in log_dir.rglob('*.ndjson'):
+        try:
+            for line in ndjson_file.read_text(encoding='utf-8', errors='replace').splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    row = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(row, dict) and 'id' in row:
+                    ids.add(str(row['id']))
+        except OSError:
+            continue
+    return ids
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument('--repo-root', default='.', type=Path)
+    ap.add_argument('--log-dir', default=None, type=Path,
+                     help='Directory containing downloaded *.ndjson artifacts (optional)')
+    args = ap.parse_args(argv)
+
+    root = args.repo_root
+    doc_path = root / 'docs' / 'agent-ndjson.md'
+    doc_ids, doc_many_ids = parse_doc_registry(doc_path)
+
+    code_paths = sorted((root / 'tests').glob('*.ps1')) + [root / 'run_setup.bat']
+    code_paths = [p for p in code_paths if p.is_file()]
+    code_ids = scan_code_ids(code_paths)
+
+    doc_only = sorted(doc_ids - code_ids)
+    code_only = sorted(code_ids - doc_ids)
+
+    print(f"Doc-registered IDs: {len(doc_ids)} ({len(doc_many_ids)} tagged '(x many)')")
+    print(f"Code-emitted IDs (PowerShell scan): {len(code_ids)}")
+    print()
+
+    ok = True
+    if doc_only:
+        ok = False
+        print(f"## Registered in docs but no matching code emission site found ({len(doc_only)})")
+        print("(stale/removed row -- doc likely needs cleanup -- OR a legitimate 'Dynamic-tests")
+        print(" NDJSON' row from tests/dynamic_tests.py, which this scanner does not read (Python")
+        print(" file, out of scope by design -- see this script's module docstring). Verify by")
+        print(" hand against dynamic_tests.py before treating any of these as a real gap.)")
+        for i in doc_only:
+            print(f"  - {i}")
+        print()
+
+    if code_only:
+        ok = False
+        print(f"## Emitted in code but not registered in docs/agent-ndjson.md ({len(code_only)})")
+        print("(the AGENT DIRECTIVE gap this tool exists to catch -- register these)")
+        for i in code_only:
+            print(f"  - {i}")
+        print()
+
+    if args.log_dir:
+        observed = scan_log_ids(args.log_dir)
+        print(f"Observed IDs in downloaded NDJSON artifacts: {len(observed)}")
+        known = doc_ids | code_ids
+        never_observed = sorted(i for i in known if i not in observed)
+        if never_observed:
+            print(f"## Known IDs never observed in this run's artifacts ({len(never_observed)})")
+            print("(ADVISORY ONLY -- many of these are legitimately lane/flag-gated or")
+            print(" inline-emitted rows that don't reach a real CI artifact by design; see")
+            print(" docs/agent-ndjson.md 'Key facts for debugging missing rows'. Not a failure")
+            print(" signal on its own -- for human review only, never affects exit code.)")
+            for i in never_observed:
+                print(f"  - {i}")
+        print()
+
+    if ok:
+        print("PASS: no doc/code registry mismatches found.")
+        return 0
+    else:
+        print("FAIL: doc/code registry mismatches found (see above). This check is advisory")
+        print("(non-gating) -- it will not block PR merges, but should be addressed.")
+        return 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Add `tools/check_ndjson_registry.py` (stdlib-only): cross-checks `docs/agent-ndjson.md`'s NDJSON row registry against three sources -- the doc itself, static scans of `tests/*.ps1`/`run_setup.bat` (covering all three PowerShell emission conventions: `id='...'` hashtable literals, `Write-Result '...'` positional, `-Id '...'` named-parameter), and optionally IDs actually observed in downloaded NDJSON artifacts from a CI run. `tests/dynamic_tests.py` (Python, different emission pattern) is explicitly out of scope, documented in the tool's own docstring and output.
- Wire it into `batch-check.yml` as a new `ndjson-registry-check` job (`needs: [selftest]`, `continue-on-error: true` -- fully non-gating while the tool is new, matching this repo's established convention for young/advisory lanes).
- Add 5 unit tests in `tests/test_check_ndjson_registry.py` covering brace expansion, all three code emission patterns, log-file parsing, and both pass/fail end-to-end paths.
- Update `CLAUDE.md`: move the old speculative backlog entry to a Closed Backlog writeup, and add a new Active Backlog item listing the 11 genuinely undocumented rows and 3 stale registry entries the tool's first real run surfaced (deliberately left unfixed here -- verifying the tool works and fixing every finding are different tasks).

### Fix-up (second commit)

CI verification on the first push (run 28871527445) caught a real bug in the job's own artifact-download step: all 8 lane artifacts (`ci_test_results-selftest-*`) zip a file with the identical name (`ci_test_results.ndjson`), and `merge-multiple: true` flattened all 8 downloads into one directory, so each download silently overwrote the last -- only 1 ID was ever visible to the `--log-dir` cross-check instead of the full cross-lane set. This only affected the advisory, non-exit-code-affecting "never observed" section; the primary doc-vs-code diff was already exactly correct (19 doc-only, 11 code-only). Fixed by dropping `merge-multiple`, so each artifact lands in its own subdirectory (the scanner already globs recursively). Re-verified on run 28878294793: "Observed IDs" went from 1 to 124.

## Test plan

- [x] `python -m compileall -q .` -- clean
- [x] `python -m pyflakes .` -- clean
- [x] `python tools/check_delimiters.py run_setup.bat` -- no issues (file untouched, confirms no regression)
- [x] `python -m yamllint .github/workflows/` -- clean
- [x] `actionlint -oneline .github/workflows/*.yml` -- clean
- [x] `python -m pytest tests/test_*.py -q` -- 197 passed, 2 skipped (no regressions)
- [x] ASCII-only sweep of touched files -- clean (no non-ASCII introduced)
- [x] CI run 28871527445 (commit 98ee8e5): all 8 matrix lanes + `selftest-gate` green; `ndjson-registry-check` ran and reported 19 doc-only + 11 code-only findings with exit code 1, correctly non-gating (overall run conclusion `success`)
- [x] CI run 28878294793 (commit e3c6e56, artifact-collision fix): all 8 matrix lanes + `selftest-gate` green again; `ndjson-registry-check`'s log-dir cross-check now correctly observes 124 IDs across all 8 lanes (up from the collision-degraded 1); doc/code diff counts unchanged and correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015xbWLPbiaKVsobB9FZy8kS)_