### PR TITLE
Add Deno-for-Python README section; make PEP 723 write-back design implementation-ready

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -550,6 +550,60 @@ a fact confirmed with no action needed, or a recurring/periodic check belongs in
      limited to post-mortem diagnostics after a failure, not new discovery capability, since a
      successful smoke run means nothing was actually missing. Way-later, diagnostic-only,
      low-priority.
+   - **Concrete design (2026-07-11 follow-up), implementation-ready.** Confirmed via uv's own
+     docs: `uv add --script <file> <pkg1> <pkg2> ...` inserts a fresh `# /// script` block if none
+     exists, or updates an existing valid one; the written constraint defaults to a lower bound
+     (`>=X.Y`, resolved against the current latest compatible version) rather than an exact pin,
+     adjustable via `--bounds`. This means the write-back step needs network access at call time
+     (to resolve the bound), so it must run **after** the dependency-install phase has already
+     succeeded, not before -- reusing network access that phase already needed, not adding a new
+     network dependency. Idempotency (re-running `uv add --script` with the same package already
+     present) is expected to be a no-op per uv's own `add` semantics, but this must be verified
+     empirically in the CI test below, not assumed from docs alone (this repo's own convention:
+     "trust but verify" cross-tool assumptions, per the `docs/agent-lessons-learned.md` precedent
+     of the `Get-FileHash` module-autoload surprise). Malformed-existing-header behavior is
+     **unconfirmed** and flagged as an open question for whoever implements this: if `uv add
+     --script` errors on a malformed block rather than repairing it, the safe fallback is to
+     delete/replace the malformed block first (REQ-005.1's parser already detects this case) so
+     uv writes a clean one, rather than relying on uv to repair in place.
+     - **Trigger point**: after `:after_env_mode_selection`'s uv-provider dependency-install call
+       succeeds, and again after a successful warnfix repair (so modules warnfix discovers, which
+       aren't in the original resolved requirements list, still get promoted into the header).
+       Package names: reuse the already-resolved direct-dependency list from REQ-005.1-005.7 (not
+       a full `pip freeze` of the transitive closure -- PEP 723 headers declare direct
+       dependencies, matching what `requirements.txt`/`pyproject.toml` would normally contain).
+     - **Scope of the *entry* file only, not every `.py` file in the folder.** PEP 723 headers are
+       only meaningful on the file actually invoked via `uv run`; write into `%HP_ENTRY%` (REQ-002's
+       already-resolved entry selection), not into helper/sibling modules.
+     - **Invocation**: `"%HP_UV_EXE%" add --script "%HP_ENTRY%" pkg1 pkg2 ...` -- via the
+       already-resolved `HP_UV_EXE` path, never a bare `uv` PATH lookup, matching this repo's
+       "interpreter-anchored execution" principle (see Bootstrap Architecture Principles above).
+     - **Skip conditions**: source is already an authoritative, unchanged PEP 723 header with
+       nothing new to add; provider is not uv (v1 scope); `HP_SKIP_PEP723_WRITEBACK=1` (new
+       suppression-only flag, per REQ-001's "flags only suppress" rule); `HP_CI_SKIP_ENV=1` (no
+       real install cycle happens on that path). Always best-effort -- any failure (network hiccup,
+       uv error) logs `[WARN]` and continues; never gates the Prime Directive.
+     - **Log contract**: `[INFO] REQ-005: Wrote inferred dependencies into <entry>.py's PEP 723
+       header (via uv add --script).` -- never silent, matching every other REQ-005 augmentation
+       step's "no silent fallback" design principle.
+     - **Test plan** (new NDJSON rows, naming mirrors the existing `self.pep723.*` family):
+       `self.pep723.writeback.fresh` (no existing header -> new block appears with expected
+       packages), `self.pep723.writeback.idempotent` (run twice -> second run doesn't grow/duplicate
+       the header -- this is the empirical check for the unverified idempotency assumption above),
+       `self.pep723.writeback.malformed` (starts malformed -> cleanly replaced, not left broken),
+       `self.pep723.writeback.skipflag` (`HP_SKIP_PEP723_WRITEBACK=1` -> entry file untouched),
+       `self.pep723.writeback.warnfix` (a warnfix-only-discovered module ends up in the header too,
+       proving the post-repair trigger point works, not just the up-front one).
+     - **Docs to update alongside implementation**: `docs/agent-ndjson.md` (new rows);
+       `docs/agent-interconnect.md` (a new section -- this touches REQ-002 entry selection, REQ-005
+       dependency resolution, and uv-only `HP_UV_EXE` availability all at once, worth its own
+       cross-reference note); `README.md` (new REQ-005 sub-bullet + the new flag added to the
+       "Advanced Environment Variables" table); move this item to Closed Backlog once shipped.
+     - **Effort estimate**: comparable to a single already-shipped REQ-013/REQ-023-style addition
+       this session (a goto-based call site, a package-list assembly step reusing already-resolved
+       data, a skip-flag check) -- most of the real effort is in the five test scenarios and
+       confirming the malformed-header behavior empirically, not in new batch logic. Fits this
+       repo's "one feature slice per loop" norm as a single loop, unlike the AV-Safe Build Path PRD.
 6. **Opt-in "trust me, my script is idempotent" fast-discovery mode (way-later; needs its own
    dedicated design loop, not a quick add).** Raised via a 3rd-party analysis the owner shared
    (low confidence, no repo access -- see the new README section for the full non-idempotency

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -550,22 +550,64 @@ a fact confirmed with no action needed, or a recurring/periodic check belongs in
      limited to post-mortem diagnostics after a failure, not new discovery capability, since a
      successful smoke run means nothing was actually missing. Way-later, diagnostic-only,
      low-priority.
-   - **Concrete design (2026-07-11 follow-up), implementation-ready.** Confirmed via uv's own
-     docs: `uv add --script <file> <pkg1> <pkg2> ...` inserts a fresh `# /// script` block if none
-     exists, or updates an existing valid one; the written constraint defaults to a lower bound
-     (`>=X.Y`, resolved against the current latest compatible version) rather than an exact pin,
-     adjustable via `--bounds`. This means the write-back step needs network access at call time
-     (to resolve the bound), so it must run **after** the dependency-install phase has already
-     succeeded, not before -- reusing network access that phase already needed, not adding a new
-     network dependency. Idempotency (re-running `uv add --script` with the same package already
-     present) is expected to be a no-op per uv's own `add` semantics, but this must be verified
-     empirically in the CI test below, not assumed from docs alone (this repo's own convention:
-     "trust but verify" cross-tool assumptions, per the `docs/agent-lessons-learned.md` precedent
-     of the `Get-FileHash` module-autoload surprise). Malformed-existing-header behavior is
-     **unconfirmed** and flagged as an open question for whoever implements this: if `uv add
-     --script` errors on a malformed block rather than repairing it, the safe fallback is to
-     delete/replace the malformed block first (REQ-005.1's parser already detects this case) so
-     uv writes a clean one, rather than relying on uv to repair in place.
+   - **Concrete design (2026-07-11 follow-up, empirically verified 2026-07-12 against uv 0.8.17
+     in a local scratch dir -- not just uv's docs), implementation-ready.** The original design
+     pass below was written from doc summaries alone and got one detail wrong; corrected here
+     from direct testing, since this repo's own convention is "trust but verify" cross-tool
+     assumptions (see `docs/agent-lessons-learned.md`'s `Get-FileHash` module-autoload precedent).
+     **uv version caveat**: this repo intentionally never pins uv (always latest, per the uv-first
+     REQ-009 philosophy), so all of the following is confirmed against 0.8.17 specifically --
+     re-verify against whatever uv ships when this is actually implemented, using the same
+     scratch-dir method (`mkdir` a temp dir, write a throwaway `.py`, run the commands below,
+     inspect the output). None of the findings below depend on exact output formatting the
+     implementation should hard-code, though, so a future uv release changing cosmetic details
+     (e.g. the constraint format) should not break anything designed this way.
+     - **CORRECTED: no version bound is written by default.** `uv add --script file.py requests`
+       writes a bare `"requests"` line, not a `>=X.Y` lower bound -- confirmed with `--offline`
+       against an unresolved/uncached package too (still succeeded, still bare). Contrary to the
+       doc-summary-based assumption in the original design pass, this means the write-back step
+       does **not** need network access to produce a valid, useful header -- it's a metadata-only
+       operation. (It may still be *called* after a successful install for ordering/simplicity
+       reasons, just not because it structurally requires network to function.)
+     - **CONFIRMED: idempotent.** Re-running `uv add --script` with an already-present package
+       produces a byte-identical file (tested directly, not assumed).
+     - **CONFIRMED: merges into an existing valid header, doesn't touch unrelated fields.** Adding
+       a new package to a file that already has a valid `# /// script` block appends it
+       alphabetically into the existing `dependencies` list and leaves an existing
+       `requires-python` line completely untouched.
+     - **CONFIRMED: malformed existing header -> hard error, file left untouched.** Tested against
+       a deliberately broken TOML block: `uv add --script` exits 2 with a TOML parse error and
+       does **not** modify the file at all -- it does not attempt to repair in place. This makes
+       the originally-proposed fallback mandatory, not optional: the bootstrapper must detect a
+       malformed header first (REQ-005.1's parser already does this) and strip/delete the broken
+       block before calling `uv add --script`, so uv then writes a clean one from scratch --
+       confirmed this two-step repair sequence works cleanly end to end.
+     - **NEW FINDING: a fresh header also gets an auto-written `requires-python`, but only once.**
+       Creating a header from scratch (no prior block) writes `requires-python = ">=X.Y"`
+       reflecting whichever Python `uv add --script` resolves by default -- controllable
+       explicitly via `-p`/`--python "<path>"` (tested: `-p 3.11` reliably produces
+       `>=3.11`). Once a header exists, later `add` calls leave its `requires-python` alone
+       (confirmed above), so this is a one-time effect on first write-back, not a per-run
+       overwrite risk. Design implication: always pass `-p "%HP_PY%"` (the bootstrapper's own
+       already-resolved interpreter) explicitly on the first write-back, rather than letting uv
+       guess from whatever's ambient -- this makes the written `requires-python` reflect the
+       interpreter that was actually validated, and has no effect on this bootstrapper's *own*
+       REQ-004 version-selection logic (which reads `runtime.txt`/`pyproject.toml`, not PEP 723's
+       `requires-python`), so there is no correctness conflict with a pre-existing `runtime.txt`
+       pin -- it purely makes the file more self-describing for someone who later runs it directly
+       via plain `uv run` outside this bootstrapper entirely.
+     - **CONFIRMED: `--no-sync` is a no-op for `--script` mode** (uv prints its own warning saying
+       so: "a no-op for Python scripts with inline metadata, which always run in isolation").
+       `uv add --script` does not eagerly build or cache a separate environment as a side effect
+       of adding a dependency -- confirmed no new environment cache directory appears after the
+       call. This is genuinely a metadata-only operation; no redundant install/disk cost to worry
+       about, and no `--no-sync` flag needed in the actual invocation.
+     - **CONFIRMED: no package-existence validation at add time.** `uv add --script` happily wrote
+       a deliberately nonexistent package name (`this-package-definitely-does-not-exist-xyz123abc`)
+       into the header with no error. This reinforces (doesn't just theorize) that this
+       bootstrapper must only ever feed it package names it has *already confirmed installed*
+       (the resolved requirements list, or a warnfix repair that already succeeded) -- never a
+       speculative or unvalidated name -- since uv will not catch a bad name for us here.
      - **Trigger point**: after `:after_env_mode_selection`'s uv-provider dependency-install call
        succeeds, and again after a successful warnfix repair (so modules warnfix discovers, which
        aren't in the original resolved requirements list, still get promoted into the header).
@@ -575,9 +617,12 @@ a fact confirmed with no action needed, or a recurring/periodic check belongs in
      - **Scope of the *entry* file only, not every `.py` file in the folder.** PEP 723 headers are
        only meaningful on the file actually invoked via `uv run`; write into `%HP_ENTRY%` (REQ-002's
        already-resolved entry selection), not into helper/sibling modules.
-     - **Invocation**: `"%HP_UV_EXE%" add --script "%HP_ENTRY%" pkg1 pkg2 ...` -- via the
-       already-resolved `HP_UV_EXE` path, never a bare `uv` PATH lookup, matching this repo's
+     - **Invocation**: `"%HP_UV_EXE%" add --script "%HP_ENTRY%" -p "%HP_PY%" pkg1 pkg2 ...` -- via
+       the already-resolved `HP_UV_EXE` path, never a bare `uv` PATH lookup, matching this repo's
        "interpreter-anchored execution" principle (see Bootstrap Architecture Principles above).
+       The `-p "%HP_PY%"` is only load-bearing on the very first write-back (fresh header, no
+       prior `requires-python`) per the empirically-confirmed one-time-write behavior above; safe
+       to pass unconditionally on every call since it's a no-op once a header already exists.
      - **Skip conditions**: source is already an authoritative, unchanged PEP 723 header with
        nothing new to add; provider is not uv (v1 scope); `HP_SKIP_PEP723_WRITEBACK=1` (new
        suppression-only flag, per REQ-001's "flags only suppress" rule); `HP_CI_SKIP_ENV=1` (no
@@ -586,14 +631,18 @@ a fact confirmed with no action needed, or a recurring/periodic check belongs in
      - **Log contract**: `[INFO] REQ-005: Wrote inferred dependencies into <entry>.py's PEP 723
        header (via uv add --script).` -- never silent, matching every other REQ-005 augmentation
        step's "no silent fallback" design principle.
-     - **Test plan** (new NDJSON rows, naming mirrors the existing `self.pep723.*` family):
-       `self.pep723.writeback.fresh` (no existing header -> new block appears with expected
-       packages), `self.pep723.writeback.idempotent` (run twice -> second run doesn't grow/duplicate
-       the header -- this is the empirical check for the unverified idempotency assumption above),
-       `self.pep723.writeback.malformed` (starts malformed -> cleanly replaced, not left broken),
-       `self.pep723.writeback.skipflag` (`HP_SKIP_PEP723_WRITEBACK=1` -> entry file untouched),
-       `self.pep723.writeback.warnfix` (a warnfix-only-discovered module ends up in the header too,
-       proving the post-repair trigger point works, not just the up-front one).
+     - **Test plan** (new NDJSON rows, naming mirrors the existing `self.pep723.*` family; all five
+       scenarios below were dry-run manually in a local scratch dir against real uv 0.8.17 before
+       writing this spec, so this is now a port to `tests/selfapps_*.ps1`/NDJSON form, not fresh
+       exploration): `self.pep723.writeback.fresh` (no existing header -> new block appears with
+       expected packages and a `requires-python` matching the `-p` value passed),
+       `self.pep723.writeback.idempotent` (run twice -> second run produces a byte-identical file),
+       `self.pep723.writeback.malformed` (starts malformed -> cleanly replaced via the strip-then-add
+       sequence, not left broken -- this is the scenario that would have failed hard without the
+       repair step, since a bare `uv add --script` call against a malformed block errors out and
+       touches nothing), `self.pep723.writeback.skipflag` (`HP_SKIP_PEP723_WRITEBACK=1` -> entry
+       file untouched), `self.pep723.writeback.warnfix` (a warnfix-only-discovered module ends up in
+       the header too, proving the post-repair trigger point works, not just the up-front one).
      - **Docs to update alongside implementation**: `docs/agent-ndjson.md` (new rows);
        `docs/agent-interconnect.md` (a new section -- this touches REQ-002 entry selection, REQ-005
        dependency resolution, and uv-only `HP_UV_EXE` availability all at once, worth its own

--- a/README.md
+++ b/README.md
@@ -689,6 +689,34 @@ None of this rules out a faster path for a user who genuinely knows their own sc
 
 ---
 
+## Python_vs_Windows and the "Deno for Python" Question
+
+People occasionally ask whether anything plays the role for Python that [Deno](https://deno.com/) -- a zero-config, single-binary JavaScript/TypeScript runtime built by one of Node's original creators -- plays for JavaScript: no install rituals, no dependency-hell, just run the file. That question isn't hypothetical -- it's been asked directly, by name, on [Hacker News](https://news.ycombinator.com/item?id=35379227): *"Are there any efforts akin to deno for python?"* Python_vs_Windows doesn't reimplement the Python runtime the way Deno reimplemented JavaScript's, but on Windows, for the specific problem of "I was handed a `.py` file and nothing else," it answers the same question in spirit.
+
+The repository's Prime Directive: on a clean Windows 10+ machine with only a `.py` file, double-click a batch file, and it bootstraps an isolated runtime environment, installs every required dependency, and runs the script -- no manual configuration.
+
+Here's how that maps to Deno's actual design, point by point:
+
+**1. Zero-config, single-command execution**
+Deno: `deno run script.ts` downloads missing modules and executes, no setup step.
+This repo: double-click `run_setup.bat`. It scans the script, builds an isolated environment, installs what's missing, and runs it.
+
+**2. Rust-powered speed, with real fallbacks underneath**
+Deno is built in Rust end to end. This repo uses [uv](https://github.com/astral-sh/uv) -- Astral's Rust-based Python toolchain -- as its preferred, fastest environment provider. Underneath that, it doesn't depend on any single mechanism working: if uv isn't available, it cascades through several independent fallback tiers -- Conda/Miniconda, a checksum-verified embedded Python download straight from python.org, a local `venv`, and, as a last resort with explicit user consent, an unmanaged system Python. No single one of these being blocked or missing takes the whole tool down with it.
+
+**3. Automatic dependency discovery**
+Deno parses import URLs directly from the source file. This repo resolves dependencies in priority order: PEP 723 inline script metadata, then `pyproject.toml`, then `requirements.txt`, and only if none of those exist, a best-effort static-analysis scan (`pipreqs`) to infer what the script imports.
+
+**4. Compiling to a standalone executable**
+`deno compile` packages a script into a single distributable binary. This repo does the same in spirit: after setup succeeds, it bundles the app and its environment into a single-file Windows EXE via PyInstaller, so it can be handed to someone else without asking them to set anything up.
+
+**5. Controlled execution, not sandboxing**
+Deno enforces permissions by default (`--allow-net`, `--allow-read`, etc.). Python has no native equivalent, so this repo takes a different, deliberate precaution instead: it treats every run of the user's code as potentially non-idempotent -- a script can overwrite files, send an email, mutate a database, or actuate connected hardware -- so it runs that code purposefully and at most once per invocation automatically. A fresh build gets a single, time-boxed verification run; a real run is then offered, not forced; and anything beyond that single automatic run requires explicit consent that names the risk. Session isolation backs this up structurally too -- `PYTHONPATH` and `PYTHONHOME` are cleared on every run so the host system can't leak unrelated packages into the bootstrapped environment.
+
+The gap between the two projects is real -- Deno is a from-scratch runtime; this is a batch file orchestrating existing Python tooling. But for the narrow, common case this repo targets -- a non-technical user on Windows with someone else's script and nothing else -- it's the same promise: point it at the file, get a working run, no ceremony.
+
+---
+
 ## Known Limitations
 
 - **Implicit/plugin dependencies**: Dependencies that are not detected via static import analysis (for example, `pandas` needing `openpyxl` for `read_excel`) will surface as `ImportError` at runtime. See [Dependency strategy](#dependency-strategy) for detail.


### PR DESCRIPTION
## Summary

**Deno for Python README section:**
- Added a "Python_vs_Windows and the 'Deno for Python' Question" section near the end of `README.md`, positioning this bootstrapper against a real, recurring question (cited from a Hacker News thread) by mapping its actual design choices onto Deno's zero-config, single-binary design point by point.
- Content was provided by the owner; normalized to ASCII (em-dashes -> ` -- `, `<cite>` HTML tag -> markdown italics) to match this repo's existing documentation conventions, with all keywords/links preserved verbatim.

**PEP 723 write-back design, made implementation-ready and empirically verified:**
- `CLAUDE.md`'s existing Active Backlog item ("`autopep723` / `uv add --script` as a PEP 723 auto-write-back mechanism") previously just noted it "needs its own design pass." Expanded it into a concrete spec: trigger point, exact invocation, skip conditions plus a new `HP_SKIP_PEP723_WRITEBACK` opt-out flag, log contract, and five CI test scenarios.
- Then empirically tested the actual `uv add --script` behavior against real uv 0.8.17 in a local scratch directory (fresh header creation, idempotency, merge-vs-replace on an existing valid header, malformed-header handling, and the `requires-python` auto-write behavior) rather than trusting doc summaries. This corrected one wrong assumption (no version bound is written by default — a doc-summary-based claim that turned out false, meaning the operation doesn't structurally need network) and upgraded four previously-"unconfirmed" claims to confirmed, including the finding that malformed-header repair genuinely requires the strip-then-add sequence (a bare `uv add --script` call against broken TOML hard-errors and touches nothing).
- No code changes yet — this is planning/design work only, ready for a future implementation loop.

## Test plan
- [x] `python -m compileall -q .`
- [x] `python -m pyflakes .`
- [x] `python tools/check_delimiters.py run_setup.bat`
- [x] ASCII sweep (both files clean)
- [x] `python -m pytest tests/test_*.py -q` (215 passed, 2 skipped)
- [x] Docs-only change, no behavioral impact
