### PR TITLE
Promote PEP 723 write-back design into a full, code-grounded implementation plan

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -507,152 +507,21 @@ a fact confirmed with no action needed, or a recurring/periodic check belongs in
    creation), and the current fixed order is not wrong, just not optimal in either direction.
    Revisit if the network-correlated-embed-failure pattern shows up for real in CI or user
    reports, rather than speculatively building it now.
-5. **`autopep723` / `uv add --script` as a PEP 723 auto-write-back mechanism (soon-ish; needs its
-   own design pass, not a quick add).** Researched at the owner's request (2026-07-11). Two
-   distinct ideas got raised together and are worth separating:
-   - As a *discovery* mechanism (an alternative to pipreqs), `autopep723` offers little: it's
-     AST-based static import scanning, the same fundamental technique pipreqs already uses, with
-     the same blind spot (dynamic/plugin-style imports it can't see without executing the code --
-     e.g. `pandas.read_excel` needing `openpyxl`, same example already documented in the
-     Dependency strategy section above). It would not catch anything warnfix's build-time trace
-     doesn't already catch.
-   - As a *write-back* mechanism, it's genuinely different from anything this repo has today:
-     `autopep723` (zero dependencies, stdlib-only AST scan) and uv's own native `uv add --script
-     script.py pkg1 pkg2` both insert/update a PEP 723 `# /// script` header **directly in the
-     user's own `.py` file**, not a separate `requirements.auto.txt`. Since PEP 723 is already
-     this bootstrapper's #1 authoritative dependency source (REQ-005.1), a write-back step would
-     *promote* pipreqs's/warnfix's inferred deps into the authoritative, persistent format instead
-     of leaving them in the non-authoritative fallback file -- a more durable fix than today's
-     `requirements.auto.txt`, and this is also the natural mechanism for the "auto insert/repair a
-     malformed PEP 723 header" idea raised separately, not a different feature.
-   - Scope for a first cut: uv lane only (`uv add --script`, or `uv tool run autopep723`, both
-     require `uv.exe` already present -- no new acquisition tier needed), best-effort/optional
-     (never gating), and it modifies the user's own source file, which is a bigger design decision
-     than anything pipreqs does today (idempotency on repeat runs, not clobbering an existing
-     malformed header incorrectly, whether it runs before or after pipreqs) -- that design work is
-     the reason this isn't a quick add despite the underlying uv command being simple. Replicating
-     to conda/venv/embed/system lanes is explicitly a later step, not part of a first cut.
-   - `pip-compile-multi` (researched, same request) is **not applicable** -- it's a multi-file
-     lockfile-DAG tool for projects with segmented requirement sets (base/dev/prod splits); this
-     bootstrapper builds one flat environment for one script, so there's no dependency-segregation
-     problem for it to solve. `vulture` (researched, same request) is **not applicable either**,
-     and for a different reason: it's a static dead-code/unused-import *linter* (finds declared-
-     but-unused code via AST, same limitation class as pipreqs/autopep723 -- it does not execute
-     code or profile runtime imports at all), not a runtime-import logger; it cannot help with
-     dependency *discovery* in the direction this repo needs. `PYTHONPROFILEIMPORTTIME=1` /
-     `sys.modules` inspection (researched, same request) is a real *runtime* signal source (unlike
-     the three static tools above), but using it as a discovery mechanism would mean executing the
-     user's script specifically to observe it -- exactly the non-idempotency risk REQ-018 already
-     exists to prevent (see item 6 below and the new README section on this). The only genuinely
-     low-risk use is piggybacking it onto the bootstrapper's *existing* single verification run
-     (the EXE/interpreter smoke test that already happens once, per REQ-018) as a supplementary
-     diagnostic capture -- no new execution, so no new idempotency risk -- but its value there is
-     limited to post-mortem diagnostics after a failure, not new discovery capability, since a
-     successful smoke run means nothing was actually missing. Way-later, diagnostic-only,
-     low-priority.
-   - **Concrete design (2026-07-11 follow-up, empirically verified 2026-07-12 against uv 0.8.17
-     in a local scratch dir -- not just uv's docs), implementation-ready.** The original design
-     pass below was written from doc summaries alone and got one detail wrong; corrected here
-     from direct testing, since this repo's own convention is "trust but verify" cross-tool
-     assumptions (see `docs/agent-lessons-learned.md`'s `Get-FileHash` module-autoload precedent).
-     **uv version caveat**: this repo intentionally never pins uv (always latest, per the uv-first
-     REQ-009 philosophy), so all of the following is confirmed against 0.8.17 specifically --
-     re-verify against whatever uv ships when this is actually implemented, using the same
-     scratch-dir method (`mkdir` a temp dir, write a throwaway `.py`, run the commands below,
-     inspect the output). None of the findings below depend on exact output formatting the
-     implementation should hard-code, though, so a future uv release changing cosmetic details
-     (e.g. the constraint format) should not break anything designed this way.
-     - **CORRECTED: no version bound is written by default.** `uv add --script file.py requests`
-       writes a bare `"requests"` line, not a `>=X.Y` lower bound -- confirmed with `--offline`
-       against an unresolved/uncached package too (still succeeded, still bare). Contrary to the
-       doc-summary-based assumption in the original design pass, this means the write-back step
-       does **not** need network access to produce a valid, useful header -- it's a metadata-only
-       operation. (It may still be *called* after a successful install for ordering/simplicity
-       reasons, just not because it structurally requires network to function.)
-     - **CONFIRMED: idempotent.** Re-running `uv add --script` with an already-present package
-       produces a byte-identical file (tested directly, not assumed).
-     - **CONFIRMED: merges into an existing valid header, doesn't touch unrelated fields.** Adding
-       a new package to a file that already has a valid `# /// script` block appends it
-       alphabetically into the existing `dependencies` list and leaves an existing
-       `requires-python` line completely untouched.
-     - **CONFIRMED: malformed existing header -> hard error, file left untouched.** Tested against
-       a deliberately broken TOML block: `uv add --script` exits 2 with a TOML parse error and
-       does **not** modify the file at all -- it does not attempt to repair in place. This makes
-       the originally-proposed fallback mandatory, not optional: the bootstrapper must detect a
-       malformed header first (REQ-005.1's parser already does this) and strip/delete the broken
-       block before calling `uv add --script`, so uv then writes a clean one from scratch --
-       confirmed this two-step repair sequence works cleanly end to end.
-     - **NEW FINDING: a fresh header also gets an auto-written `requires-python`, but only once.**
-       Creating a header from scratch (no prior block) writes `requires-python = ">=X.Y"`
-       reflecting whichever Python `uv add --script` resolves by default -- controllable
-       explicitly via `-p`/`--python "<path>"` (tested: `-p 3.11` reliably produces
-       `>=3.11`). Once a header exists, later `add` calls leave its `requires-python` alone
-       (confirmed above), so this is a one-time effect on first write-back, not a per-run
-       overwrite risk. Design implication: always pass `-p "%HP_PY%"` (the bootstrapper's own
-       already-resolved interpreter) explicitly on the first write-back, rather than letting uv
-       guess from whatever's ambient -- this makes the written `requires-python` reflect the
-       interpreter that was actually validated, and has no effect on this bootstrapper's *own*
-       REQ-004 version-selection logic (which reads `runtime.txt`/`pyproject.toml`, not PEP 723's
-       `requires-python`), so there is no correctness conflict with a pre-existing `runtime.txt`
-       pin -- it purely makes the file more self-describing for someone who later runs it directly
-       via plain `uv run` outside this bootstrapper entirely.
-     - **CONFIRMED: `--no-sync` is a no-op for `--script` mode** (uv prints its own warning saying
-       so: "a no-op for Python scripts with inline metadata, which always run in isolation").
-       `uv add --script` does not eagerly build or cache a separate environment as a side effect
-       of adding a dependency -- confirmed no new environment cache directory appears after the
-       call. This is genuinely a metadata-only operation; no redundant install/disk cost to worry
-       about, and no `--no-sync` flag needed in the actual invocation.
-     - **CONFIRMED: no package-existence validation at add time.** `uv add --script` happily wrote
-       a deliberately nonexistent package name (`this-package-definitely-does-not-exist-xyz123abc`)
-       into the header with no error. This reinforces (doesn't just theorize) that this
-       bootstrapper must only ever feed it package names it has *already confirmed installed*
-       (the resolved requirements list, or a warnfix repair that already succeeded) -- never a
-       speculative or unvalidated name -- since uv will not catch a bad name for us here.
-     - **Trigger point**: after `:after_env_mode_selection`'s uv-provider dependency-install call
-       succeeds, and again after a successful warnfix repair (so modules warnfix discovers, which
-       aren't in the original resolved requirements list, still get promoted into the header).
-       Package names: reuse the already-resolved direct-dependency list from REQ-005.1-005.7 (not
-       a full `pip freeze` of the transitive closure -- PEP 723 headers declare direct
-       dependencies, matching what `requirements.txt`/`pyproject.toml` would normally contain).
-     - **Scope of the *entry* file only, not every `.py` file in the folder.** PEP 723 headers are
-       only meaningful on the file actually invoked via `uv run`; write into `%HP_ENTRY%` (REQ-002's
-       already-resolved entry selection), not into helper/sibling modules.
-     - **Invocation**: `"%HP_UV_EXE%" add --script "%HP_ENTRY%" -p "%HP_PY%" pkg1 pkg2 ...` -- via
-       the already-resolved `HP_UV_EXE` path, never a bare `uv` PATH lookup, matching this repo's
-       "interpreter-anchored execution" principle (see Bootstrap Architecture Principles above).
-       The `-p "%HP_PY%"` is only load-bearing on the very first write-back (fresh header, no
-       prior `requires-python`) per the empirically-confirmed one-time-write behavior above; safe
-       to pass unconditionally on every call since it's a no-op once a header already exists.
-     - **Skip conditions**: source is already an authoritative, unchanged PEP 723 header with
-       nothing new to add; provider is not uv (v1 scope); `HP_SKIP_PEP723_WRITEBACK=1` (new
-       suppression-only flag, per REQ-001's "flags only suppress" rule); `HP_CI_SKIP_ENV=1` (no
-       real install cycle happens on that path). Always best-effort -- any failure (network hiccup,
-       uv error) logs `[WARN]` and continues; never gates the Prime Directive.
-     - **Log contract**: `[INFO] REQ-005: Wrote inferred dependencies into <entry>.py's PEP 723
-       header (via uv add --script).` -- never silent, matching every other REQ-005 augmentation
-       step's "no silent fallback" design principle.
-     - **Test plan** (new NDJSON rows, naming mirrors the existing `self.pep723.*` family; all five
-       scenarios below were dry-run manually in a local scratch dir against real uv 0.8.17 before
-       writing this spec, so this is now a port to `tests/selfapps_*.ps1`/NDJSON form, not fresh
-       exploration): `self.pep723.writeback.fresh` (no existing header -> new block appears with
-       expected packages and a `requires-python` matching the `-p` value passed),
-       `self.pep723.writeback.idempotent` (run twice -> second run produces a byte-identical file),
-       `self.pep723.writeback.malformed` (starts malformed -> cleanly replaced via the strip-then-add
-       sequence, not left broken -- this is the scenario that would have failed hard without the
-       repair step, since a bare `uv add --script` call against a malformed block errors out and
-       touches nothing), `self.pep723.writeback.skipflag` (`HP_SKIP_PEP723_WRITEBACK=1` -> entry
-       file untouched), `self.pep723.writeback.warnfix` (a warnfix-only-discovered module ends up in
-       the header too, proving the post-repair trigger point works, not just the up-front one).
-     - **Docs to update alongside implementation**: `docs/agent-ndjson.md` (new rows);
-       `docs/agent-interconnect.md` (a new section -- this touches REQ-002 entry selection, REQ-005
-       dependency resolution, and uv-only `HP_UV_EXE` availability all at once, worth its own
-       cross-reference note); `README.md` (new REQ-005 sub-bullet + the new flag added to the
-       "Advanced Environment Variables" table); move this item to Closed Backlog once shipped.
-     - **Effort estimate**: comparable to a single already-shipped REQ-013/REQ-023-style addition
-       this session (a goto-based call site, a package-list assembly step reusing already-resolved
-       data, a skip-flag check) -- most of the real effort is in the five test scenarios and
-       confirming the malformed-header behavior empirically, not in new batch logic. Fits this
-       repo's "one feature slice per loop" norm as a single loop, unlike the AV-Safe Build Path PRD.
+5. **PEP 723 dependency write-back via `uv add --script`** -- full implementation plan at
+   `docs/plan-pep723-writeback.md`. Promotes resolved dependencies into a persistent, authoritative
+   PEP 723 header in the user's own entry `.py` file (using uv's native `uv add --script`) instead
+   of leaving them only in non-authoritative `requirements.auto.txt` -- a second, independently-
+   maintained path to declare dependencies that doesn't depend on `pipreqs`. Scope for v1: uv lane
+   only, best-effort/non-gating, entry file only. Two research/testing passes completed (initial
+   design + scratch-dir verification against uv 0.8.17; a follow-up pass that directly compared uv
+   0.8.17 against current uv 0.11.28 and confirmed real version-drift risk -- e.g. the default
+   write changed from a bare package name to a version-bound one between those releases -- plus a
+   web/GitHub-issues research pass and a code-grounded implementation trace of the actual
+   `run_setup.bat` hook points). **Status: implementation-ready**, sized to fit this repo's "one
+   feature slice per loop" norm (with a suggested two-loop split if the single-loop budget feels
+   tight -- see the plan doc's Part 4). Not yet scheduled for a specific loop; ready whenever
+   picked up. `pip-compile-multi` and `vulture` (researched alongside this) are **not applicable**
+   to this repo (see the plan doc's summary) -- not carried forward as backlog items.
 6. **Opt-in "trust me, my script is idempotent" fast-discovery mode (way-later; needs its own
    dedicated design loop, not a quick add).** Raised via a 3rd-party analysis the owner shared
    (low confidence, no repo access -- see the new README section for the full non-idempotency

--- a/docs/plan-pep723-writeback.md
+++ b/docs/plan-pep723-writeback.md
@@ -1,0 +1,408 @@
+# Implementation Plan: PEP 723 Dependency Write-Back via `uv add --script`
+
+**Status:** Implementation-ready. Two research/testing passes completed (2026-07-11 initial
+design + local scratch-dir verification against uv 0.8.17; 2026-07-12 follow-up: web/docs/GitHub-
+issues research pass, a second local scratch-dir pass comparing uv 0.8.17 against uv 0.11.28 to
+directly test version-drift risk, and a code-grounded implementation pass tracing the actual
+`run_setup.bat` hook points). No code written yet.
+**Owner:** Python_vs_Windows maintainer
+**Related:** `CLAUDE.md` Active Backlog (this item is linked from there); `docs/prd-av-safe-build-
+path.md` (a structurally similar large design doc, for format precedent).
+
+---
+
+## Goal
+
+After this bootstrapper successfully resolves and installs a script's dependencies (via pipreqs
+discovery, heuristic augmentation, and/or the warnfix repair loop), promote the final resolved
+dependency list into a persistent, authoritative PEP 723 `# /// script` header directly in the
+user's entry `.py` file, using uv's native `uv add --script` command -- instead of leaving
+inferred deps only in the non-authoritative `requirements.auto.txt`. This makes the file
+self-describing and durable (PEP 723 is already this repo's #1 authoritative dependency source
+per REQ-005.1), and gives a second, independently-maintained path to declare dependencies that
+doesn't depend on `pipreqs` (which this repo already treats with some wariness -- see
+`CLAUDE.md`'s pipreqs pin rationale section).
+
+**Scope for v1: uv lane only** (the provider that created `.uv_env`), best-effort/non-gating,
+**entry file only** (not every `.py` file in the folder). Replicating to conda/venv/embed/system
+lanes is explicitly a later step.
+
+---
+
+## Part 1: Empirical findings (both testing passes)
+
+### Pass 1 (2026-07-11, against uv 0.8.17 only)
+
+- **No version bound written by default** at the time: `uv add --script file.py requests` wrote
+  a bare `"requests"` line, confirmed even with `--offline` against an uncached package.
+- **Idempotent**: re-running with an already-present package produced a byte-identical file.
+- **Merges cleanly into an existing valid header**: a new package is appended alphabetically;
+  an existing `requires-python` line is left completely untouched.
+- **Malformed existing header -> hard error, file left untouched**: exit 2, TOML parse error,
+  zero modification to the file. This makes a strip-then-retry repair sequence *mandatory*, not
+  optional, since uv will never self-repair a broken block.
+- **`requires-python` is auto-written only on first-ever header creation**, never touched on
+  later `add` calls; fully controllable via `-p`/`--python "<path>"`.
+- **`--no-sync` is a no-op in script mode** -- no redundant environment gets built as a side
+  effect of adding a dependency; this is genuinely a metadata-only operation.
+- **No package-existence validation at add time** -- `uv add --script` happily wrote a
+  deliberately nonexistent package name with no error. This bootstrapper must only ever feed it
+  package names it has *already confirmed installed*.
+
+### Pass 2 (2026-07-12): web/docs/GitHub research
+
+Full agent report is not reproduced verbatim here; the actionable findings are:
+
+1. **Open uv bug, issue #15156 ("Cached Script Dependencies Not Properly Invalidated")**: a
+   sequence of `uv add --script` (change deps) then `uv run --script` (execute) can see a STALE
+   cached resolution even with `--refresh`/`--force-reinstall`; renaming the file "fixes" it,
+   implying the cache key is filename-derived. **This bootstrapper does not call `uv run
+   --script` on the entry file** (it runs the entry via its own separately-managed `.uv_env`
+   interpreter, or the built PyInstaller EXE), so this bug does not affect this bootstrapper's
+   own immediate execution correctness. It IS a real risk for the exact scenario this feature
+   enables: someone *later* running the promoted, self-describing file directly via `uv run
+   <entry>.py` outside this bootstrapper could hit stale cached results if a same-named file was
+   previously run with different dependencies. Document as a known limitation, don't silently
+   ignore.
+2. **Lockfile side-effect** (confirmed independently in Pass 2's local testing, see below): if a
+   `<entry>.py.lock` file already exists next to the target script, `uv add --script`
+   automatically reads and rewrites/extends that lockfile as an undocumented side effect, with no
+   flag to suppress it by default.
+3. **Version drift is real and was directly demonstrated**, not just theoretical (see local
+   testing below).
+4. **Other confirmed GitHub issues**: #10918 (open) -- a `# ///` closing fence with trailing
+   whitespace fails to parse as valid, meaning a header can become "malformed" from something as
+   innocuous as an editor adding trailing whitespace, not just from bad TOML content (confirmed
+   locally, see below). #15956 (open) -- `uv add --script` prints a benign stderr warning if
+   `VIRTUAL_ENV` is set in the calling environment; not a failure (confirmed locally, see below).
+   #13447 and #12499 were real past bugs (both fixed) about comment-deletion and TOML-block-
+   adjacency corruption around the metadata block -- evidence the header-insertion logic has had
+   genuine correctness bugs before.
+5. **autopep723 does NOT validate `uv add --script`'s write path.** It has its own, independent
+   TOML-writing code and only uses uv as an ephemeral runner (`uv run --with <deps>`), never `uv
+   add`/`uv run --script`. There is no "battle-tested by a popular third-party tool" confidence to
+   lean on here -- confidence rests solely on this repo's own direct testing plus uv's own
+   documented/changelogged behavior.
+
+### Pass 2 local scratch-dir testing (uv 0.8.17 vs uv 0.11.28, both installed side by side)
+
+- **CONFIRMED VERSION DRIFT, directly observed, not inferred from changelog text alone**: uv
+  0.11.28's default behavior differs from 0.8.17 -- it now writes a version *lower bound*
+  (`"pandas[excel]>=3.0.3"`) where 0.8.17 wrote a bare name (`"pandas[excel]"`). This is the
+  single most important finding of this pass: the "no version bound by default" claim from Pass 1
+  was correct for 0.8.17 specifically and is **already false** for current uv. Since this repo
+  never pins uv's version, production behavior will match whatever the *current* uv does, not the
+  0.8.17 baseline. **Design implication: do not hard-code an assumption about whether a bound is
+  present in the written output -- treat "whatever uv writes" as opaque and correct by
+  construction**, which the original design already avoided asserting as a hard requirement, but
+  this confirms that caution was warranted, not excessive.
+- **Extras syntax (`pandas[excel]`) works correctly on both versions** and is correctly
+  recognized as the same logical package on re-add: adding bare `pandas` after `pandas[excel]`
+  was already present did not duplicate or downgrade the entry; the extras+bound form was kept.
+- **CRLF line endings are NOT preserved in the inserted header** on either version: the new `#
+  /// script ... # ///` block is written with LF line endings, while the original file's body
+  (below the header) keeps its original CRLF endings untouched. This produces a *mixed*
+  line-ending file if the original was CRLF throughout -- confirmed via byte-level hexdump
+  inspection on both uv versions. This is cosmetic, not functional (Python's own parser and any
+  reasonable editor handle mixed line endings fine), but should be mentioned in the feature's
+  log/doc text so a Windows user who diffs their file isn't surprised.
+- **Paths containing spaces work correctly** on both versions, given proper `"..."` quoting of
+  the script path argument -- confirms the design's `"%HP_ENTRY%"` quoting approach is necessary
+  and sufficient.
+- **CONFIRMED: an existing `.lock` sidecar gets silently rewritten** as an automatic side effect
+  of `uv add --script`, on both versions -- directly reproduced (mtime change, new package
+  content appearing in the lock) with zero flags set. **Confirmed the exact filename convention**:
+  `<script-name>.py` -> `<script-name>.py.lock` (verified directly, not assumed).
+  - **Also tested**: `--frozen` *does* suppress the lockfile rewrite on 0.11.28 (mtime unchanged,
+    new package not written into the lock), while still updating the `.py` header itself and
+    without raising an error -- despite uv's own stderr text calling `--frozen` "a no-op for
+    Python scripts with inline metadata." A quick follow-up check (`uv run --script ... --locked`
+    against the now-out-of-sync lock) did not immediately surface an error either, which is
+    surprising given `--locked`'s documented "assert lockfile unchanged" semantics. **This
+    `--frozen` behavior is interesting but NOT adopted for v1** -- relying on an undocumented,
+    seemingly-inconsistent interaction (a flag whose own warning text calls it a no-op, yet it
+    measurably changes behavior) is riskier than the simpler original design decision: if a
+    `.lock` file already exists, skip the write-back entirely. This respects a user who has
+    opted into uv's stricter locked workflow and avoids scope creep into lockfile maintenance
+    (hash verification, transitive pinning) which is a much bigger commitment than "write the
+    dependency list."
+- **CONFIRMED: trailing whitespace on the closing `# ///` fence causes the same hard error
+  (exit 2, file untouched)** as gross TOML syntax errors, on both versions -- directly reproduces
+  GitHub issue #10918's report. The malformed-header repair path must treat this as just another
+  case of "uv said exit 2" (see Part 2's decision not to build a bespoke pre-validator), not a
+  special case needing its own detection logic.
+- **Duplicate-metadata-block test was inconclusive.** Attempted to reproduce the specific
+  behavior change from PR #19544 ("reject duplicate script metadata blocks," landed ~0.11.17,
+  previously silently treated as postlude). The synthetic test used (two complete, well-formed
+  `# /// script ... # ///` block pairs back to back) produced an identical hard TOML-parse error
+  on *both* 0.8.17 and 0.11.28 -- meaning this specific construction doesn't cleanly isolate the
+  changelog's described behavior difference (the "silently treated as postlude" case likely
+  requires a more specific malformed shape than what was tested here). **Do not treat this as
+  "the risk doesn't exist"** -- it's a genuine gap in this testing pass, not a disproof of the
+  changelog entry. The practical design implication stands regardless: the repair step's block-
+  stripping regex must remove the *entire* old block cleanly, with no stray remnant that could
+  read as a second block under any uv version's rules.
+- **CONFIRMED: `VIRTUAL_ENV` set in the calling environment produces only a benign stderr
+  warning** (`does not match the script environment path ... and will be ignored`), exit code
+  still 0. Confirms the design point that stderr text must never be treated as a failure signal
+  by itself -- only the process exit code should determine success/failure.
+
+---
+
+## Part 2: Code-grounded implementation plan
+
+This section was produced by tracing the actual `run_setup.bat` (verify current line numbers
+before implementing -- the file changes between now and whenever this is picked up; treat these
+as strong pointers, not guaranteed-stable line anchors).
+
+### 2.0 Corrections to the original (2026-07-11) design, found by reading the live code
+
+1. **"Malformed header detection already exists" is only half true.** `:extract_pep723_requirements`
+   is a naive PowerShell line-scanner, not a TOML validator -- it treats "block found but yielded
+   zero deps" as the malformed signal, a weak proxy that will not necessarily agree with uv's real
+   TOML parser on edge cases (e.g. the trailing-whitespace case above would likely not be caught by
+   this exact-string check either). **Decision: do not build a second bespoke pre-validator.**
+   Delegate malformed-detection entirely to uv itself via an attempt-first/strip-on-failure
+   sequence (Part 2.2). This is more robust against version drift than hand-rolling TOML
+   validation, since it automatically inherits whatever uv's authors decide "malformed" means,
+   release to release.
+2. **The literal log-contract string in the original design is unsafe as written.**
+   `docs/agent-lessons-learned.md`'s "`:log` echoes UNQUOTED" section is explicit: `:log` does
+   `echo %date% %time% %MSG%` with no quoting, so a literal `<`/`>` in the message text is parsed
+   by cmd as redirection and silently eats the log line (this bit the REQ-009 cascade once
+   already). The originally-proposed message `"[INFO] REQ-005: Wrote inferred dependencies into
+   <entry>.py's PEP 723 header..."` **must not** be implemented with literal angle brackets. Drop
+   the filename from the message entirely (recommended, matches several other REQ-005 log lines
+   that don't name the file), or accept the same already-documented risk the four existing
+   `%HP_ENTRY%`-in-`:log` call sites carry.
+3. **Exact hook points and a new state variable needed:**
+   - Fresh-install trigger: the `:lock_done` label (shared fallthrough for both conda and uv
+     after dependency install + lock-snapshot capture, right before the pyvisa/visa detection
+     comment). A single `if "%HP_ENV_MODE%"=="uv"` gate here covers both paths that can reach it.
+   - Warnfix trigger: between the `[REPAIR] rebuild complete after warnfix.` log line and the
+     `:warnfix_cascade_detect` call -- `~missing_modules.txt` and `~warnfix_repair_failed.flag`
+     are both still on disk at that point (deleted shortly after), so this is the only safe
+     window to read them.
+   - **Neither trigger point currently knows *which* packages actually installed successfully**
+     when the install command reports partial failure (a single `uv pip install -r
+     requirements.txt` covering N packages failing doesn't say which of the N failed). Given the
+     confirmed "uv never validates a package name" finding, adopt an **all-or-nothing
+     confirmation rule per trigger**: only attempt write-back when the *entire* install/repair
+     round is known to have fully succeeded, never a partial/best-guess subset. This is a
+     deliberate, conservative scope decision, not an oversight.
+4. **Re-entrancy.** The REQ-009 provider cascade re-enters `:after_env_mode_selection` from
+   scratch on every tier retry (documented in `docs/agent-interconnect.md`: *"Do not introduce
+   first-run-only state into `:after_env_mode_selection` without making it idempotent"*). The new
+   `HP_UV_INSTALL_OK` tracking variable (2.3 below) must be reset at the top of that label's
+   scope, alongside the existing `HP_DEP_SKIP`/`HP_DEP_RESULT` resets.
+
+### 2.1 New embedded-helper shape
+
+**One new Python helper, `tools/pep723_writeback.py`, embedded as `HP_PEP723_WRITEBACK`
+(`~pep723_writeback.py`)**, with a canonical `tools/` source and a PayloadSync test -- matching
+the more recent, more-scrutinized precedent (`collect_submodules.py`, `hidden_import_scan.py`)
+rather than the older embedded-only style.
+
+**Why a Python helper instead of inline batch `uv add --script pkg1 pkg2 ...`?** Assembling a
+space-joined, individually-quoted package-arg list in batch from a loop over `requirements.txt`
+requires delayed expansion (this repo's `agent-lessons-learned.md` explicitly warns against this,
+and `tests/harness.ps1` has static checks forbidding it), and any package spec containing `<`/`>`
+(a bare version constraint like `numpy<2`) would need extremely careful quoting to survive both
+CMD's own parsing and any eventual `:log` call describing the result. Python already owns this
+exact job pattern elsewhere in the repo (`~prep_requirements.py`).
+
+Invoked as:
+```
+"%HP_PY%" "~pep723_writeback.py" "%HP_ENTRY%" "%HP_UV_EXE%" "%HP_PY%" "<packages_file>"
+```
+where `<packages_file>` is a plain-text file (one requirement-spec-or-bare-name per line) that
+the batch caller has already produced by copying either `requirements.txt` (fresh trigger) or
+`~missing_modules.txt` (warnfix trigger). No parsing of loose CLI args happens on the batch side.
+
+**Helper logic:**
+1. Read the packages file; strip blank/`#`-comment lines. If empty, print `SKIP:no_packages`,
+   exit 0.
+2. Compute the lockfile sidecar path (`<entry>.py` -> `<entry>.py.lock`, confirmed convention)
+   and check existence; if present, print `SKIP:lockfile`, exit 0, **without ever invoking uv**.
+3. Run `uv add --script <entry> -p <python> <packages...>` via `subprocess.run`.
+   - Exit 0: print `OK:<n>` (n = package count passed), exit 0.
+   - Exit 2 (confirmed malformed-TOML signal, on both idle-syntax-error and trailing-whitespace
+     cases): **strip the entire existing `# /// script` ... `# ///` block** from the entry file
+     (tolerant regex matching both fence lines with optional trailing whitespace), then retry the
+     *same* `uv add --script` call exactly once. If the retry also fails, print
+     `ERROR:strip_retry_failed:<rc>`, exit 1 (operate on an in-memory copy; only write the file
+     if the retry is about to actually run).
+   - Any other non-zero exit: print `ERROR:uv_rc_<n>`, exit 1. Do not attempt further repair --
+     best-effort failure, consistent with "never gating."
+4. **Never treat stderr text as a failure signal by itself** (confirmed benign stderr can occur,
+   e.g. the `VIRTUAL_ENV` warning) -- success/failure is determined solely by the process return
+   code.
+5. Never call `uv add --script` with a package name that wasn't already present in the input
+   file -- this helper performs zero independent package-name inference; it is purely a
+   plumbing/CLI-safety layer over data the caller has already validated as "confirmed installed."
+
+The single stdout result line is read back into a batch variable via the same `for /f
+"usebackq delims=" %%R in ("~pep723_result.txt") do set "HP_PEP723_RESULT=%%R"` pattern already
+used for `~dep_check.py`'s result line, keeping the new code idiomatic with the rest of the file.
+
+Because the helper does the strip-and-retry internally, `run_setup.bat` never needs its own
+bespoke "detect malformed PEP 723 header" step for this feature -- it delegates entirely to uv's
+exit code (per 2.0's point 1), which is simpler and more future-proof than hardcoding today's
+understanding of "malformed" into a second parser that could silently diverge from uv's own
+evolving rules.
+
+### 2.2 Skip-condition checks (in order, short-circuit) and flag wiring
+
+New subroutine `:pep723_writeback`, called with one argument (`fresh` or `warnfix`) for log-
+message differentiation. Goto-based internal dispatch, not nested parens, per this repo's
+established cascade-dispatch convention.
+
+1. `if not "%HP_ENV_MODE%"=="uv" exit /b 0` -- v1 scope gate, silent (no log line at all, to
+   avoid log noise on every single non-uv run).
+2. `if defined HP_SKIP_PEP723_WRITEBACK ( call :log "[INFO] REQ-005: PEP 723 write-back skipped
+   (HP_SKIP_PEP723_WRITEBACK set)." & exit /b 0 )` -- new suppression-only flag (REQ-001 "flags
+   only suppress" rule).
+3. `if defined HP_CI_SKIP_ENV exit /b 0` -- defensive; technically unreachable given call-site
+   ordering, but cheap insurance against a future refactor.
+4. `if not defined HP_UV_EXE exit /b 0` / `if not defined HP_ENTRY exit /b 0` / `if not exist
+   "%HP_ENTRY%" exit /b 0` -- defensive precondition re-checks, matching this repo's general
+   subroutine-boundary style.
+5. **Trigger-specific "confirmed installed" gate** (new, from 2.0 point 3):
+   - Fresh trigger: `if not defined HP_UV_INSTALL_OK` -> skip with an `[INFO]` line explaining
+     the install did not fully succeed. `HP_UV_INSTALL_OK` is a **new** variable, set to `1`
+     inside the existing uv-install branch on genuine install success, and also set to `1` when
+     `HP_DEP_SKIP` short-circuited the install (already-satisfied-by-lock case -- still a
+     "confirmed installed" state). Reset to empty at the top of `:after_env_mode_selection` for
+     cascade re-entrancy correctness (2.0 point 4).
+   - Warnfix trigger: `if exist "~warnfix_repair_failed.flag"` -> skip (all-or-nothing per
+     round).
+6. **Existing `.lock` sidecar check** -- implemented inside the Python helper (2.1 step 2), not
+   in batch. Batch-side callers interpret the helper's `SKIP:lockfile` result and log accordingly
+   (no filename in the message, per the `:log` unquoted-metacharacter rule).
+7. **Optional, not load-bearing for v1**: an "already-authoritative, nothing changed" no-op check
+   -- when the run's dep source was already PEP 723 and the resolved set is unchanged from what's
+   already declared, skip the uv call entirely to avoid an unnecessary file touch on every run.
+   Since `uv add --script` is independently confirmed idempotent, correctness does not depend on
+   this optimization -- cutting it for v1 still produces a correct feature, just with one extra
+   no-op uv invocation per run on already-fully-annotated scripts. **Flagged as a nice-to-have,
+   safe to defer to a later pass.**
+
+**`HP_SKIP_PEP723_WRITEBACK` wiring**: declared alongside other `HP_SKIP_*` flags near the top of
+the file; documented in README's "Advanced Environment Variables" table as suppression-only, per
+REQ-001.
+
+**Log contract (revised for `:log` safety, per 2.0 point 2):**
+- Success: `[INFO] REQ-005: PEP 723 header write-back succeeded via uv add --script.` (no entry
+  filename, no raw package-spec text; a package count via a plain-decimal variable is fine if
+  wanted).
+- Each skip condition: its own `[INFO]`-level, operator-free, filename-free message, so log-
+  scraping tests can distinguish reasons.
+- Failure: `[WARN] REQ-005: PEP 723 header write-back failed (uv exit <n>); continuing.` where
+  `<n>` is a plain decimal exit code -- never gates the Prime Directive.
+
+### 2.3 CI test plan
+
+New file **`tests/selfapps_pep723_writeback.ps1`**, structured like `tests/selfapps_warnfix.ps1`
+(scenario-selected via an env var) and reusing the `Write-NdjsonRow` boilerplate pattern already
+duplicated across every `selfapps_*.ps1` file (no shared module exists in this repo -- follow
+that convention rather than introducing a new shared import). Each scenario spins up its own
+scratch directory, copies `run_setup.bat` in, writes a stub `.py`, runs the bootstrap, and asserts
+against both the log AND the entry file's own post-run content (this feature's whole point is a
+file mutation, so assertions must read the actual `.py` file, not just log text).
+
+| Test ID | Setup | Assertions |
+|---|---|---|
+| `self.pep723.writeback.fresh` | No existing header; stub imports `requests` (pipreqs/heuristic resolves `requests`+`certifi`); no `requirements.txt`/`pyproject.toml`. | Success log line present; entry file now contains a `# /// script` block with `requests`/`certifi` and a `requires-python` line. |
+| `self.pep723.writeback.idempotent` | Run the bootstrapper twice in the same scratch dir without deleting the entry file. | Entry file byte-identical after run 2 vs. run 1. |
+| `self.pep723.writeback.malformed` | Entry file pre-seeded with a deliberately broken `# /// script` block. | Success log line still appears (strip-then-retry worked); post-run entry file has a valid, freshly-written header, not the original broken block. |
+| `self.pep723.writeback.skipflag` | `HP_SKIP_PEP723_WRITEBACK=1`; no pre-existing header. | Entry file byte-identical before/after; skip-flag log line present. |
+| `self.pep723.writeback.warnfix` | Entry imports a module warnfix (not pipreqs) will discover, forcing the repair loop to fire during the build. | Both the warnfix repair AND a second write-back succeed; post-run header includes the warnfix-only-discovered module, proving the second trigger point fires. |
+| `self.pep723.writeback.trailing_ws_malformed` (new, from issue #10918) | Entry pre-seeded with an otherwise-valid header whose closing `# ///` fence has trailing whitespace. | Same success assertions as `.malformed` -- proves the strip-and-retry path handles this "looks fine to a human, invalid to a strict parser" case, and that the entire old block (not a stray remnant) got removed. |
+| `self.pep723.writeback.existing_lockfile` (new, from finding #2) | No pre-existing header, but a `<entry>.py.lock` sidecar is pre-created before the run. | Lockfile-skip log line present; entry `.py` file byte-identical before/after (no header written); the `.lock` file itself untouched -- proves the helper truly never invokes `uv add --script` in this case. |
+
+All scenarios need `HP_ENV_MODE` to actually resolve to `uv`; each test should assert that
+precondition explicitly and emit `skip=true` with reason `provider_not_uv` if a given CI lane
+doesn't reach uv (mirroring this suite's existing non-Windows-skip pattern, applied to a
+different precondition).
+
+**CI wiring**: add step(s) invoking the new test file in `.github/workflows/batch-check.yml`,
+gated to lanes where uv is the default provider (`real`/`cache`), explicitly NOT `conda-full`
+(which forces conda-only, out of v1 scope). Confirm the exact lane-to-provider mapping
+empirically (Part 3) rather than assuming.
+
+### 2.4 Docs to update in the same commit
+
+- `docs/agent-ndjson.md`: the 7 new row IDs, in a new subsection for whichever lane(s) the CI
+  wiring lands on.
+- `docs/agent-interconnect.md`: a new section near the existing `### warnfix install + uv mode`
+  and `### dep-check + uv mode lock file interconnection` sections, since this feature is a
+  direct sibling dependency of both. Cross-reference: REQ-002 entry selection, REQ-005's
+  `requirements.txt` snapshot timing (post-augmentation, not pre), uv-only `HP_UV_EXE`
+  availability, and the `HP_UV_INSTALL_OK` re-entrancy requirement.
+- `docs/agent-lessons-learned.md`: consider a small addendum to the existing "`:log` echoes
+  UNQUOTED" section noting this feature's near-miss (2.0 point 2), only if the implementation
+  actually needed the correction (per that doc's "record hazards actually hit" convention).
+- `README.md`: new REQ-005 sub-bullet (or a standalone `[REQ-005.11]`-style section, following the
+  `## [REQ-023] Venv Fallback Canary Probe` format: title, bullets, explicit Log contract, CI test
+  flag, Test NDJSON rows); new row in the "Advanced Environment Variables" table for
+  `HP_SKIP_PEP723_WRITEBACK=1`.
+- `CLAUDE.md`: move the Active Backlog pointer to this document into Closed Backlog once shipped,
+  following the existing Closed Backlog entry style -- what shipped, what was corrected from this
+  plan during implementation, "CLOSED by this PR."
+
+---
+
+## Part 3: Required first step before writing any code
+
+Before writing any `run_setup.bat` or helper code, the implementer must re-run an abbreviated
+version of the Part 1 empirical testing against whatever `uv` version is actually current at
+implementation time (this repo never pins uv, and Part 1 already directly demonstrated real
+behavior drift between 0.8.17 and 0.11.28, not just theoretical risk):
+
+1. Check `uv --version`.
+2. In a scratch directory, re-confirm: idempotency of repeated adds; malformed-header exit code
+   and untouched-file behavior; `requires-python` one-time-write behavior and `-p` control;
+   `--no-sync` no-op status; no package-existence validation; the trailing-whitespace-closing-
+   fence malformed case (issue #10918); the `<script>.py.lock` filename convention and its
+   auto-rewrite side effect.
+3. Record findings as a dated addendum to this document (in the style of Part 1's two existing
+   dated passes) before writing batch/Python code, so the design's assumptions are re-validated
+   against current reality rather than trusted from this document alone.
+
+---
+
+## Part 4: Sizing and iteration-slicing recommendation
+
+The core feature (fresh trigger + warnfix trigger + skip flag + happy-path tests) fits comfortably
+in this repo's "one feature slice per loop" norm. The additions from the code-grounded pass (the
+`HP_UV_INSTALL_OK` state, the lockfile-skip path, the two new adversarial-input test scenarios)
+push it closer to the edge of a single slice. **Recommended split if the single-loop budget feels
+tight:**
+
+- **Loop 1**: the two hook points, skip-condition logic, `tools/pep723_writeback.py`, and the
+  three simplest/most load-bearing tests (`fresh`, `idempotent`, `skipflag`) -- proves the
+  mechanism works end to end. All doc updates except the Closed Backlog move.
+- **Loop 2**: the four "resilience under adversarial input" tests (`malformed`, `warnfix`,
+  `trailing_ws_malformed`, `existing_lockfile`), CI workflow wiring, and the Closed Backlog move.
+
+Loop 1 alone already ships a working, tested feature; Loop 2 hardens it against the specific edge
+cases these two research passes surfaced, rather than being pure test-count padding.
+
+**Part 3's empirical re-verification step happens at the very start of Loop 1**, not as a
+separately schedulable task -- it directly determines whether the malformed-detection design in
+Part 2.1 still matches current uv behavior before any code is written against it.
+
+---
+
+## Critical files for implementation
+
+- `run_setup.bat` -- hook points at `:lock_done` and the warnfix repair block; new
+  `:pep723_writeback` subroutine and `HP_PEP723_WRITEBACK` base64 payload declaration.
+- `tools/pep723_writeback.py` (new) -- canonical helper source, following the
+  `tools/collect_submodules.py` / `tools/hidden_import_scan.py` PayloadSync-tested pattern.
+- `tests/selfapps_pep723_writeback.ps1` (new) -- following `tests/selfapps_warnfix.ps1`'s
+  scenario-selection structure and `tests/selfapps_ux_hardening.ps1`'s NDJSON boilerplate.
+- `tests/test_pep723_writeback.py` (new) -- following `tests/test_collect_submodules.py`'s
+  `PayloadSync` class pattern.
+- `.github/workflows/batch-check.yml` -- new CI step(s), gated to uv-default lanes.
+- `CLAUDE.md` -- Active Backlog pointer -> Closed Backlog move once shipped.


### PR DESCRIPTION
## Summary

Second research pass on the PEP 723 write-back feature (previously flagged "sounds worth pursuing" and asked to be tested/researched further before implementation).

**Local testing, extended and cross-checked against version drift:**
- Installed a second uv (0.11.28, current) alongside the previously-tested 0.8.17 and re-ran the full test matrix against both side by side. **Directly confirmed real version drift**: the default `uv add --script` write changed from a bare package name (0.8.17) to a version-bound one (0.11.28) — this was a doc-summary-based assumption corrected last time, and it turns out the correction itself was already stale by the time of testing, which is exactly the risk this repo's "never pin uv" philosophy predicts.
- New findings: extras syntax (`pandas[excel]`) merges/dedupes correctly; the inserted header uses LF while the original file's body keeps its own line endings (mixed-CRLF cosmetic side effect); paths with spaces work with proper quoting; an **existing `.lock` sidecar file gets silently auto-rewritten** with no suppression flag (confirmed the exact `<script>.py.lock` filename convention too); a trailing-whitespace closing fence reproduces GitHub issue #10918's malformed-header report exactly; a `VIRTUAL_ENV` set in the environment produces only a benign warning, never a failure.

**Web/docs/GitHub-issues research pass:**
- Found an **open, unresolved uv bug** (#15156) about stale cached resolution after `add --script` + `run --script` — assessed as not affecting this bootstrapper's own execution (it never calls `uv run --script` on the entry file) but a real limitation for the promoted file's future portability.
- Two historical write-path bugs (now fixed) around comment deletion and TOML-block adjacency — evidence this exact code path has had real correctness bugs before.
- Confirmed `autopep723` doesn't actually validate `uv add --script`'s write path (it has its own independent TOML writer) — removes an implicit assumption that a popular third-party tool's track record backs this specific command.

**Code-grounded implementation trace:**
- A design agent read the actual `run_setup.bat` and found the previous write-up's assumptions were only half right: the "malformed header detection already exists" claim doesn't hold up (it's a weak heuristic, not a real TOML validator), and the originally-proposed log message would have hit this repo's own documented `:log`-echoes-unquoted hazard. Also surfaced a real gap: neither trigger point currently knows *which* packages actually installed when a bulk install partially fails, leading to a deliberate all-or-nothing confirmation rule.

**Outcome**: promoted the whole design out of `CLAUDE.md`'s Active Backlog into its own document, `docs/plan-pep723-writeback.md` (mirroring the AV-Safe Build Path PRD's format, since it's now comparably deep), with exact hook points, a new embedded-helper design, an ordered skip-condition list, a 7-scenario CI test plan, a required first-step re-verification procedure (since uv drifts), a two-loop split recommendation, and every doc file that needs updating alongside implementation. `CLAUDE.md`'s backlog entry is now a short pointer. No `run_setup.bat` code changes — planning only, implementation-ready whenever picked up.

## Test plan
- [x] `python -m compileall -q .`
- [x] `python -m pyflakes .`
- [x] `python tools/check_delimiters.py run_setup.bat`
- [x] ASCII sweep (both files clean)
- [x] `python -m pytest tests/test_*.py -q` (215 passed, 2 skipped)
- [x] Docs-only change, no behavioral impact


---
_Generated by [Claude Code](https://claude.ai/code/session_015xbWLPbiaKVsobB9FZy8kS)_