### PR TITLE
Extend ndjson-registry-check to scan tests/dynamic_tests.py (Python)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -478,34 +478,27 @@ a fact confirmed with no action needed, or a recurring/periodic check belongs in
   verification, new fallback-ladder wiring, new tests) -- backlog for a dedicated future round,
   not attempted piecemeal.
 
-- **`ndjson-registry-check` permanently red on the "doc-registered but no code emission site
-  found" category (approved for implementation, ready when picked up)**: confirmed via direct
-  inspection of `tests/dynamic_tests.py` and `tools/check_ndjson_registry.py`'s own module
-  docstring -- the scanner's `code_paths` cover `tests/*.ps1`, `run_setup.bat`, and
-  `.github/workflows/*.yml` only; Python source was excluded by design from day one. All 16 IDs
-  the scanner flags every single run under "registered in docs but no matching code emission
-  site found" are exactly the rows `dynamic_tests.py` emits via plain Python dict literals
-  (`record({"id": "...", ...})`, written straight to JSON) -- `pr.to_conda`, `pr.pandas.openpyxl`,
-  `pr.pandas.xlsxwriter`, `pr.requests.certifi`, `pr.sqlalchemy.pymysql`, `pr.matplotlib.tk`,
-  `pr.cryptography.cffi`, `pr.pycryptodome.cffi`, `app.visa.detect`, `app.pyserial.detect`,
-  `dp.pep440`, `dp.detect.runtime`, `dp.detect.pyproject`, `entry.select.single`,
-  `entry.select.main_vs_app`, `entry.select.common_vs_generic`. These rows are genuinely emitted
-  and genuinely correct in the doc registry (confirmed live on the diagnostics site) -- the
-  scanner simply cannot see them, so this category is mathematically guaranteed to be non-empty
-  on every run, forever, until the scanner is taught to parse Python too. Unlike a normal
-  advisory finding, this bucket carries zero information for a human glancing at the check (it
-  never converges to green, never changes) -- it is pure, permanent noise layered on top of the
-  scanner's two genuinely-useful categories (undocumented code-only rows, and the log
-  cross-check). Fix: extend `tools/check_ndjson_registry.py` with a fourth code-scanning path for
-  `tests/dynamic_tests.py` (and any future Python test files) that recognizes the
-  `record({"id": "...", ...})` / `record({"id": f"...", ...})` call pattern (a regex over
-  `"id"\s*:\s*"..."` plus f-string prefix handling for the templated `pr.{_pkg}.{_target}` case
-  is likely sufficient, mirroring the existing `CODE_JSONLITERAL_ID_RE` convention already used
-  for the raw-JSON-string-literal PowerShell/YAML case). Once closed, re-evaluate whether the job
-  should gain a stricter non-`continue-on-error` posture, since its only remaining noise source
-  today is exactly this gap. Scope is small and self-contained (one new regex + code_paths entry
-  in one file, no run_setup.bat/tests/*.ps1 changes) -- implement when picked up, no further
-  design discussion needed first.
+- **`ndjson-registry-check`: re-evaluate for a stricter non-`continue-on-error` posture.** Now
+  that the scanner reads `tests/dynamic_tests.py` (see Closed Backlog entry below), a local
+  dry-run against this repo's real state shows a clean `PASS: no doc/code registry mismatches
+  found.` for the first time -- confirm this holds in real CI (not just the local dry-run) across
+  a few runs before flipping `continue-on-error: true` -> gating in `batch-check.yml`. Small,
+  low-risk follow-up once confirmed; deliberately not bundled into the scanner-fix PR itself
+  (CI behavior changes are their own unit, verified separately per this repo's "one thing at a
+  time" convention).
+
+- **Provider symmetry: no standalone Python-download tier**: confirmed gap in the REQ-009
+  provider cascade (uv -> conda -> venv -> system). uv and conda both self-acquire a full Python
+  interpreter (uv's managed CPython, conda's bundled Miniconda Python); venv and system
+  (`:resolve_system_python`) both require an *ambient* interpreter already on the host and have
+  no download path of their own. If uv is unreachable, conda create/install fails, and no
+  ambient `python`/`py` launcher exists, the bootstrap has no remaining way to acquire a Python
+  interpreter and falls through to `:die`. A future tier could target the official
+  python.org embeddable zip (`python-X.Y.Z-embed-amd64.zip`), verified by checksum, extracted to
+  a local/isolated directory, treated like an ambient interpreter, with pip bootstrapped via
+  `get-pip.py` if needed to feed warnfix. This is a substantial feature (new tier, checksum
+  verification, new fallback-ladder wiring, new tests) -- backlog for a dedicated future round,
+  not attempted piecemeal.
 
 ## Periodic Maintenance Checks (recurring, quarterly)
 
@@ -653,6 +646,41 @@ rather than relying on manual memory.
 ## Closed Backlog
 
 Items completed and shipped:
+
+- **`ndjson-registry-check` Python-source scanning (closes the permanent 16-row noise gap)**:
+  `tools/check_ndjson_registry.py` previously only scanned `tests/*.ps1`, `run_setup.bat`, and
+  `.github/workflows/*.yml` -- `tests/dynamic_tests.py` (Python) was out of scope by design, so
+  the 16 rows it emits (`pr.to_conda`, `dp.pep440`, `entry.select.*`, etc.) showed up as
+  "registered in docs but no matching code emission site found" on literally every single run,
+  forever, with zero chance of ever converging to green. Added `scan_dynamic_tests_ids()`: an
+  `ast`-based resolver (not regex -- the id-construction shapes turned out more varied than the
+  original backlog note assumed) that walks `record({"id": ...})` calls and resolves the id
+  value three ways: a plain string literal; an f-string templated from an enclosing `for`
+  loop's literal iterable (`f"pr.{_pkg}.{_target}"`, including `dict.items()` iteration via a
+  locally-tracked dict-literal assignment, e.g. `needed = {...}; for dst, var in
+  needed.items():`); or a *bare* loop variable used directly as the id with no string literal
+  at all (`for rec_id, ... in [("entry.select.single", ...), ...]: record({"id": rec_id, ...})`
+  -- the `entry.select.*` rows use this shape, which a pure regex cannot resolve at all). Also
+  handles the one-hop `rec = {"id": ...}; ...; record(rec)` indirection
+  `ensure_extracted()` uses. Deliberately does not attempt anything more dynamic than that
+  (nested loops, non-literal iterables, function calls) -- see the module docstring and
+  `_for_loop_bindings`'s own docstring for the exact resolution scope.
+  Running the extended scanner against this repo's real state immediately surfaced 7
+  **genuinely new**, previously-invisible undocumented rows the old scope could never have
+  found even in principle: `helpers.run_setup`, `bootstrap.status`, and 5
+  `helpers.decode.~<name>.py` rows (one per embedded helper payload
+  `ensure_extracted()` decodes out of `run_setup.bat`). Backfilled all 7 into
+  `docs/agent-ndjson.md`'s "Dynamic-tests NDJSON" section in the same commit, matching this
+  repo's established backfill-in-the-same-PR convention. Also fixed a latent bug the tilde in
+  `helpers.decode.~detect_python.py` exposed: `DOC_TOKEN_RE` (the doc-side token regex) didn't
+  include `~` in its character class, so it silently mis-split any tilde-containing id into two
+  bogus tokens at the tilde boundary -- fixed by adding `~` to the regex's character class.
+  A local dry-run now shows a clean `PASS: no doc/code registry mismatches found.` for the
+  first time since the job was added -- see the new Active Backlog entry above for the
+  follow-up (confirm this holds in real CI, then consider flipping the job off
+  `continue-on-error`). 3 new unit tests in `tests/test_check_ndjson_registry.py` cover the
+  three id-resolution shapes plus the `.items()`/`rec` indirection and an end-to-end `main()`
+  wiring check. CLOSED by this PR.
 
 - **Proactive disk-space check (REQ-025)**: closes the 2026-07 iteration-pass finding that the
   only disk-space-related output anywhere in `run_setup.bat` was the post-flight "SAFE TO DELETE

--- a/docs/agent-ndjson.md
+++ b/docs/agent-ndjson.md
@@ -131,8 +131,22 @@ pr.requests.certifi, pr.sqlalchemy.pymysql, pr.matplotlib.tk,
 pr.cryptography.cffi, pr.pycryptodome.cffi,
 app.visa.detect, app.pyserial.detect,
 dp.pep440 (x many), dp.detect.runtime, dp.detect.pyproject,
-entry.select.single, entry.select.main_vs_app, entry.select.common_vs_generic
+entry.select.single, entry.select.main_vs_app, entry.select.common_vs_generic,
+helpers.run_setup, bootstrap.status,
+helpers.decode.~detect_python.py, helpers.decode.~prep_requirements.py,
+helpers.decode.~print_pyver.py, helpers.decode.~detect_visa.py,
+helpers.decode.~find_entry.py
 ```
+
+**Backfilled 2026-07 via `tools/check_ndjson_registry.py`'s new AST-based Python scan.** The 7
+`helpers.*`/`bootstrap.status` rows above were always emitted (`ensure_extracted()`'s payload-decode
+loop and `main()`'s status-file read at the top of `tests/dynamic_tests.py`) but were invisible to
+this registry until the scanner learned to parse Python. `helpers.run_setup` fires only on the rare
+`run_setup.bat missing` guard clause (a hard `SystemExit(1)` before any other row); `bootstrap.status`
+fires exactly once per `dynamic_tests.py` run (pass/fail depending on whether `~bootstrap.status.json`
+parses); the 5 `helpers.decode.*` rows fire once per embedded helper payload
+(`~detect_python.py`/`~prep_requirements.py`/`~print_pyver.py`/`~detect_visa.py`/`~find_entry.py`)
+decoded out of `run_setup.bat`.
 
 ## Test-logs NDJSON (harness/selftest, additional rows)
 

--- a/tests/test_check_ndjson_registry.py
+++ b/tests/test_check_ndjson_registry.py
@@ -98,6 +98,84 @@ def test_main_scans_workflow_yaml_for_inline_emissions(tmp_path, capsys):
     assert "PASS: no doc/code registry mismatches found." in captured.out
 
 
+def test_scan_dynamic_tests_ids_resolves_literal_fstring_and_bare_name(tmp_path):
+    # Mirrors the three id-construction shapes actually used in tests/dynamic_tests.py:
+    # a plain literal, an f-string templated from a for-loop's literal tuple list, and a
+    # bare loop variable used directly as the id (no quotes at all).
+    py = tmp_path / "dynamic_tests.py"
+    py.write_text(
+        "def record(rec):\n"
+        "    pass\n\n"
+        "def main():\n"
+        "    record({\"id\": \"plain.literal\", \"pass\": True})\n\n"
+        "    for _pkg, _target in [(\"requests\", \"certifi\"), (\"sqlalchemy\", \"pymysql\")]:\n"
+        "        record({\"id\": f\"pr.{_pkg}.{_target}\", \"pass\": True})\n\n"
+        "    for rec_id, expected, files in [\n"
+        "        (\"entry.select.single\", \"entry1.py\", {\"entry1.py\": \"x\"}),\n"
+        "        (\"entry.select.main_vs_app\", \"main.py\", {\"main.py\": \"x\"}),\n"
+        "    ]:\n"
+        "        record({\"id\": rec_id, \"expected\": expected, \"pass\": True})\n",
+        encoding="utf-8",
+    )
+    ids = check_ndjson_registry.scan_dynamic_tests_ids(py)
+    assert ids == {
+        "plain.literal",
+        "pr.requests.certifi",
+        "pr.sqlalchemy.pymysql",
+        "entry.select.single",
+        "entry.select.main_vs_app",
+    }
+
+
+def test_scan_dynamic_tests_ids_resolves_rec_indirection_via_dict_items(tmp_path):
+    # Mirrors ensure_extracted()'s `needed = {...}; for dst, var in needed.items(): rec = {...};
+    # ...; record(rec)` pattern -- the two-hop indirection (dict-literal assignment, then
+    # record(name) rather than record({...}) directly) plus a .items() iterable resolved via
+    # a locally-tracked dict literal, not a List/Tuple literal.
+    py = tmp_path / "dynamic_tests.py"
+    py.write_text(
+        "def record(rec):\n"
+        "    pass\n\n"
+        "def ensure_extracted():\n"
+        "    needed = {\"~a.py\": \"VAR_A\", \"~b.py\": \"VAR_B\"}\n"
+        "    for dst, var in needed.items():\n"
+        "        rec = {\"id\": f\"helpers.decode.{dst}\", \"var\": var}\n"
+        "        rec.update({\"pass\": True})\n"
+        "        record(rec)\n",
+        encoding="utf-8",
+    )
+    ids = check_ndjson_registry.scan_dynamic_tests_ids(py)
+    assert ids == {"helpers.decode.~a.py", "helpers.decode.~b.py"}
+
+
+def test_main_wires_in_dynamic_tests_py_scan(tmp_path, capsys):
+    # End-to-end: a doc-registered id that only exists as a dynamic_tests.py record({"id": ...})
+    # call (not any PowerShell/batch/YAML pattern) must be found via the AST scan, and a tilde
+    # in the id (as in the real helpers.decode.~detect_python.py row) must round-trip through
+    # both the doc-side token regex and the code-side AST scan without mismatch.
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "agent-ndjson.md").write_text(
+        "```\nhelpers.decode.~a.py\n```\n", encoding="utf-8"
+    )
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "run_setup.bat").write_text("rem no rows here\n", encoding="utf-8")
+    (tmp_path / "tests" / "dynamic_tests.py").write_text(
+        "def record(rec):\n"
+        "    pass\n\n"
+        "def main():\n"
+        "    needed = {\"~a.py\": \"VAR_A\"}\n"
+        "    for dst, var in needed.items():\n"
+        "        record({\"id\": f\"helpers.decode.{dst}\", \"var\": var})\n",
+        encoding="utf-8",
+    )
+
+    result = check_ndjson_registry.main(["--repo-root", str(tmp_path)])
+    captured = capsys.readouterr()
+
+    assert result == 0
+    assert "PASS: no doc/code registry mismatches found." in captured.out
+
+
 def test_main_reports_fail_on_undocumented_code_row(tmp_path, capsys):
     (tmp_path / "docs").mkdir()
     (tmp_path / "docs" / "agent-ndjson.md").write_text("```\n```\n", encoding="utf-8")

--- a/tools/check_ndjson_registry.py
+++ b/tools/check_ndjson_registry.py
@@ -1,18 +1,22 @@
 #!/usr/bin/env python3
 """Cross-checks NDJSON row IDs across three sources: docs/agent-ndjson.md (doc),
-PowerShell Write-NdjsonRow/Write-Result call sites plus run_setup.bat inline
-emissions and .github/workflows/*.yml inline PowerShell emissions (code), and
+code emission sites (PowerShell Write-NdjsonRow/Write-Result call sites plus
+run_setup.bat inline emissions, .github/workflows/*.yml inline PowerShell
+emissions, and tests/dynamic_tests.py's Python record({"id": ...}) calls), and
 observed NDJSON artifacts from a CI run (log, optional).
 
 Advisory tool: reports mismatches, does not attempt to be exhaustive.
-Scope: PowerShell-emitted rows only (tests/*.ps1, run_setup.bat,
-.github/workflows/*.yml inline `run:` blocks -- several rows, e.g.
-self.pytest.unit, self.cache.corrupted, are emitted directly from workflow
-YAML, not from a tests/*.ps1 file). dynamic_tests.py's Python-side rows are
-out of scope -- docs/agent-ndjson.md's own "Dynamic-tests NDJSON" section
-already acknowledges several of those as "(x many)" per-test-case IDs.
+Python scanning (tests/dynamic_tests.py only) uses `ast` to resolve id values
+that are string literals, f-strings templated from an enclosing `for` loop's
+literal iterable (e.g. f"pr.{_pkg}.{_target}"), or a bare loop variable used
+directly as the id (e.g. `for rec_id, ... in [("entry.select.single", ...), ...]:
+record({"id": rec_id, ...})`) -- including the one-hop `rec = {"id": ...}; ...;
+record(rec)` indirection this file also uses. It does not attempt to resolve
+ids built from anything more dynamic than that (nested loops, function calls,
+non-literal iterables) -- see scan_dynamic_tests_ids's and _resolve_id_value's docstrings.
 """
 import argparse
+import ast
 import json
 import re
 import sys
@@ -20,7 +24,7 @@ from pathlib import Path
 
 DOC_FENCE_RE = re.compile(r'```(?:\w*)\n(.*?)\n```', re.DOTALL)
 BRACE_RE = re.compile(r'([A-Za-z0-9_.\-]*)\{([^{}]+)\}')
-DOC_TOKEN_RE = re.compile(r'([A-Za-z0-9][A-Za-z0-9_.\-]*\.[A-Za-z0-9_.\-]*)(?:\s*\(([^()]*)\))?')
+DOC_TOKEN_RE = re.compile(r'([A-Za-z0-9][A-Za-z0-9_.~\-]*\.[A-Za-z0-9_.~\-]*)(?:\s*\(([^()]*)\))?')
 CODE_HASHTABLE_ID_RE = re.compile(r"""\bid\s*=\s*['"]([A-Za-z0-9][A-Za-z0-9_.\-]*)['"]""")
 CODE_WRITERESULT_ID_RE = re.compile(r"""Write-Result\s+['"]([A-Za-z0-9][A-Za-z0-9_.\-]*)['"]""")
 CODE_NAMEDPARAM_ID_RE = re.compile(r"""-Id\s+['"]([A-Za-z0-9][A-Za-z0-9_.\-]*)['"]""")
@@ -74,6 +78,163 @@ def scan_code_ids(paths):
     return ids
 
 
+def _literal(node):
+    """Return the literal value of a simple ast.Constant, else None."""
+    return node.value if isinstance(node, ast.Constant) else None
+
+
+def _for_loop_bindings(for_node, local_dicts):
+    """For `for TARGET in ITER:`, return a list of {name: literal_value} dicts, one per
+    iteration, if ITER is a literal List/Tuple, or a `.items()` call on a name already
+    resolved (via local_dicts) to a literal dict assigned earlier in the same scope (e.g.
+    `needed = {...}; for dst, var in needed.items():`). Returns None if ITER isn't
+    resolvable this way at all (e.g. a function call, an unresolved name) -- callers must
+    treat None as "can't resolve, skip". A tuple-unpacking target may mix literal and
+    non-literal positions (e.g. `for rec_id, expected, files in [(str, str, {...}), ...]`)
+    -- non-literal positions (like a dict literal) are simply omitted from each binding
+    rather than failing the whole loop, since a caller only needs the specific name(s) it
+    actually references as an id value.
+    """
+    iter_node = for_node.iter
+    if isinstance(iter_node, (ast.List, ast.Tuple)):
+        elts = iter_node.elts
+    elif (isinstance(iter_node, ast.Call) and isinstance(iter_node.func, ast.Attribute)
+            and iter_node.func.attr == 'items' and isinstance(iter_node.func.value, ast.Name)
+            and iter_node.func.value.id in local_dicts
+            and isinstance(local_dicts[iter_node.func.value.id], ast.Dict)):
+        dict_node = local_dicts[iter_node.func.value.id]
+        elts = [ast.Tuple(elts=[k, v]) for k, v in zip(dict_node.keys, dict_node.values)]
+    else:
+        return None
+    target = for_node.target
+    if isinstance(target, ast.Name):
+        names = [target.id]
+    elif isinstance(target, ast.Tuple):
+        names = [t.id if isinstance(t, ast.Name) else None for t in target.elts]
+    else:
+        return None
+
+    bindings = []
+    for elt in elts:
+        binding = {}
+        if len(names) == 1:
+            val = _literal(elt)
+            if val is not None:
+                binding[names[0]] = val
+        else:
+            if not isinstance(elt, ast.Tuple) or len(elt.elts) < len(names):
+                return None
+            for name, sub in zip(names, elt.elts):
+                if name is None:
+                    continue
+                val = _literal(sub)
+                if val is not None:
+                    binding[name] = val
+        bindings.append(binding)
+    return bindings
+
+
+def _resolve_id_value(value_node, loop_stack):
+    """Resolve an "id" dict-value AST node to a list of concrete id strings, using the
+    innermost enclosing for-loop's per-iteration bindings (loop_stack[-1]) when the value
+    is a bare loop variable or an f-string templated from loop variables. Returns [] if
+    unresolvable (e.g. templated from something other than the innermost loop, or from a
+    non-literal source) -- unresolvable ids are silently skipped, matching this tool's
+    "advisory, not exhaustive" posture rather than raising.
+    """
+    lit = _literal(value_node)
+    if lit is not None:
+        return [str(lit)]
+
+    if isinstance(value_node, ast.Name):
+        if not loop_stack:
+            return []
+        return [str(b[value_node.id]) for b in loop_stack[-1] if value_node.id in b]
+
+    if isinstance(value_node, ast.JoinedStr):
+        if not loop_stack:
+            return []
+        bindings = loop_stack[-1]
+        out = []
+        for binding in bindings:
+            parts = []
+            ok = True
+            for piece in value_node.values:
+                if isinstance(piece, ast.Constant):
+                    parts.append(str(piece.value))
+                elif isinstance(piece, ast.FormattedValue) and isinstance(piece.value, ast.Name):
+                    name = piece.value.id
+                    if name not in binding:
+                        ok = False
+                        break
+                    parts.append(str(binding[name]))
+                else:
+                    ok = False
+                    break
+            if ok:
+                out.append(''.join(parts))
+        return out
+
+    return []
+
+
+def _dict_id_values(dict_node, loop_stack):
+    if not isinstance(dict_node, ast.Dict):
+        return []
+    for key, value in zip(dict_node.keys, dict_node.values):
+        if isinstance(key, ast.Constant) and key.value == 'id':
+            return _resolve_id_value(value, loop_stack)
+    return []
+
+
+def scan_dynamic_tests_ids(path: Path):
+    """AST-walk tests/dynamic_tests.py for record({"id": ...}) calls (direct dict literal,
+    or a `rec = {...}` assignment later passed as `record(rec)`), resolving ids per
+    _resolve_id_value's rules. See this module's docstring for the resolution scope/limits.
+    """
+    ids = set()
+    try:
+        tree = ast.parse(path.read_text(encoding='utf-8', errors='replace'))
+    except (OSError, SyntaxError):
+        return ids
+
+    def walk_body(stmts, loop_stack, local_dicts):
+        for stmt in stmts:
+            if isinstance(stmt, ast.Assign) and isinstance(stmt.value, ast.Dict):
+                for t in stmt.targets:
+                    if isinstance(t, ast.Name):
+                        local_dicts[t.id] = stmt.value
+            elif isinstance(stmt, ast.Expr) and isinstance(stmt.value, ast.Call):
+                call = stmt.value
+                if isinstance(call.func, ast.Name) and call.func.id == 'record' and call.args:
+                    arg = call.args[0]
+                    if isinstance(arg, ast.Dict):
+                        ids.update(_dict_id_values(arg, loop_stack))
+                    elif isinstance(arg, ast.Name) and arg.id in local_dicts:
+                        ids.update(_dict_id_values(local_dicts[arg.id], loop_stack))
+            elif isinstance(stmt, ast.For):
+                bindings = _for_loop_bindings(stmt, local_dicts)
+                next_stack = loop_stack + [bindings] if bindings else loop_stack
+                walk_body(stmt.body, next_stack, dict(local_dicts))
+                walk_body(stmt.orelse, loop_stack, dict(local_dicts))
+            elif isinstance(stmt, (ast.If, ast.While)):
+                walk_body(stmt.body, loop_stack, local_dicts)
+                walk_body(stmt.orelse, loop_stack, local_dicts)
+            elif isinstance(stmt, ast.Try):
+                walk_body(stmt.body, loop_stack, local_dicts)
+                for handler in stmt.handlers:
+                    walk_body(handler.body, loop_stack, local_dicts)
+                walk_body(stmt.orelse, loop_stack, local_dicts)
+                walk_body(stmt.finalbody, loop_stack, local_dicts)
+            elif isinstance(stmt, ast.With):
+                walk_body(stmt.body, loop_stack, local_dicts)
+            elif isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                walk_body(stmt.body, [], {})
+
+    walk_body(tree.body, [], {})
+    return ids
+
+
 def scan_log_ids(log_dir: Path):
     ids = set()
     if not log_dir or not log_dir.is_dir():
@@ -115,21 +276,25 @@ def main(argv=None):
     code_paths = [p for p in code_paths if p.is_file()]
     code_ids = scan_code_ids(code_paths)
 
+    dynamic_tests_path = root / 'tests' / 'dynamic_tests.py'
+    if dynamic_tests_path.is_file():
+        code_ids |= scan_dynamic_tests_ids(dynamic_tests_path)
+
     doc_only = sorted(doc_ids - code_ids)
     code_only = sorted(code_ids - doc_ids)
 
     print(f"Doc-registered IDs: {len(doc_ids)} ({len(doc_many_ids)} tagged '(x many)')")
-    print(f"Code-emitted IDs (PowerShell scan): {len(code_ids)}")
+    print(f"Code-emitted IDs (PowerShell + dynamic_tests.py AST scan): {len(code_ids)}")
     print()
 
     ok = True
     if doc_only:
         ok = False
         print(f"## Registered in docs but no matching code emission site found ({len(doc_only)})")
-        print("(stale/removed row -- doc likely needs cleanup -- OR a legitimate 'Dynamic-tests")
-        print(" NDJSON' row from tests/dynamic_tests.py, which this scanner does not read (Python")
-        print(" file, out of scope by design -- see this script's module docstring). Verify by")
-        print(" hand against dynamic_tests.py before treating any of these as a real gap.)")
+        print("(stale/removed row -- doc likely needs cleanup. Could also mean")
+        print(" tests/dynamic_tests.py builds this id from something the AST resolver doesn't")
+        print(" handle -- nested loops, a non-literal iterable, a function call -- see this")
+        print(" module's docstring before assuming a real gap.)")
         for i in doc_only:
             print(f"  - {i}")
         print()


### PR DESCRIPTION
## Summary

Closes the pre-approved Active Backlog item: the `ndjson-registry-check` advisory job's
permanent "16 doc-only rows" false-positive gap. `tools/check_ndjson_registry.py` previously only
scanned `tests/*.ps1`, `run_setup.bat`, and `.github/workflows/*.yml` -- `tests/dynamic_tests.py`
(Python) was out of scope by design, so the 16 rows it emits (`pr.to_conda`, `dp.pep440`,
`entry.select.*`, etc.) showed up as "registered in docs but no matching code emission site
found" on literally every single run, forever, with zero chance of ever converging to green.

- Added `scan_dynamic_tests_ids()`: an `ast`-based resolver (not regex -- the id-construction
  shapes turned out more varied than the original backlog note assumed) that walks
  `record({"id": ...})` calls and resolves the id value three ways: a plain string literal; an
  f-string templated from an enclosing `for` loop's literal iterable (`f"pr.{_pkg}.{_target}"`,
  including `dict.items()` iteration via a locally-tracked dict-literal assignment); or a *bare*
  loop variable used directly as the id with no string literal at all (the `entry.select.*` rows
  use this shape, which a pure regex cannot resolve at all). Also handles the one-hop
  `rec = {"id": ...}; ...; record(rec)` indirection `ensure_extracted()` uses.
- Running the extended scanner against this repo's real state surfaced 7 genuinely new,
  previously-invisible undocumented rows: `helpers.run_setup`, `bootstrap.status`, and 5
  `helpers.decode.~<name>.py` rows. Backfilled all 7 into `docs/agent-ndjson.md` in this same
  commit.
- Fixed a latent bug the tilde in those ids exposed: the doc-side token regex (`DOC_TOKEN_RE`)
  didn't include `~` in its character class, silently mis-splitting any tilde-containing id at
  the tilde boundary.
- 3 new unit tests in `tests/test_check_ndjson_registry.py` cover the three id-resolution shapes
  plus the `.items()`/`rec` indirection and an end-to-end `main()` wiring check.

**Left `continue-on-error: true` in place for this push** -- flipping the job's gating posture is
its own follow-up (already noted in `CLAUDE.md`'s Active Backlog) once confirmed green across a
few real CI runs, not bundled in blind.

## Test plan

- [x] Local sanity sweep: `compileall`, `pyflakes`, `check_delimiters.py`, `yamllint`,
      `actionlint`, ASCII sweep, PowerShell AST parse sweep, `pytest` (204 passed) -- all clean.
- [x] CI run [28958030287](https://github.com/mixmansoundude/Python_vs_Windows/actions/runs/28958030287)
      (commit `66a358c`) completed with conclusion `success`.
- [x] **The `ndjson-registry-check` job itself now shows `PASS: no doc/code registry mismatches
      found.`** -- confirmed directly in the job log, the first time this job has ever gone green
      since it was added.


---
_Generated by [Claude Code](https://claude.ai/code/session_015xbWLPbiaKVsobB9FZy8kS)_