### PR TITLE
Backfill NDJSON registry, extend scanner to workflow YAML, fix selftest-gate artifact collision

### DIFF
--- a/.github/workflows/batch-check.yml
+++ b/.github/workflows/batch-check.yml
@@ -2711,7 +2711,15 @@ jobs:
         with:
           pattern: selftest-verdict-*
           path: ${{ runner.temp }}/selftest-verdicts
-          merge-multiple: true
+          # derived requirement: NOT merge-multiple -- every lane's artifact zips a file with the
+          # identical local name (lane_verdict.json), so merging them into one flat directory made
+          # each download silently overwrite the last, leaving the aggregation step below able to
+          # see only ONE lane's verdict (Get-ChildItem found a single surviving file) instead of
+          # all matrix lanes'. Found while auditing this exact artifact-collision pattern after
+          # tools/check_ndjson_registry.py's own download step hit the identical bug (see
+          # docs/agent-lessons-learned.md). Without merge-multiple, each artifact lands in its own
+          # <path>/<artifact-name>/ subdirectory; the aggregation step's Get-ChildItem already uses
+          # -Recurse, so no other change is needed to see every lane's verdict.
 
       - name: Aggregate verdicts
         id: aggregate

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -504,17 +504,6 @@ a fact confirmed with no action needed, or a recurring/periodic check belongs in
 "Known Findings", `docs/agent-lessons-learned.md`, or "Periodic Maintenance Checks" below instead
 (see those sections' own scope notes).
 
-- **Backfill the 11 real gaps surfaced by the new NDJSON registry check**: the first real
-  run of `tools/check_ndjson_registry.py` (see Closed Backlog) found 11 row IDs genuinely
-  emitted in code but never registered in `docs/agent-ndjson.md` (`conda.url`, `env.mode`,
-  `helper.find_entry.syntax`, `helper.invoke`, `entry.expected`, `entry.helper.ok`,
-  `entry.single.direct`, `envsmoke.run`, `self.cache.corrupted`, `self.exe.smokerun`,
-  `self.warnfix.platform_filter`) and 3 stale registry entries with zero matching emission
-  site anywhere in the repo (`self.heuristics.pytest`, `self.parse_warn.pytest`,
-  `self.pytest.unit` -- likely rows removed from code without a doc update at the time).
-  Deliberately left unfixed in the same PR as the tool itself (verify-the-tool-works vs.
-  fix-every-finding are different tasks); register/remove these in a dedicated follow-up.
-
 - **pipreqs dead-or-not / internalization decision (2026-07)**: pipreqs (bndr/pipreqs) is
   stagnant (maintenance-only, looking for maintainers) but not at risk of disappearing from
   PyPI outright -- PyPI does not delete established packages. The real risk the community
@@ -672,6 +661,42 @@ rather than relying on manual memory.
 ## Closed Backlog
 
 Items completed and shipped:
+
+- **NDJSON registry backfill + scanner scope fix + `selftest-gate` artifact-collision fix**:
+  follow-up to the registry-check tool below (same day). Investigating its first real findings
+  (11 code-only rows, 3 doc-only "stale" rows) found the "stale" classification was **wrong**:
+  those 3 rows (`self.heuristics.pytest`, `self.parse_warn.pytest`, `self.pytest.unit`) were
+  never removed from code -- they're emitted directly from inline PowerShell in
+  `.github/workflows/batch-check.yml`, a file the scanner never read (it only scanned
+  `tests/*.ps1` and `run_setup.bat`). Extended `tools/check_ndjson_registry.py`'s `code_paths`
+  to also scan `.github/workflows/*.yml`/`*.yaml`, which fixed the false "stale" classification
+  and surfaced 3 MORE genuinely-undocumented rows the old scope had made invisible entirely
+  (`meta.env.mode`, `self.cache.bootstrap.failed`, and `workflow.lint` from the separate dormant
+  `workflow-lint.yml`) -- bringing the real gap count to 14, not 11. Also found and added a 4th
+  PowerShell/JSON emission convention while scanning workflow YAML: a raw JSON-string literal
+  (`'{"id":"...",...}'`), used by the "Catch cache lane bootstrap failure" step instead of the
+  `id = '...'` hashtable-literal form the other three conventions use. All 14 rows are now
+  registered in `docs/agent-ndjson.md` (see that file's "Key facts" section for the full
+  per-row breakdown); a clean re-run now shows 0 code-only findings and exactly the 16
+  genuinely-out-of-scope `dynamic_tests.py` rows as the only doc-only findings. Two new unit
+  tests cover the JSON-literal pattern and workflow-YAML scanning.
+
+  Separately, while auditing the repo for other instances of the exact artifact-collision bug
+  the registry-check job itself had (see the entry below), found a second, pre-existing
+  instance: `selftest-gate`'s "Download lane verdicts" step had the identical
+  `merge-multiple: true` + identical-local-filename (`lane_verdict.json`) collision, silently
+  limiting its `has_failures` aggregation to whichever single lane's verdict survived instead of
+  ORing all 8 matrix lanes. Lower severity than it sounds: `has_failures` only gates
+  `model-quick-fix`'s auto-fix trigger, not PR merge gating (the `real`/`conda-full` matrix jobs
+  gate merges via their own independent check conclusions) -- but it could silently skip
+  auto-fix attempts when a non-surviving lane had real failures. Fixed with the same one-line
+  removal of `merge-multiple`. Audited the workflow's two other `merge-multiple: true` usages:
+  one (`iterate-logs-*` download) is a single-named-artifact download with no collision
+  possible, confirmed safe and left as-is. Added a general lessons-learned entry
+  (`docs/agent-lessons-learned.md`, "`download-artifact@v6` `merge-multiple: true` silently
+  overwrites same-named files") documenting the hazard class and an audit method for future
+  additions, so this class of bug is checked for by construction rather than rediscovered a
+  third time. CLOSED by this PR.
 
 - **CI-side NDJSON row registry check (3-way: doc vs code vs log)**: no automated signal
   existed that `docs/agent-ndjson.md`'s row registry had drifted from what the code actually

--- a/docs/agent-lessons-learned.md
+++ b/docs/agent-lessons-learned.md
@@ -267,6 +267,54 @@ inventory step instead of routing it through the process environment. Applied to
 General rule: NEVER pass data >32 KB through GitHub Actions step `env:` -- write to a
 temp file in `$GITHUB_WORKSPACE` and read from disk instead.
 
+## `download-artifact@v6` `merge-multiple: true` silently overwrites same-named files
+
+**This has now bitten this repo twice with the identical root cause.** When a workflow step
+downloads MULTIPLE artifacts matching a `pattern:`, and each of those artifacts zips a file with
+the SAME local filename (only the artifact's own top-level *name* differs, e.g.
+`ci_test_results-selftest-<mode>-<run>-<attempt>` all containing `ci_test_results.ndjson`, or
+`selftest-verdict-<mode>` all containing `lane_verdict.json`), setting `merge-multiple: true`
+extracts every matched artifact into ONE flat directory. Because the local filenames collide,
+each subsequent download silently overwrites the previous one -- **only the last-downloaded
+artifact's content survives**, with no error, warning, or non-zero exit code anywhere in the
+step. Any step downstream that reads "the file" in that directory silently sees just one lane's
+data instead of all of them.
+
+**Confirmed instances (both fixed):**
+1. `ndjson-registry-check`'s "Download lane NDJSON artifacts" step (added 2026-07): caught during
+   CI verification of the job's first real run -- the `--log-dir` cross-check reported only 1
+   observed ID across all 8 lanes instead of the expected 100+. This was advisory-only (never
+   affected the job's exit code or the primary doc-vs-code diff), but degraded the tool's third
+   data source to near-uselessness.
+2. `selftest-gate`'s "Download lane verdicts" step (pre-existing, found while auditing the first
+   instance for other occurrences of the same pattern): silently limited the `has_failures`
+   aggregation to whichever single lane's `lane_verdict.json` happened to survive the collision,
+   instead of the OR of all 8 matrix lanes. Lower severity than it sounds -- `has_failures` only
+   feeds `model-quick-fix`'s auto-fix trigger (`HAS_FAILURES` env var), NOT PR merge gating
+   itself (the `real`/`conda-full` matrix jobs gate merges via their own individual GitHub check
+   conclusions, entirely independent of this aggregation) -- but it could have caused the
+   auto-fix bot to skip attempting a fix when a non-surviving lane genuinely had failures.
+
+**The fix is the same in both cases and is the correct default: drop `merge-multiple` entirely.**
+Without it, `download-artifact@v6` places each matched artifact into its own
+`<path>/<artifact-name>/` subdirectory, so no collision is possible. Every consumer in this repo
+that reads the downloaded files already does so via `Get-ChildItem -Recurse` / `Path.rglob` /
+equivalent, so removing `merge-multiple` requires no other code change -- the recursive read
+already looks inside per-artifact subdirectories.
+
+**When `merge-multiple: true` IS actually safe (confirmed present, unfixed, correctly so):**
+`batch-check.yml`'s "Download iterate logs artifact" step (`publish_diag` job) downloads a
+single artifact by exact `name:`, not a `pattern:` matching several -- there is only ever one
+artifact in play, so no collision is possible regardless of the flag.
+
+**Audit method for future additions:** before setting `merge-multiple: true` on any
+`download-artifact@v6` step that uses `pattern:` (matches more than one artifact), trace the
+matching `upload-artifact@v6` step(s) and check whether the uploaded `path:` is the same local
+filename across all matched artifacts. If yes, either drop `merge-multiple` (preferred -- almost
+always safe, since consuming code should already handle nested subdirectories) or give each
+upload a distinct filename. Do not add `merge-multiple: true` to a new multi-artifact download
+step without doing this check first.
+
 ---
 
 ## Heuristic dep-augmentation (HP_PREP_REQUIREMENTS): pandas[excel] extras syntax

--- a/docs/agent-ndjson.md
+++ b/docs/agent-ndjson.md
@@ -17,7 +17,7 @@ accidental removal or unexpected additions.**
 ```
 self.harness.started, self.bootstrap.state, self.empty_repo.msg,
 self.empty_repo.no_spurious_warn,
-self.env.smoke.conda, self.env.smoke.run, self.env.smoke.uv,
+self.env.smoke.conda, self.env.smoke.run, self.env.smoke.uv, envsmoke.run,
 self.uv.managed.interpreter,
 self.exe.build, self.exe.run,
 self.exe.smokerun.xfail, self.exe.smokerun.exedata.xfail, self.exe.smokerun.exedyn.xfail,
@@ -28,6 +28,7 @@ self.checkpoint.accept, self.checkpoint.decline,
 self.entry.entry1, self.entry.entryA, self.entry.entryB, self.entry.entryC, self.entry.entryD,
 self.entry.helper.invoke.absent, self.entry.results, self.entry.spaced-path, self.entry.picker,
 self.entry.req011.crossdir, self.entry.req011.sameDir, self.isolation.req010.pythonpath,
+entry.single.direct, entry.expected, helper.invoke,
 self.envname.hyphen, self.size.tripwire,
 reqspec.translate.{gte,eq,compat,gt,neq,lte}, reqspec.conda.dryrun,
 reqspec.conda.channelpin, reqspec.conda.dryrun.failcase,
@@ -141,7 +142,10 @@ batch.delayed.off, batch.delayed.enable_absent, batch.bang.scan,
 conda.channels, pipreqs.flags, pyi.onefile, log.rotate, tilde.naming,
 visa.detect, emit.helpers, env.state.write, dep.check.parse_lock,
 dp.compat, prep.multi.constraint, batch.paren.balance, env.foldername,
-conda.path,
+conda.path, conda.url, env.mode,
+self.warnfix.platform_filter, self.exe.smokerun, helper.find_entry.syntax, entry.helper.ok,
+self.cache.corrupted, self.cache.bootstrap.failed,
+meta.env.mode, workflow.lint,
 version.metadata,
 host.env.os, host.env.ps, host.env.python,
 batch.req009.venv_unconditional, batch.req009.provider_logs, batch.req009.cascade_detect, batch.req009.cascade_consent, batch.req009.cascade_exec,
@@ -213,6 +217,38 @@ self.venv.fallback, self.venv.canary_fail, self.venv.nopip_retry, self.entry.ove
   this row does not currently appear in a real CI artifact -- same situation as `self.exe.smokerun`
   and other inline-emitted rows. It is registered above so its id is not mistaken for an
   unexpected/typo'd addition if a future lane change makes it fire.
+- **Backfilled 2026-07 via `tools/check_ndjson_registry.py`'s first real run.** Twelve rows were
+  genuinely emitted but never registered: `conda.url` and `env.mode` (inline `run_setup.bat`,
+  `HP_NDJSON`-gated -- the Miniconda download-probe outcome and the REQ-009 selected-provider
+  log, respectively), `self.warnfix.platform_filter` (inline `run_setup.bat`, confirms the
+  warnfix POSIX-module filter ran), `self.exe.smokerun` (inline `run_setup.bat`'s
+  `:smokerun_ndjson`, the EXE smoke exit-code row -- already referenced by the bullet above but
+  never formally registered), `helper.find_entry.syntax` (inline `run_setup.bat`, HP_FIND_ENTRY
+  payload compile-probe result) and `entry.helper.ok` (`harness.ps1` re-emits the same
+  pass/fail under this id), `entry.single.direct` (`selfapps_single.ps1`, REQ-002 -- already
+  referenced two bullets above but never formally registered), `entry.expected` and
+  `helper.invoke` (both `selfapps_single.ps1`, REQ-002 companion failure-detail rows --
+  `helper.invoke` is the same passive failure-detector documented for
+  `self.entry.helper.invoke.absent` above, just the underlying row itself), `envsmoke.run`
+  (`selfapps_envsmoke.ps1`, REQ-003 failure-detail row), and `self.cache.corrupted` (`harness.ps1`,
+  see `docs/agent-lessons-learned.md`'s cache-lane corruption-handling entry for the full
+  mechanism). This pass also caught the tool's own scope gap: `.github/workflows/*.yml` inline
+  PowerShell/Python was not scanned at all, which produced two kinds of error simultaneously --
+  three ALREADY-registered rows (`self.heuristics.pytest`, `self.parse_warn.pytest`,
+  `self.pytest.unit`, all emitted from `batch-check.yml` steps) were misreported as stale, and at
+  least two genuinely emitted rows (`self.cache.bootstrap.failed`, the sibling of
+  `self.cache.corrupted` documented in the same lessons-learned entry; `meta.env.mode`, the
+  per-lane "matrix mode meta row" step that fires unconditionally at the end of every selftest
+  matrix lane) were invisible to the tool entirely -- they never appeared in either the doc_only
+  or code_only list on the first run, because the tool didn't scan the file that emits them. A
+  fourth PowerShell/JSON emission convention was also found and added to the scanner: a raw
+  JSON-string literal (`'{"id":"...",...}'`), used by the "Catch cache lane bootstrap failure"
+  step instead of the `id = '...'` hashtable-literal form the other three conventions use.
+  `tools/check_ndjson_registry.py` now scans `.github/workflows/*.yml`/`*.yaml` in addition to
+  `tests/*.ps1` and `run_setup.bat`, and recognizes all four conventions. `workflow.lint` (from
+  the separate, dormant `workflow-lint.yml` -- `workflow_dispatch`-only, not run automatically;
+  see AGENTS.md/CLAUDE.md for why) was registered too for the same completeness reason, even
+  though that workflow rarely executes in practice.
 - `pipreqs.install` and `pipreqs.run` (backfilled into the registry 2026-07; both already
   existed in code before this) were emitted but undocumented gaps in this registry.
   `pipreqs.install` is emitted inline by `run_setup.bat` (gated on `HP_NDJSON`) right after the

--- a/tests/test_check_ndjson_registry.py
+++ b/tests/test_check_ndjson_registry.py
@@ -23,12 +23,13 @@ def test_parse_doc_registry_expands_braces_and_strips_annotations(tmp_path):
     assert many_ids == {"pr.to_conda"}
 
 
-def test_scan_code_ids_covers_all_three_emission_patterns(tmp_path):
+def test_scan_code_ids_covers_all_four_emission_patterns(tmp_path):
     ps1 = tmp_path / "selfapps_example.ps1"
     ps1.write_text(
         "Write-NdjsonRow ([ordered]@{ id = 'self.example.hashtable'; pass = $true })\n"
         "Write-Result 'batch.example.writeresult' 'desc' $true @{}\n"
-        "Write-EntryRow -Id 'self.example.namedparam' -Expected $x\n",
+        "Write-EntryRow -Id 'self.example.namedparam' -Expected $x\n"
+        '$row = \'{"id":"self.example.jsonliteral","pass":true}\'\n',
         encoding="utf-8",
     )
     ids = check_ndjson_registry.scan_code_ids([ps1])
@@ -36,6 +37,7 @@ def test_scan_code_ids_covers_all_three_emission_patterns(tmp_path):
         "self.example.hashtable",
         "batch.example.writeresult",
         "self.example.namedparam",
+        "self.example.jsonliteral",
     }
 
 
@@ -63,6 +65,31 @@ def test_main_reports_pass_when_doc_and_code_agree(tmp_path, capsys):
         encoding="utf-8",
     )
     (tmp_path / "run_setup.bat").write_text("rem no rows here\n", encoding="utf-8")
+
+    result = check_ndjson_registry.main(["--repo-root", str(tmp_path)])
+    captured = capsys.readouterr()
+
+    assert result == 0
+    assert "PASS: no doc/code registry mismatches found." in captured.out
+
+
+def test_main_scans_workflow_yaml_for_inline_emissions(tmp_path, capsys):
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "agent-ndjson.md").write_text(
+        "```\nself.example.workflow.row\n```\n", encoding="utf-8"
+    )
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "run_setup.bat").write_text("rem no rows here\n", encoding="utf-8")
+    workflows_dir = tmp_path / ".github" / "workflows"
+    workflows_dir.mkdir(parents=True)
+    (workflows_dir / "batch-check.yml").write_text(
+        "jobs:\n"
+        "  example:\n"
+        "    steps:\n"
+        "      - run: |\n"
+        "          $row = [ordered]@{ id = 'self.example.workflow.row'; pass = $true }\n",
+        encoding="utf-8",
+    )
 
     result = check_ndjson_registry.main(["--repo-root", str(tmp_path)])
     captured = capsys.readouterr()

--- a/tools/check_ndjson_registry.py
+++ b/tools/check_ndjson_registry.py
@@ -1,13 +1,16 @@
 #!/usr/bin/env python3
 """Cross-checks NDJSON row IDs across three sources: docs/agent-ndjson.md (doc),
 PowerShell Write-NdjsonRow/Write-Result call sites plus run_setup.bat inline
-emissions (code), and observed NDJSON artifacts from a CI run (log, optional).
+emissions and .github/workflows/*.yml inline PowerShell emissions (code), and
+observed NDJSON artifacts from a CI run (log, optional).
 
 Advisory tool: reports mismatches, does not attempt to be exhaustive.
-Scope: PowerShell-emitted rows only (tests/*.ps1, tests/harness.ps1,
-run_setup.bat). dynamic_tests.py's Python-side rows are out of scope --
-docs/agent-ndjson.md's own "Dynamic-tests NDJSON" section already
-acknowledges several of those as "(x many)" per-test-case IDs.
+Scope: PowerShell-emitted rows only (tests/*.ps1, run_setup.bat,
+.github/workflows/*.yml inline `run:` blocks -- several rows, e.g.
+self.pytest.unit, self.cache.corrupted, are emitted directly from workflow
+YAML, not from a tests/*.ps1 file). dynamic_tests.py's Python-side rows are
+out of scope -- docs/agent-ndjson.md's own "Dynamic-tests NDJSON" section
+already acknowledges several of those as "(x many)" per-test-case IDs.
 """
 import argparse
 import json
@@ -21,6 +24,7 @@ DOC_TOKEN_RE = re.compile(r'([A-Za-z0-9][A-Za-z0-9_.\-]*\.[A-Za-z0-9_.\-]*)(?:\s
 CODE_HASHTABLE_ID_RE = re.compile(r"""\bid\s*=\s*['"]([A-Za-z0-9][A-Za-z0-9_.\-]*)['"]""")
 CODE_WRITERESULT_ID_RE = re.compile(r"""Write-Result\s+['"]([A-Za-z0-9][A-Za-z0-9_.\-]*)['"]""")
 CODE_NAMEDPARAM_ID_RE = re.compile(r"""-Id\s+['"]([A-Za-z0-9][A-Za-z0-9_.\-]*)['"]""")
+CODE_JSONLITERAL_ID_RE = re.compile(r'"id"\s*:\s*"([A-Za-z0-9][A-Za-z0-9_.\-]*)"')
 
 
 def expand_braces(text: str) -> str:
@@ -65,6 +69,8 @@ def scan_code_ids(paths):
             ids.add(m.group(1))
         for m in CODE_NAMEDPARAM_ID_RE.finditer(text):
             ids.add(m.group(1))
+        for m in CODE_JSONLITERAL_ID_RE.finditer(text):
+            ids.add(m.group(1))
     return ids
 
 
@@ -100,7 +106,12 @@ def main(argv=None):
     doc_path = root / 'docs' / 'agent-ndjson.md'
     doc_ids, doc_many_ids = parse_doc_registry(doc_path)
 
-    code_paths = sorted((root / 'tests').glob('*.ps1')) + [root / 'run_setup.bat']
+    code_paths = (
+        sorted((root / 'tests').glob('*.ps1'))
+        + [root / 'run_setup.bat']
+        + sorted((root / '.github' / 'workflows').glob('*.yml'))
+        + sorted((root / '.github' / 'workflows').glob('*.yaml'))
+    )
     code_paths = [p for p in code_paths if p.is_file()]
     code_ids = scan_code_ids(code_paths)
 


### PR DESCRIPTION
## Summary

Follow-up to `tools/check_ndjson_registry.py` (merged in #328). Investigating its first real findings (11 code-only rows, 3 doc-only "stale" rows) showed the "stale" classification was **wrong**: those 3 rows (`self.heuristics.pytest`, `self.parse_warn.pytest`, `self.pytest.unit`) were never removed from code -- they're emitted directly from inline PowerShell in `.github/workflows/batch-check.yml`, a file the scanner never read (it only scanned `tests/*.ps1` and `run_setup.bat`).

- Extended `tools/check_ndjson_registry.py`'s `code_paths` to also scan `.github/workflows/*.yml`/`*.yaml`, which fixed the false "stale" classification and surfaced 3 more genuinely undocumented rows the old scope had made invisible entirely (`meta.env.mode`, `self.cache.bootstrap.failed`, and `workflow.lint` from the separate dormant `workflow-lint.yml`) -- bringing the real gap count to 14, not 11.
- Found and added a 4th PowerShell/JSON emission convention while scanning workflow YAML: a raw JSON-string literal (`'{"id":"...",...}'`), used by the "Catch cache lane bootstrap failure" step instead of the `id = '...'` hashtable-literal form the other three conventions use.
- All 14 rows are now registered in `docs/agent-ndjson.md`. A clean re-run shows 0 code-only findings and exactly the 16 genuinely-out-of-scope `dynamic_tests.py` rows as the only doc-only findings.
- Two new unit tests cover the JSON-literal pattern and workflow-YAML scanning.

Separately, while auditing the repo for other instances of the exact artifact-collision bug the registry-check job itself had (fixed in #328), found a second, pre-existing instance: `selftest-gate`'s "Download lane verdicts" step had the identical `merge-multiple: true` + identical-local-filename (`lane_verdict.json`) collision, silently limiting its `has_failures` aggregation to whichever single lane's verdict survived instead of ORing all 8 matrix lanes.

- Lower severity than it sounds: `has_failures` only gates `model-quick-fix`'s auto-fix trigger, not PR merge gating (the `real`/`conda-full` matrix jobs gate merges via their own independent check conclusions) -- but it could silently skip auto-fix attempts when a non-surviving lane had real failures.
- Fixed with the same one-line removal of `merge-multiple`.
- Audited the workflow's other `merge-multiple: true` usage (`iterate-logs-*` download): single-named-artifact download, no collision possible, confirmed safe and left as-is.
- Added a general lessons-learned entry (`docs/agent-lessons-learned.md`) documenting the hazard class and an audit method for future `download-artifact@v6` additions.

CLAUDE.md's Active Backlog "Backfill" item is resolved by this PR and moved to Closed Backlog with the corrected story.

## Test plan

- [x] `python -m compileall -q .` -- clean
- [x] `python -m pyflakes .` -- clean
- [x] `python tools/check_delimiters.py run_setup.bat` -- no issues (file untouched)
- [x] `python -m yamllint .github/workflows/` -- clean
- [x] `actionlint -oneline .github/workflows/*.yml` -- clean
- [x] `python -m pytest tests/test_*.py -q` -- 198 passed, 2 skipped (no regressions; +1 new test vs. prior PR)
- [x] ASCII-only sweep of touched files -- clean
- [x] Local run of `tools/check_ndjson_registry.py` before push: 0 code-only findings, 16 doc-only (all confirmed `dynamic_tests.py` exclusions)
- [x] CI run 28903123522 (commit 3120387): all 8 matrix lanes + `selftest-gate` + `model-quick-fix` + `publish_diag` green
- [x] `ndjson-registry-check`'s job log in that same CI run confirms the corrected counts in the real CI environment: "Registered in docs but no matching code emission site found (16)" and no "Emitted in code but not registered" section at all (0 findings) -- proves the workflow-YAML scanning fix works end-to-end, not just locally
- [x] Same job's log-dir cross-check still shows "Observed IDs in downloaded NDJSON artifacts: 124" (consistent with the artifact-collision fix from #328), confirming that fix remains intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015xbWLPbiaKVsobB9FZy8kS)_