### PR TITLE
Doc cleanup pass + NI-VISA PowerShell consistency fix + diagnostics visibility for ndjson-registry-check

### DIFF
--- a/.github/workflows/batch-check.yml
+++ b/.github/workflows/batch-check.yml
@@ -2863,7 +2863,25 @@ jobs:
 
       - name: Run NDJSON registry cross-check
         shell: bash
-        run: python3 tools/check_ndjson_registry.py --repo-root . --log-dir "${{ runner.temp }}/ndjson-logs"
+        run: |
+          set -o pipefail
+          python3 tools/check_ndjson_registry.py --repo-root . --log-dir "${{ runner.temp }}/ndjson-logs" \
+            | tee ~ndjson-registry-report.txt
+
+      - name: Upload NDJSON registry report
+        # derived requirement: makes this advisory job's findings visible on the diagnostics
+        # site with zero new download-artifact wiring -- name it to match the ci_test_results-*
+        # wildcard pattern already used by publish_diag's "Download CI NDJSON artifacts" step, so
+        # it lands in _artifacts/batch-check/_ci_artifacts/ alongside the per-lane NDJSON files
+        # without a dedicated download step. See tools/diag/publish_index.py's
+        # _collect_batch_ndjson_links() for the Quick Links entry that surfaces it by name.
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: ci_test_results-ndjson-registry-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ~ndjson-registry-report.txt
+          if-no-files-found: warn
+          retention-days: 7
 
   model-quick-fix:
     name: Model quick-fix (inline)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,25 +99,39 @@ git push -u origin <branch-name>
 
 ## Mandatory Sanity Checks
 
-Run these before every commit. README.md changes do not affect them but run as a baseline.
+Run this full sweep before every commit. README.md-only changes do not affect most of these
+checks but still run the sweep as a baseline (it also catches an accidental non-doc diff).
 
 ```bash
-# Python syntax and name errors
-python -m compileall -q .
-python -m pyflakes .
+python -m compileall -q . && echo "COMPILEALL OK"
+python -m pyflakes . 2>&1 | head -20
+python tools/check_delimiters.py run_setup.bat && echo "DELIM OK"
+python -m yamllint .github/workflows/ && echo "YAMLLINT OK"
+export PATH="$PATH:/root/go/bin"
+actionlint -oneline .github/workflows/*.yml && echo "ACTIONLINT OK"
 
-# Delimiter balance in the main bootstrapper
-python tools/check_delimiters.py run_setup.bat
+for f in run_setup.bat tests/harness.ps1 docs/agent-interconnect.md docs/agent-lessons-learned.md CLAUDE.md; do
+  out=$(grep -nP '[^\x00-\x7F]' "$f")
+  if [ -n "$out" ]; then echo "=== $f ==="; echo "$out"; fi
+done
+echo "ASCII SWEEP DONE"
+git diff --stat origin/main
 
-# YAML lint (if workflow files changed)
-python -m yamllint .github/workflows/
+pwsh -c "
+\$ErrorActionPreference = 'Stop'
+\$fail = 0
+Get-ChildItem /home/user/Python_vs_Windows/tests/*.ps1, /home/user/Python_vs_Windows/tools/*.ps1 | ForEach-Object {
+  try { [System.Management.Automation.Language.Parser]::ParseFile(\$_.FullName, [ref]\$null, [ref]\$null) | Out-Null }
+  catch { Write-Host \"PARSE FAIL: \$(\$_.FullName): \$_\"; \$fail = 1 }
+}
+if (\$fail -eq 0) { Write-Host 'PS PARSE SWEEP DONE - ALL CLEAN' }
+"
+python -m pytest /home/user/Python_vs_Windows/tests/test_*.py -q 2>&1 | tail -5
 ```
 
-For modified PowerShell files, see **AGENTS.md** for the AST-based syntax validation method
-(`pwsh -c "[System.Management.Automation.Language.Parser]::ParseFile(...)"`) since PSGallery
-is blocked by proxy on CI runners.
-
-For actionlint (workflow files), see **AGENTS.md** for the download/install method.
+The ASCII sweep's file list is illustrative, not exhaustive -- extend it to cover whatever
+files the current change actually touches. `actionlint`/`pwsh` install methods (if not already
+present in the environment) are documented in **AGENTS.md**.
 
 ---
 
@@ -188,62 +202,6 @@ This is the deliverable. Treat changes carefully.
    {"state":"ok|no_python_files|error","exitCode":0,"pyFiles":0}
    ```
    CI harnesses and `tests/selftest.ps1` read this. See README.md for full contract.
-
----
-
-## Edit Detection Sprint (Loops 1-3) -- SHIPPED
-
-All three loops are complete and live in `run_setup.bat`.
-
-### Loop 1 -- PyInstaller build artifact cleanup
-
-After a successful PyInstaller build, `run_setup.bat` now:
-- Deletes the `build\%ENVNAME%\` directory.
-- Deletes `%ENVNAME%.spec` **unless** a spec file pre-existed (guarded by
-  `HP_SPEC_PREEXIST` set before PyInstaller runs).
-- Logs: `[INFO] PyInstaller build artifacts cleaned up.`
-
-### Loop 2 -- Dependency skip (HP_DEP_CHECK / ~dep_check.py)
-
-After `pipreqs` generates `requirements.auto.txt`, `run_setup.bat` compares the
-output against `~environment.lock.txt` (written on first successful conda install).
-If every package listed by pipreqs is already present in the lock file, conda install
-is skipped entirely.
-- Log line: `Dep-check: all pipreqs packages satisfied in lock; skipping conda install.`
-- The lock file is written via `conda list --export` gated on errorlevel=0 AND
-  non-empty output.
-- Skip is conservative: if package name normalization is uncertain, falls through to
-  `conda install`.
-
-### Loop 3 -- Env-state fast path (HP_ENV_STATE / ~env_state.py)
-
-After a successful bootstrap, `run_setup.bat` writes `~env.state.json`:
-```json
-{
-  "schema": 1,
-  "env_name": "...",
-  "env_path": "...",
-  "python_version": "...",
-  "req_hash": "...",
-  "runtime_hash": "...",
-  "lock_hash": "..."
-}
-```
-On the next run, if state is valid and `python.exe` is present in the env, `conda create`
-is skipped entirely.
-- Log line: `Env-state fast path: reusing conda env <ENVNAME>.`
-- Schema field = 1. If schema is unknown or missing, treated as stale (not error).
-- State file is not backwards compatible before it was introduced -- first run after
-  upgrade does a full rebuild (expected behavior).
-
-### Runtime artifacts written by the bootstrapper
-
-| File | When written |
-|------|-------------|
-| `~bootstrap.status.json` | Every run (state, exitCode, pyFiles) |
-| `~setup.log` | Every run (probe errors, bootstrap path) |
-| `~environment.lock.txt` | conda mode: after conda list --export; uv mode: copy of ~dependency_installed.txt |
-| `~env.state.json` | After successful full bootstrap |
 
 ---
 
@@ -322,6 +280,9 @@ Test files and what they cover:
 | `test_parse_warn.py` | PyInstaller warn-file translation table (REQ-007: 5.x and 6.x formats, all TRANSLATIONS entries) |
 | `test_publish_index_regex.py` | Regex patterns in diagnostics publisher |
 | `test_sanitize_iterate_payload.py` | NDJSON redaction and deduplication |
+| `test_collect_submodules.py` | `--collect-submodules` double-gate (used AND installed), adversarial import-scan cases, AST-failure regex fallback, HP_COLLECT_SUBMODULES payload sync |
+| `test_hidden_import_scan.py` | `--hidden-import` auto-recovery strictness (ModuleNotFoundError + installed only), typo/ImportError/circular-import non-triggers, tried-list loop guard, HP_HIDDEN_IMPORT_SCAN payload sync |
+| `test_check_ndjson_registry.py` | NDJSON registry cross-check: brace expansion, all four code emission patterns, log-file parsing, pass/fail end-to-end paths |
 
 ### Static harness (Windows-only, requires PowerShell)
 ```batch
@@ -504,38 +465,6 @@ a fact confirmed with no action needed, or a recurring/periodic check belongs in
 "Known Findings", `docs/agent-lessons-learned.md`, or "Periodic Maintenance Checks" below instead
 (see those sections' own scope notes).
 
-- **pipreqs dead-or-not / internalization decision (2026-07)**: pipreqs (bndr/pipreqs) is
-  stagnant (maintenance-only, looking for maintainers) but not at risk of disappearing from
-  PyPI outright -- PyPI does not delete established packages. The real risk the community
-  cites is future-Python bitrot (an AST parser silently failing on new syntax), which this repo
-  has already pre-empted twice over: the 0.4.13 pin (see "pipreqs pin rationale" above) avoids
-  0.5.0's `<3.13` Requires-Python ceiling, and the warnfix build-time safety net (see
-  "Dependency Discovery Fallback: warnfix" above) means the bootstrap **never hard-fails** even
-  if pipreqs is 100% unavailable -- confirmed by the new `self.stub.pipreqs_version_fail` test
-  (Closed Backlog, this pass) which forces pipreqs's own install to fail via
-  `HP_PIPREQS_VERSION=99.99.99` (already an env-overridable variable, no code change needed to
-  trigger this; a nonexistent version number was chosen over pipreqs 0.5.0's real `<3.13` cap
-  after CI showed the cap alone does not reliably fail across every lane's ambient Python) and
-  proves the bootstrap still reaches a working, fully-run EXE via warnfix
-  alone. Decision: **defer full internalization** (embedding a native AST-based scanner +
-  mapping table to replace pipreqs entirely). It is technically feasible and roughly the size a
-  3rd-party estimate suggested (a few hundred lines + a small mapping table), but it duplicates
-  a safety net that already works and is tested, and is its own nontrivial project (matching
-  pipreqs's accumulated edge-case handling: encoding fallback, syntax-error tolerance, stdlib
-  filtering). When it is eventually undertaken: write a **clean-room** scanner rather than
-  copying pipreqs's actual source or mapping file (pipreqs is MIT-licensed; copying it verbatim
-  would require carrying its copyright notice -- a clean-room reimplementation sidesteps this
-  entirely, though crediting pipreqs by name/link as prior art in a code comment is a fair
-  courtesy). Seed the mapping table by extending this repo's own already-license-clear
-  `tools/parse_warn.py` `TRANSLATIONS` dict rather than importing external mapping databases
-  (showmereqs/FawltyDeps/marimo/Grayskull all carry their own licenses needing separate audit,
-  and none of those tables have been vetted against this repo's actual needs). Use
-  `sys.stdlib_module_names` with a `try/except ImportError` guard per the existing
-  "Embedded-helper Python baseline" convention (it's a 3.10+ feature; must degrade gracefully
-  on an older ambient interpreter on the venv/system fallback tiers). Do not chase alternative
-  tools as a wholesale replacement: `pigar` was correctly ruled out elsewhere (its wheel bundles
-  an ~40 MB SQLite package database, a non-starter for a single-file bootstrapper).
-
 - **Provider symmetry: no standalone Python-download tier**: confirmed gap in the REQ-009
   provider cascade (uv -> conda -> venv -> system). uv and conda both self-acquire a full Python
   interpreter (uv's managed CPython, conda's bundled Miniconda Python); venv and system
@@ -548,6 +477,34 @@ a fact confirmed with no action needed, or a recurring/periodic check belongs in
   `get-pip.py` if needed to feed warnfix. This is a substantial feature (new tier, checksum
   verification, new fallback-ladder wiring, new tests) -- backlog for a dedicated future round,
   not attempted piecemeal.
+
+- **No concurrent-instance protection (double-click race, 2026-07 iteration-pass finding)**:
+  confirmed via code search -- no mutex/lockfile mechanism exists anywhere in `run_setup.bat`.
+  A beginner double-clicking the `.bat` twice in quick succession (a plausible real action --
+  no console window may be visibly open yet during the earliest startup checks, so a second
+  click can look like "nothing happened") launches two concurrent bootstrap processes that race
+  on the same `conda create -n <name>` / same `~setup.log` writes / same `dist\<name>.exe`
+  PyInstaller build target, risking a confusing corrupted state (partial env, truncated log,
+  half-written EXE) that a beginner has no obvious way to diagnose or recover from beyond
+  deleting generated folders and retrying. A future fix needs a lightweight lock (e.g. a tilde-
+  prefixed lockfile with the owning PID, checked and staled-out if the owning process no longer
+  exists) plus a friendly message for the second instance ("setup is already running in this
+  folder; please wait") rather than letting it silently race. Backlog for a dedicated round --
+  batch has no native mutex primitive, so this needs careful design (stale-lock detection after
+  a crash, cross-process visibility) and its own test coverage, not a piecemeal addition.
+
+- **No proactive disk-space check (2026-07 iteration-pass finding)**: confirmed via code search
+  -- the only disk-space-related output is the post-flight "SAFE TO DELETE to reclaim disk
+  space" hint; there is no pre-flight free-space check before Miniconda download/install or
+  conda env creation (which together can require several hundred MB to a few GB depending on
+  packages). A beginner on a low-spec/older machine who runs out of space mid-bootstrap sees
+  whatever low-level error curl/conda/pip happens to surface for "no space left on device"
+  rather than a clear, early, plain-language message. Lower urgency than the concurrent-instance
+  finding above -- existing `[ERROR]`/`[WARN]` logging conventions mean the user isn't left with
+  zero explanation, just a less specifically-tailored one -- but worth a future round: a cheap
+  `fsutil volume diskfree` (or PowerShell `Get-PSDrive`) check before the first large download,
+  with a generous threshold and a friendly early abort/warning rather than a failure deep inside
+  a conda solver or pip install.
 
 ## Periodic Maintenance Checks (recurring, quarterly)
 
@@ -657,6 +614,40 @@ rather than relying on manual memory.
     real user run (normal internet, interactive/admin session) to confirm the same valid installer succeeds
     off-CI (expected ~30-45 min per the maintainer's prior experience). Until then, treat the
     "environmental" classification as strongly-supported-but-provisional.
+
+- **pipreqs dead-or-not / internalization decision (2026-07, moved here from Active Backlog
+  during a 2026-07 documentation thinning pass -- this is a decision already made with no
+  action pending, not open future work).** pipreqs (bndr/pipreqs) is stagnant
+  (maintenance-only, looking for maintainers) but not at risk of disappearing from PyPI
+  outright -- PyPI does not delete established packages. The real risk the community cites is
+  future-Python bitrot (an AST parser silently failing on new syntax), which this repo has
+  already pre-empted twice over: the 0.4.13 pin (see "pipreqs pin rationale" above) avoids
+  0.5.0's `<3.13` Requires-Python ceiling, and the warnfix build-time safety net (see
+  "Dependency Discovery Fallback: warnfix" above) means the bootstrap **never hard-fails** even
+  if pipreqs is 100% unavailable -- confirmed by `self.stub.pipreqs_version_fail` (Closed
+  Backlog), which forces pipreqs's own install to fail via `HP_PIPREQS_VERSION=99.99.99`
+  (already an env-overridable variable, no code change needed to trigger this; a nonexistent
+  version number was chosen over pipreqs 0.5.0's real `<3.13` cap after CI showed the cap alone
+  does not reliably fail across every lane's ambient Python) and proves the bootstrap still
+  reaches a working, fully-run EXE via warnfix alone. Decision: **defer full internalization**
+  (embedding a native AST-based scanner + mapping table to replace pipreqs entirely). It is
+  technically feasible and roughly the size a 3rd-party estimate suggested (a few hundred lines
+  + a small mapping table), but it duplicates a safety net that already works and is tested,
+  and is its own nontrivial project (matching pipreqs's accumulated edge-case handling:
+  encoding fallback, syntax-error tolerance, stdlib filtering). When it is eventually
+  undertaken: write a **clean-room** scanner rather than copying pipreqs's actual source or
+  mapping file (pipreqs is MIT-licensed; copying it verbatim would require carrying its
+  copyright notice -- a clean-room reimplementation sidesteps this entirely, though crediting
+  pipreqs by name/link as prior art in a code comment is a fair courtesy). Seed the mapping
+  table by extending this repo's own already-license-clear `tools/parse_warn.py`
+  `TRANSLATIONS` dict rather than importing external mapping databases (showmereqs/
+  FawltyDeps/marimo/Grayskull all carry their own licenses needing separate audit, and none of
+  those tables have been vetted against this repo's actual needs). Use
+  `sys.stdlib_module_names` with a `try/except ImportError` guard per the existing
+  "Embedded-helper Python baseline" convention (it's a 3.10+ feature; must degrade gracefully
+  on an older ambient interpreter on the venv/system fallback tiers). Do not chase alternative
+  tools as a wholesale replacement: `pigar` was correctly ruled out elsewhere (its wheel
+  bundles an ~40 MB SQLite package database, a non-starter for a single-file bootstrapper).
 
 ## Closed Backlog
 
@@ -990,3 +981,14 @@ Items completed and shipped:
   lower-bound version from all forms (python=X.Y, python==X.Y, python>=X.Y, python>X.Y).
   Log line: `[INFO] uv: creating venv at .uv_env with Python X.Y`. Covered by new NDJSON
   row `self.contract.uv.pyver` (contract-uv lane). CLOSED by this PR.
+- **Edit Detection Sprint (Loops 1-3)**: the earliest fast-path work in this repo's history,
+  predating most of the conventions documented above. Loop 1 (PyInstaller build artifact
+  cleanup): after a successful build, deletes `build\%ENVNAME%\` and `%ENVNAME%.spec` unless
+  a spec file pre-existed (`HP_SPEC_PREEXIST`), logging `[INFO] PyInstaller build artifacts
+  cleaned up.` Loop 2 (`HP_DEP_CHECK`/`~dep_check.py`) and Loop 3 (`HP_ENV_STATE`/
+  `~env_state.py`) are the dep-check skip and env-state fast paths already summarized under
+  "run_setup.bat Rules" above; their runtime-artifact schedule (`~bootstrap.status.json`,
+  `~setup.log`, `~environment.lock.txt`, `~env.state.json`) and the `~env.state.json` schema
+  both live in AGENTS.md's "Runtime artifact paths" section -- not duplicated here. All three
+  loops are complete and live in `run_setup.bat`. CLOSED (this entry condensed from a
+  standalone top-level section during a 2026-07 documentation thinning pass).

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ trend toward this altitude -- keep the requirement crisp and let mechanism detai
   0) Manual override (`%1` argument, e.g. drag-and-drop) -- if the file is co-located with the bootstrapper (REQ-011), it is used directly and skips all auto-detection.
   1) Common names in order: `main.py` > `app.py` > `run.py` > `cli.py`
   2) Otherwise, the sole file containing a **substantive** `if __name__ == "__main__":` guard (a guard whose body is only `pass`, comments, a docstring, or `...` does not count, so a real sibling entry wins).
-  - If no single clear entry remains after those checks (multiple files, no clear winner), the bootstrapper reverts to the spirit of its original behavior:
+  - If no single clear entry remains after those checks (multiple files, no clear winner), the bootstrapper falls through to a deterministic resolution:
     - **Interactive picker (timed)** -- when a human is present (interactive console; not CI/`NOINPUT`/`HP_NONINTERACTIVE`), it prints an alphabetical numbered menu (up to 9 files) and waits ~30s. Typing a valid number selects that file; **timeout (or no console) -> the alphabetical default**. The menu also explains how to avoid the prompt next time (drag-and-drop a file onto the batch, rename to `main.py`/`app.py`/`run.py`/`cli.py`, or add a single `__main__` guard).
     - **Alphabetical fallback (deterministic)** -- the non-interactive / default path: the alphabetically-first candidate (preferring files that declared a `__main__` guard, otherwise any `.py` file). This is the guaranteed terminal pick, so something always runs and packages instead of the entry resolving to empty. `find_entry` logs `[BOOT] REQ-002: No clear entry found; selecting <file> (alphabetical fallback).` and exits with a distinct ambiguous code that triggers the picker.
 
@@ -265,6 +265,18 @@ The install strategy varies by the active REQ-009 provider. The steps below appl
   attempts to identify and install the missing packages using whatever signal is available. It cannot map all module
   names to conda package names (for example, `PIL` maps to `pillow`, `cv2` maps to `opencv`). This is a known
   limitation, not a bug.
+
+### Dependency strategy
+
+Summary of the design above, for readers linking directly to this anchor: **pipreqs is discovery
+only** (static import scanning, never trusted for completeness or exact versions), **`requirements.txt`
+is a hint, not authority** (getting the code to run takes priority over preserving the original
+author's exact pin set), and **conda-forge is truth** (the resolved conda environment is the
+source of record once installed, per REQ-006's channel policy). The known module-name-to-package-name
+mapping limitation (`PIL` -> `pillow`, `cv2` -> `opencv`) above is the main practical consequence:
+static analysis and the warnfix repair loop cannot always guess the correct package name from an
+`import` statement, so an unusual mapping can occasionally require a `requirements.txt` hint from
+the user to resolve cleanly on the first try.
 
 ---
 
@@ -518,7 +530,6 @@ set lives in `run_setup.bat`.
 - Update conda base periodically (~30 days), but **skip on first Miniconda install**. Ensure base is configured to conda-forge before updating to avoid prompts.
 - Single rolling log `~setup.log` capped near **10 MB** total, don't spin out extra log files. Trim at start. Use debug-level detail when `VERBOSE=1`.
 - Tilde-prefix any files not meant to persist (or may remain after a crash) so they are easy to ignore in VCS.
-- Batch robustness for some approaches:
 - Avoid `EnableDelayedExpansion`. If unavoidable, enable only around the exact lines, then disable. Force disable at script start.
 - Be robust against parent shells started with `CMD /V:ON` and 3rd-party wrappers.
 - Treat special characters (`&`, `~`, etc.) carefully in batch.
@@ -531,7 +542,7 @@ set lives in `run_setup.bat`.
 
 ## Agent Guardrails (Codex / Copilot / other agents)
 
-- Enforce and obey this readme document and see See **[AGENTS.md](./AGENTS.md)**.
+- Enforce and obey this README; see **[AGENTS.md](./AGENTS.md)** for the full agent policy.
   
 ---
 

--- a/run_setup.bat
+++ b/run_setup.bat
@@ -1364,7 +1364,7 @@ if errorlevel 1 (
   rem derived requirement: curl can leave a partial file on failure; delete before fallback
   rem so PowerShell does not find a corrupt file and skip its own download attempt.
   if exist "%NIVISA_INSTALLER%" del "%NIVISA_INSTALLER%" >nul 2>&1
-  powershell -Command "try { [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; Invoke-WebRequest -Uri 'https://download.ni.com/support/nipkg/products/ni-v/ni-visa/24.0/runtime/ni-visa-runtime_24.0.0_windows.exe' -OutFile '%NIVISA_INSTALLER%' -UseBasicParsing -ErrorAction Stop } catch { exit 1 }" 2>> "%LOG%"
+  powershell -NoProfile -ExecutionPolicy Bypass -Command "try { [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; Invoke-WebRequest -Uri 'https://download.ni.com/support/nipkg/products/ni-v/ni-visa/24.0/runtime/ni-visa-runtime_24.0.0_windows.exe' -OutFile '%NIVISA_INSTALLER%' -UseBasicParsing -ErrorAction Stop } catch { exit 1 }" 2>> "%LOG%"
 )
 if not exist "%NIVISA_INSTALLER%" (
   call :log "[VISA] install_failed (download)"
@@ -1377,7 +1377,7 @@ call :log "[VISA] download method: %HP_VISA_DLVIA%"
 set "HP_VISA_DLSIZE=0"
 for %%S in ("%NIVISA_INSTALLER%") do set "HP_VISA_DLSIZE=%%~zS"
 call :log "[VISA] installer file size: %HP_VISA_DLSIZE% bytes"
-powershell -NoProfile -Command "try { $fs=[System.IO.File]::OpenRead('%NIVISA_INSTALLER%'); $a=$fs.ReadByte(); $b=$fs.ReadByte(); $fs.Close(); if ($a -eq 77 -and $b -eq 90) { 'PE_OK' } else { 'NOT_PE' } } catch { 'PROBE_ERR' }" > "~visa_pe.txt" 2>nul
+powershell -NoProfile -ExecutionPolicy Bypass -Command "try { $fs=[System.IO.File]::OpenRead('%NIVISA_INSTALLER%'); $a=$fs.ReadByte(); $b=$fs.ReadByte(); $fs.Close(); if ($a -eq 77 -and $b -eq 90) { 'PE_OK' } else { 'NOT_PE' } } catch { 'PROBE_ERR' }" > "~visa_pe.txt" 2>nul
 set "HP_VISA_PE="
 if exist "~visa_pe.txt" for /f "usebackq delims=" %%P in ("~visa_pe.txt") do set "HP_VISA_PE=%%P"
 if exist "~visa_pe.txt" del "~visa_pe.txt" >nul 2>&1

--- a/tests/test_publish_index_regex.py
+++ b/tests/test_publish_index_regex.py
@@ -12,6 +12,7 @@ from tools.diag.publish_index import (
     _build_markdown,
     _build_site_overview,
     _batch_status,
+    _collect_ndjson_registry_report_link,
     _ensure_diag_log_placeholders,
     _ensure_iterate_log_archive,
     _ensure_repo_index,
@@ -976,6 +977,35 @@ class ExtractUvSignalsTest(unittest.TestCase):
             self.assertEqual(sig["uv_used"], "1")
             self.assertEqual(sig["uv_fallback_reason"], "none")
             self.assertEqual(sig["lock_present"], "yes")
+
+
+class NdjsonRegistryReportLinkTest(unittest.TestCase):
+    def test_returns_none_when_diag_missing(self) -> None:
+        self.assertIsNone(_collect_ndjson_registry_report_link(None))
+
+    def test_returns_none_when_artifact_not_downloaded(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            diag = Path(tmp) / "diag"
+            diag.mkdir(parents=True)
+            self.assertIsNone(_collect_ndjson_registry_report_link(diag))
+
+    def test_finds_report_by_wildcard_run_attempt(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            diag = Path(tmp) / "diag"
+            report_dir = (
+                diag / "_artifacts" / "batch-check" / "_ci_artifacts"
+                / "ci_test_results-ndjson-registry-1234-1"
+            )
+            report_dir.mkdir(parents=True)
+            (report_dir / "~ndjson-registry-report.txt").write_text(
+                "PASS: no doc/code registry mismatches found.\n", encoding="utf-8"
+            )
+
+            entry = _collect_ndjson_registry_report_link(diag)
+
+            self.assertIsNotNone(entry)
+            self.assertEqual(entry["label"], "NDJSON registry cross-check report (advisory)")
+            self.assertEqual(entry["path"].name, "~ndjson-registry-report.txt")
 
 
 if __name__ == "__main__":

--- a/tools/diag/publish_index.py
+++ b/tools/diag/publish_index.py
@@ -2407,6 +2407,27 @@ def _link_entry(diag: Optional[Path], label: str, path: Path) -> Optional[dict]:
     return {"label": label, "path": path, "mirror": mirror}
 
 
+def _collect_ndjson_registry_report_link(diag: Optional[Path]) -> Optional[dict]:
+    """Surface the advisory ndjson-registry-check job's report, if present.
+
+    The report is uploaded as an artifact named ci_test_results-ndjson-registry-<run>-<attempt>
+    (matching the ci_test_results-* wildcard already downloaded by publish_diag, so no dedicated
+    download step was needed -- see the "Upload NDJSON registry report" step in batch-check.yml).
+    """
+    if not diag:
+        return None
+    ci_artifacts_root = diag / "_artifacts" / "batch-check" / "_ci_artifacts"
+    if not ci_artifacts_root.exists():
+        return None
+    try:
+        candidates = sorted(ci_artifacts_root.glob("ci_test_results-ndjson-registry-*/~ndjson-registry-report.txt"))
+    except OSError:
+        return None
+    if not candidates:
+        return None
+    return _link_entry(diag, "NDJSON registry cross-check report (advisory)", candidates[0])
+
+
 def _collect_batch_ndjson_links(diag: Optional[Path]) -> List[dict]:
     if not diag:
         return []
@@ -3366,6 +3387,7 @@ def _bundle_links(context: Context) -> List[dict]:
         append(entry)
 
     entries.extend(_collect_batch_ndjson_links(diag))
+    append(_collect_ndjson_registry_report_link(diag))
     for entry in _collect_setup_log_links(diag):
         append(entry)
 


### PR DESCRIPTION
## Summary

Two commits from a maintenance/iteration pass:

**`5eb4ee9` -- Doc cleanup + NI-VISA PowerShell consistency fix**
- README.md: removed the out-of-place phrase "the bootstrapper reverts to the spirit of its original behavior" (replaced with a plain description of the deterministic fallthrough), fixed a grammar bug ("Enforce and obey this readme document and see See..."), removed a dangling content-free bullet, and added the missing `### Dependency strategy` heading/section -- this fixes a genuinely broken anchor: README's own Known Limitations section and three separate CLAUDE.md references link to `#dependency-strategy`, but no such heading has ever existed in git history.
- CLAUDE.md: replaced the "Mandatory Sanity Checks" script with an expanded version (adds `pyflakes`, `yamllint`, `actionlint`, an ASCII sweep, `git diff --stat`, and a PowerShell AST parse sweep); removed the standalone "Edit Detection Sprint (Loops 1-3)" section and condensed it into a single Closed Backlog entry; moved the "pipreqs dead-or-not / internalization" entry from Active Backlog to Known Findings (it's a decision already made, not open work); added 3 missing rows to the Testing table (`test_collect_submodules.py`, `test_hidden_import_scan.py`, `test_check_ndjson_registry.py`); added two new Active Backlog findings from this iteration pass (no concurrent-instance/double-click protection; no proactive disk-space check).
- run_setup.bat: two NI-VISA-block PowerShell invocations changed from `powershell -Command "..."` / `powershell -NoProfile -Command "..."` to `powershell -NoProfile -ExecutionPolicy Bypass -Command "..."`, matching the other 34+ invocations in the file. Pure consistency fix, no logic change.

**`ba047a9` -- Surface ndjson-registry-check's report on the diagnostics site**
The `ndjson-registry-check` advisory job (added in #328/#329) printed its report to the job log only, with no visibility on the public diagnostics site. Fixed:
- `ndjson-registry-check` now tees its output to `~ndjson-registry-report.txt` and uploads it as `ci_test_results-ndjson-registry-${run_id}-${attempt}` -- this name matches the `ci_test_results-*` wildcard pattern `publish_diag`'s "Download CI NDJSON artifacts" step already downloads, so it lands in `_artifacts/batch-check/_ci_artifacts/` with zero new download-artifact wiring needed.
- `tools/diag/publish_index.py`: new `_collect_ndjson_registry_report_link()` finds the report by glob (run/attempt vary) and adds a "NDJSON registry cross-check report (advisory)" entry to the existing Quick Links list (covers both the markdown and HTML renderers via the shared `_bundle_links()`).
- 3 new unit tests in `tests/test_publish_index_regex.py` covering the missing-diag, artifact-not-downloaded, and found-by-wildcard cases.

## Test plan

- [x] `python -m compileall -q .`
- [x] `python -m pyflakes .`
- [x] `python tools/check_delimiters.py run_setup.bat`
- [x] `python -m yamllint .github/workflows/`
- [x] `actionlint -oneline .github/workflows/*.yml`
- [x] ASCII sweep across touched files
- [x] PowerShell AST parse sweep (`tests/*.ps1`, `tools/*.ps1`)
- [x] `python -m pytest tests/test_*.py -q` (includes the 3 new `test_publish_index_regex.py` cases)
- [x] CI run [28910623920](https://github.com/mixmansoundude/Python_vs_Windows/actions/runs/28910623920) completed with conclusion `success` (all 8 matrix lanes + gating `real`/`conda-full` lanes green, verified via the Actions API directly, not just the diagnostics site)


---
_Generated by [Claude Code](https://claude.ai/code/session_015xbWLPbiaKVsobB9FZy8kS)_