### PR TITLE
Close 3 hardening items from the reorder's research pass

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -471,26 +471,23 @@ a fact confirmed with no action needed, or a recurring/periodic check belongs in
    accumulated feature/test-scenario growth (more selftest scripts each doing a real
    `conda create`), not a regression from any single change. Worth periodic reassessment, no
    action planned yet.
-2. **`:conda_base_update`'s `Get-Content`-based `for /f` (run_setup.bat ~line 3672)** shares the
-   same `for /f` backtick-subshell invocation topology as the CONFIRMED Windows PowerShell 5.1
-   `Get-FileHash` module-autoload bug fixed in `embed_extract.ps1` this session (see
-   `docs/agent-lessons-learned.md`). Unconfirmed in this specific case (wrapped in a `try/catch`
-   that silently defaults to `'update'` on any exception, so a module-load failure here would be
-   masked, not crash), but plausible enough to warrant the same defensive rewrite. Deliberately
-   deferred (not bundled into the 2026-07-10 hardening pass): this is an inline `-Command "..."`
-   one-liner, not a separate `.ps1` file emitted via `:emit_from_base64` like `embed_extract.ps1`
-   -- per `docs/agent-lessons-learned.md`'s documented hazard, any literal `"` character inside a
-   `-Command` body breaks cmd.exe's naive quote-toggle tokenization, so a `.NET`-API rewrite here
-   either needs to avoid literal `"` entirely or convert this to an emitted `.ps1` file (more
-   invasive) -- needs its own dedicated follow-up loop.
-3. **Cleanup-review findings from a background code-review pass (2026-07-10), not yet
-   implemented**: the embed zip download has no fallback/mirror URL unlike every other download
-   in `run_setup.bat` (Miniconda, uv, get-pip all have one); `tests/harness.ps1`'s
-   `batch.req009.provider_logs` static check (titled "all four provider log lines") was never
-   extended to also assert embed's own `[BOOT]` provider-selected line; a handful of smaller
-   dead branches/duplicated boilerplate in `tools/embed_pyver_check.py` and the embed CI test
-   blocks. Logged for a future pass; not bundled into the reorder/hardening commits to keep that
-   diff reviewable and focused on what was actually discussed with the user.
+2. **`embed_pyver_check.py`'s double "unchanged" short-circuit leaves the `fell_back=True`
+   "fellback" WARN tag unreachable for above-ceiling requests (below-floor still works).**
+   `main()`'s first early-return (`requested_minor is None or requested_minor == LATEST_MINOR`)
+   is fine, but the second one (after `resolve_table_entry`, firing whenever the resolved `minor`
+   equals `LATEST_MINOR`) intercepts every above-ceiling request before it ever reaches the
+   `tag = "fellback" if fell_back else "swapped"` line -- so a user who requests a Python newer
+   than this repo's table ceiling silently gets latest with no diagnostic tag, while a
+   below-floor request still correctly reaches the tag. Low severity (the actual behavior --
+   falling back to latest -- is correct either way; only the diagnostic label is unreachable for
+   one of the two fallback directions). Low priority; fix by moving the LATEST_MINOR check inside
+   `resolve_table_entry`'s own early-return rather than duplicating it in `main()`.
+3. **~85 lines of near-duplicated env-var save/set/restore boilerplate between
+   `self.embed.fallback.decline` and `self.embed.fallback.real`** in
+   `tests/selfapps_ux_hardening.ps1`. Factorable into a shared helper, but each block forces a
+   genuinely different set of env vars (decline: 6 vars; real: 5 different vars), so the helper
+   would need real parameterization -- a small design decision, not a mechanical copy-paste
+   cleanup. Cosmetic; defer unless already touching these test blocks for another reason.
 
 *(Item 5 from the pre-existing "cosmetic log noise/path doubling" debrief note was checked
 briefly per standing instruction not to over-invest: no `--distpath`/`--workpath` override or
@@ -598,6 +595,24 @@ rather than relying on manual memory.
 
 ## Known Findings (diagnosed, no action warranted)
 
+- **Embed zip download has no genuine second-host fallback available, unlike Miniconda/uv/get-pip
+  -- researched, no action planned.** A background code-review pass flagged that the embed tier's
+  download (`:try_embed_fallback`, run_setup.bat) retries the *same* `HP_EMBED_URL`
+  (`www.python.org/ftp/python/...`) on failure, unlike Miniconda (has a `repo.continuum.io` legacy
+  alias), uv (has a pinned-release GitHub URL distinct from its "latest" CDN redirect), and get-pip
+  (has the get-pip project's own GitHub source as a second host). Researched whether an equivalent
+  second host exists for python.org's embeddable zip distribution: it does not, in the same sense.
+  `www.python.org/ftp` is itself the canonical, Fastly-CDN-backed distribution point for CPython
+  releases -- there is no alternate *official* domain serving the identical embeddable-zip artifact.
+  python.org does list community mirrors, but none are guaranteed to carry the embeddable-zip
+  variant specifically, or to match this repo's pinned SHA256 the way the primary source does by
+  construction (the checksum was computed directly from a `python.org/ftp` download at pin time) --
+  pointing at one would be a real trust/availability decision, not a mechanical copy of the
+  Miniconda/uv/get-pip pattern. Decision: no forced fallback host. The existing 2-attempt
+  same-URL retry (curl, then PowerShell `Invoke-WebRequest`) already covers the common transient
+  failure case; a genuine second-host fallback remains possible future work if a specific mirror is
+  ever vetted, but is not a quick win and is not planned.
+
 - **User-code exit-code semantics are already correctly isolated from bootstrapper status --
   verified, no action needed.** Traced the full flow: `HP_SMOKE_RC` is captured directly from
   `%ERRORLEVEL%` immediately after launching the user's program at every verification call site
@@ -674,6 +689,34 @@ rather than relying on manual memory.
 ## Closed Backlog
 
 Items completed and shipped:
+
+- **Three small hardening/cleanup items from the reorder's research pass**: (1)
+  `:conda_base_update`'s inline `-Command` PowerShell (run_setup.bat, `:conda_base_update`)
+  rewritten to raw .NET APIs (`[System.IO.File]::Exists`/`ReadAllText`/`WriteAllText`,
+  `[datetime]::Now`) in place of `Test-Path`/`Get-Content`/`Get-Date`/`Set-Content` -- closes the
+  plausible (never confirmed; masked by an existing `try/catch`) Windows PowerShell 5.1
+  `Microsoft.PowerShell.Utility` module-autoload gap documented in
+  `docs/agent-lessons-learned.md`'s "Prefer raw .NET types over Utility-module cmdlets" entry;
+  notably `Get-Date` needed replacing too, not just `Get-Content`/`Set-Content`, since it lives in
+  the same module and would fail identically if the gap were ever triggered here. All three
+  PowerShell snippets stayed inline `-Command "..."` one-liners (not converted to an emitted
+  `.ps1` file) since the .NET replacements use only single-quoted PowerShell string literals, so
+  no literal `"` was ever introduced into the `-Command` body -- the quoting hazard that would
+  have forced the more invasive `.ps1`-file conversion never actually applied once written out
+  correctly. (2) `tests/harness.ps1`'s `batch.req009.provider_logs` static check extended with a
+  5th pattern (`Embedded Python`) and retitled "all five provider log lines" -- it previously only
+  asserted the pre-Tier-5 four providers (UV/Conda/Local venv/System Python), never covering
+  embed's own `[BOOT] REQ-009: Selected Python provider: Embedded Python (python.org).` line even
+  though embed shipped as a fifth tier. (3) The embed-tier declaration-block comment at
+  run_setup.bat ~line 163 (`rem REQ-009 Tier 5: embeddable-Python fallback...`) still read "last
+  resort when uv/conda/venv/system all fail" -- stale since the REQ-009 provider-chain reorder
+  made embed execute 3rd (right after conda), not last; this was missed during that reorder
+  because only the two dispatch-chain sections' own comments were fixed at the time, not this
+  earlier declaration-block comment. Updated to state the tier's actual position and rationale
+  (front-loaded so a pinned runtime.txt/pyproject.toml version is honored before falling back to
+  ambient venv/system Python). All three were confirmed via a dedicated research pass (which also
+  covered two items that stayed open -- see Active Backlog -- and the embed-fallback-URL question,
+  which resolved to "no action" -- see Known Findings). CLOSED by this PR.
 
 - **Embed version table quarterly-maintenance-checklist entry**: the Tier 5 design doc stated
   the `EMBED_PYTHON_TABLE` in `tools/embed_pyver_check.py` should refresh on the same quarterly

--- a/docs/agent-lessons-learned.md
+++ b/docs/agent-lessons-learned.md
@@ -636,6 +636,24 @@ PowerShell module dependency, since `System.Security.Cryptography`/`System.IO`/
 `for /f`-backtick-subshell pattern should default to .NET types for hashing/archive/file-IO
 rather than assuming the equivalent PowerShell cmdlet's module will be available.
 
+**Applied defensively to a second, pre-existing `for /f`-backtick-subshell site with the same
+topology: `:conda_base_update`'s timestamp check (run_setup.bat, was CLAUDE.md Active Backlog
+item, now closed).** This site was NEVER confirmed to have failed in CI -- it is wrapped in a
+`try/catch` that silently defaults to `'update'` on any exception, so a module-autoload failure
+here would be masked (an unnecessary conda update), not a crash, unlike the embed tier's
+unguarded `Get-FileHash` call. Rewritten anyway on the same principle: `Get-Content -Raw` ->
+`[System.IO.File]::ReadAllText(path, [System.Text.Encoding]::ASCII)`, `Test-Path` ->
+`[System.IO.File]::Exists(path)`, and -- worth calling out specifically -- `Get-Date` -> `[datetime]::Now`.
+`Get-Date` is easy to overlook here: it lives in the exact same `Microsoft.PowerShell.Utility`
+module as `Get-FileHash`/`Get-Content`/`Set-Content`, so if the module-autoload gap were ever
+triggered at this call site, `Get-Date` would fail identically -- fixing only the
+Get-Content/Set-Content calls while leaving `Get-Date` in place would have been an incomplete
+fix. All three PowerShell snippets here are inline `-Command "..."` one-liners (not an emitted
+`.ps1` file via `:emit_from_base64`), so per the quoting hazard documented elsewhere in this
+file, the .NET replacement calls stick to single-quoted PowerShell string literals throughout
+(`'...'`) to avoid introducing any literal `"` into the `-Command` body -- confirmed no such
+character was added.
+
 **A second, independent bug hid behind the first and only surfaced once diagnostics were added:**
 once `Get-FileHash` was replaced, a follow-up local `pwsh` test against the real downloaded zip
 showed extraction succeeding but the `._pth` site-imports patch silently NOT applying --

--- a/run_setup.bat
+++ b/run_setup.bat
@@ -161,9 +161,12 @@ rem GitHub source (the file bootstrap.pypa.io serves is generated from this repo
 rem primary-CDN + GitHub-source fallback pattern already used for Miniconda/uv above.
 if not defined HP_GETPIP_URL set "HP_GETPIP_URL=https://bootstrap.pypa.io/get-pip.py"
 set "HP_GETPIP_FALLBACK_URL=https://raw.githubusercontent.com/pypa/get-pip/main/public/get-pip.py"
-rem REQ-009 Tier 5: embeddable-Python fallback, last resort when uv/conda/venv/system all fail
-rem (or no ambient interpreter exists at all). Only a single "latest" version is ever downloaded
-rem here -- HP_EMBED_LATEST_SHA256 MUST match the "3.14" entry embedded in the Python-side
+rem REQ-009 Tier 5 (by naming/history; executed 3rd as of the provider-chain reorder): the
+rem embeddable-Python fallback, reached right after conda fails (before venv/system) so a
+rem pinned runtime.txt/pyproject.toml version is still honored via a fresh checksummed download
+rem instead of silently falling back to whatever ambient Python happens to be on the machine.
+rem Only a single "latest" version is ever downloaded here -- HP_EMBED_LATEST_SHA256 MUST match
+rem the "3.14" entry embedded in the Python-side
 rem ~embed_pyver_check.py payload below (a unit test asserts this so a refresh that updates one
 rem but not the other is caught at CI time, not discovered live). See docs/agent-interconnect.md
 rem "Standalone Python-download tier" for the two-stage PowerShell/Python design and why a
@@ -3716,21 +3719,27 @@ if "%HP_TEST_CONDA_UPDATE%"=="1" (
 )
 if defined HP_CONDA_JUST_INSTALLED goto :cbu_firstinstall
 set "HP_CONDA_UPDATE_RESULT=update"
-for /f "delims=" %%R in ('powershell -NoProfile -ExecutionPolicy Bypass -Command "if (Test-Path '%MINICONDA_ROOT%\~conda.lastupdate') { try { $d = [datetime](Get-Content '%MINICONDA_ROOT%\~conda.lastupdate' -Raw); if (((Get-Date)-$d).TotalDays -ge 30) { 'update' } else { 'skip' } } catch { 'update' } } else { 'update' }"') do set "HP_CONDA_UPDATE_RESULT=%%R"
+rem derived requirement: raw .NET File/DateTime APIs, not Get-Content/Get-Date/Test-Path --
+rem see docs/agent-lessons-learned.md "Prefer raw .NET types over Utility-module cmdlets" for
+rem the confirmed Windows PowerShell 5.1 module-autoload gap this avoids (Get-FileHash failed
+rem to autoload in the identical for-/f-backtick-subshell topology; Get-Date/Get-Content share
+rem its Microsoft.PowerShell.Utility module, so both are equally exposed, not just the one that
+rem was actually caught failing).
+for /f "delims=" %%R in ('powershell -NoProfile -ExecutionPolicy Bypass -Command "if ([System.IO.File]::Exists('%MINICONDA_ROOT%\~conda.lastupdate')) { try { $d = [datetime]([System.IO.File]::ReadAllText('%MINICONDA_ROOT%\~conda.lastupdate', [System.Text.Encoding]::ASCII)); if (([datetime]::Now - $d).TotalDays -ge 30) { 'update' } else { 'skip' } } catch { 'update' } } else { 'update' }"') do set "HP_CONDA_UPDATE_RESULT=%%R"
 if "%HP_CONDA_UPDATE_RESULT%"=="update" goto :cbu_run
 call :log "[INFO] Conda base update: skipped (last update < 30 days ago)."
 goto :eof
 
 :cbu_firstinstall
 call :log "[INFO] Conda base update: skipped (first install)."
-powershell -NoProfile -ExecutionPolicy Bypass -Command "(Get-Date -Format 'yyyy-MM-ddTHH:mm:ss') | Set-Content -LiteralPath '%MINICONDA_ROOT%\~conda.lastupdate' -Encoding Ascii" >nul 2>&1
+powershell -NoProfile -ExecutionPolicy Bypass -Command "[System.IO.File]::WriteAllText('%MINICONDA_ROOT%\~conda.lastupdate', [datetime]::Now.ToString('yyyy-MM-ddTHH:mm:ss'), [System.Text.Encoding]::ASCII)" >nul 2>&1
 goto :eof
 
 :cbu_run
 call :log "[INFO] Conda base update: running (>=30 days since last update or no record)."
 call "%CONDA_BAT%" update -n base --all --override-channels -c conda-forge -y >> "%LOG%" 2>&1
 if not errorlevel 1 (
-  powershell -NoProfile -ExecutionPolicy Bypass -Command "(Get-Date -Format 'yyyy-MM-ddTHH:mm:ss') | Set-Content -LiteralPath '%MINICONDA_ROOT%\~conda.lastupdate' -Encoding Ascii" >nul 2>&1
+  powershell -NoProfile -ExecutionPolicy Bypass -Command "[System.IO.File]::WriteAllText('%MINICONDA_ROOT%\~conda.lastupdate', [datetime]::Now.ToString('yyyy-MM-ddTHH:mm:ss'), [System.Text.Encoding]::ASCII)" >nul 2>&1
   call :log "[INFO] Conda base update complete."
 ) else (
   call :log "[WARN] Conda base update failed; continuing."

--- a/tests/harness.ps1
+++ b/tests/harness.ps1
@@ -290,9 +290,9 @@ Write-Result "batch.req011.dircheck" "REQ-011: directory integrity check present
 $req012Patterns = @('HP_SKIP_ENTRY_SMOKE set; skipping entry-script smoke', 'HP_SKIP_EXE_SMOKERUN set; skipping EXE verification')
 $hasReq012 = ($req012Patterns | Where-Object { -not ($AllText -match $_) }).Count -eq 0
 Write-Result "batch.req012.skiphooks" "REQ-012: HP_SKIP_ENTRY_SMOKE and HP_SKIP_EXE_SMOKERUN execution-skip log lines present in run_setup.bat" $hasReq012 @{}
-$req009Patterns = @('\[BOOT\] REQ-009.*Selected.*UV', '\[BOOT\] REQ-009.*Selected.*Conda', '\[BOOT\] REQ-009.*Selected.*Local venv', '\[BOOT\] REQ-009.*Selected.*System Python')
+$req009Patterns = @('\[BOOT\] REQ-009.*Selected.*UV', '\[BOOT\] REQ-009.*Selected.*Conda', '\[BOOT\] REQ-009.*Selected.*Embedded Python', '\[BOOT\] REQ-009.*Selected.*Local venv', '\[BOOT\] REQ-009.*Selected.*System Python')
 $hasReq009 = ($req009Patterns | Where-Object { -not ($AllText -match $_) }).Count -eq 0
-Write-Result "batch.req009.provider_logs" "REQ-009: all four provider log lines present in run_setup.bat" $hasReq009 @{}
+Write-Result "batch.req009.provider_logs" "REQ-009: all five provider log lines present in run_setup.bat" $hasReq009 @{}
 $venvGuardFound = $AllText -match [regex]::Escape('"%HP_ALLOW_VENV_FALLBACK%"=="1"')
 Write-Result "batch.req009.venv_unconditional" "REQ-009: venv fallback not guarded by HP_ALLOW_VENV_FALLBACK (fallback is unconditional)" (-not $venvGuardFound) @{ guardFound = $venvGuardFound }
 $cascadeDetectPatterns = @(':warnfix_cascade_detect', 'cascade candidate detected', 'HP_TEST_FORCE_WARNFIX_UNRESOLVED', 'HP_CASCADE_CANDIDATE')


### PR DESCRIPTION
## Summary
- `:conda_base_update` (run_setup.bat) now uses raw .NET File/DateTime APIs (`[System.IO.File]::Exists`/`ReadAllText`/`WriteAllText`, `[datetime]::Now`) instead of `Test-Path`/`Get-Content`/`Get-Date`/`Set-Content`, closing the plausible (unconfirmed, masked by an existing `try/catch`) Windows PowerShell 5.1 `Microsoft.PowerShell.Utility` module-autoload gap shared with the confirmed `Get-FileHash` bug fixed earlier this session. All three PowerShell snippets stayed inline `-Command "..."` one-liners since the .NET replacements use only single-quoted string literals, so no literal `"` was introduced.
- `tests/harness.ps1`'s `batch.req009.provider_logs` static check now asserts all five provider `[BOOT]` log lines (added Embedded Python; was only checking the pre-Tier-5 four).
- Fixed a stale "last resort when uv/conda/venv/system all fail" comment on the embed-tier declaration block in `run_setup.bat` — left over from the earlier provider-chain reorder, which made embed execute 3rd (right after conda), not last.
- `CLAUDE.md`: moved the three closed items to Closed Backlog, added a Known Findings entry recording that the embed zip's missing fallback-URL question was researched and resolved to "no action" (python.org's `ftp` distribution has no genuine alternate-host mirror the way Miniconda/uv/get-pip do), and kept two lower-priority cleanup items open in Active Backlog.
- `docs/agent-lessons-learned.md`: extended the existing "Prefer raw .NET types over Utility-module cmdlets" entry with this second applied instance, per the AGENT DIRECTIVE to edit existing entries rather than only append.

## Test plan
- [x] `python -m compileall -q .`
- [x] `python -m pyflakes .`
- [x] `python tools/check_delimiters.py run_setup.bat`
- [x] `python -m yamllint .github/workflows/`
- [x] `actionlint -oneline .github/workflows/*.yml`
- [x] ASCII sweep over touched files
- [x] PowerShell AST parse sweep over `tests/*.ps1`, `tools/*.ps1`
- [x] `python -m pytest tests/test_*.py -q` (214 passed, 2 skipped)
- [ ] Windows CI lanes (this repo's bootstrapper logic cannot be exercised end-to-end outside real Windows CI; the `:conda_base_update` change is a low-risk, syntactically-verified rewrite but only real CI confirms behavior)


---
_Generated by [Claude Code](https://claude.ai/code/session_015xbWLPbiaKVsobB9FZy8kS)_