### PR TITLE
Incorporate technical review feedback; promote REQ-019; new cross-platform/PayloadSync backlog items

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -559,6 +559,50 @@ a fact confirmed with no action needed, or a recurring/periodic check belongs in
    be permanently frozen into every already-distributed copy of `run_setup.bat`, with no way to
    walk it back later even after the reason for it stops being true. Read that section before
    extending Tier B's pinning pattern anywhere else in this codebase.
+8. **Cross-platform pre-flight checks (low-effort, low-risk, deliberately kept OUT of the PEP 723
+   write-back work -- its own small, fast follow-up loop once that ships).** Raised alongside a
+   3rd-party review of the PEP 723 plan (2026-07-12): three cheap, read-only checks worth adding
+   near the existing early-warning guards (OneDrive detection, path-length guard, REQ-025 disk
+   space) in `run_setup.bat`, all "observe and warn, never silently rewrite" per this repo's
+   existing posture:
+   - **Mac-garbage filter for entry detection.** `tools/find_entry.py`'s `is_py()` currently has no
+     exclusion for macOS AppleDouble files (`._main.py`) or a stray `__MACOSX/` folder left behind
+     when a Windows user unzips something a Mac user zipped -- a real, common, well-known
+     cross-platform papercut. Fix is a one-line addition to `is_py()`'s existing filter (already
+     excludes `~`-prefixed names; add a `._`-prefix exclusion the same way) plus skipping any
+     `__MACOSX` directory in the same walk. Needs a `PayloadSync`-covered re-sync of
+     `HP_FIND_ENTRY` afterward (see item 9) and a `tests/test_find_entry.py` case.
+   - **System-directory guard.** No check currently exists for the script root being under
+     `%WINDIR%`/`%PROGRAMFILES%` (a user occasionally drops a script into a system folder thinking
+     it "installs" it) -- the bootstrapper would just fail cryptically on write-permission errors
+     several steps in. A simple early check-and-abort with a clear plain-language message (mirrors
+     the existing OneDrive/path-length warnings' placement and tone) closes this.
+   - **Correction to a 3rd-party suggestion in the same review**: a "MAX_PATH warning" was also
+     proposed as new work -- **this already exists** (the path-length guard at the top of
+     `run_setup.bat`, warning when the script root approaches the 260-char cmd.exe limit). No
+     action needed there; noted here only so it isn't rediscovered as a gap later.
+9. **Promote the remaining embedded-only `HP_*` payloads to the canonical-source-plus-
+   `PayloadSync`-plus-logic-test pattern (moderate effort, not urgent, but a real, confirmed test-
+   coverage gap).** A payload-inventory audit done alongside the cross-platform-checks review
+   (2026-07-12; see README's "Rebuilding embedded helper payloads" section for the full inventory
+   table now recorded there) found that of 16 embedded `HP_*` payloads, only 6 have a canonical
+   `tools/` source file with a `PayloadSync` byte-equality test (`HP_COLLECT_SUBMODULES`,
+   `HP_EMBED_EXTRACT`, `HP_EMBED_PYVER_CHECK`, `HP_FIND_ENTRY`, `HP_HIDDEN_IMPORT_SCAN`,
+   `HP_PARSE_WARN`). Of the remaining 10 embedded-only payloads, `HP_CONDARC` is static config (not
+   code, doesn't need this), and `HP_FAST_CHECK`/`HP_PREP_REQUIREMENTS` at least have their logic
+   tested in place (`tests/test_fast_check_pattern.py`/`tests/test_heuristics.py`, just not against
+   a separate canonical source) -- but **`HP_DEP_CHECK`, `HP_DETECT_PY`, `HP_DETECT_VISA`,
+   `HP_ENV_STATE`, `HP_FAILFAST_PROBE`, and `HP_PYPROJ_DEPS` currently have zero automated test
+   coverage of any kind**, despite several doing genuinely non-trivial logic (`HP_DETECT_PY`'s
+   multi-tier `runtime.txt`/`pyproject.toml` version-detection precedence -- referenced constantly
+   elsewhere in these docs as load-bearing; `HP_PYPROJ_DEPS`'s TOML-with-regex-fallback parser).
+   Recommended approach when picked up: extract each into a `tools/<name>.py` canonical source
+   (mirroring the `collect_submodules.py`/`hidden_import_scan.py` precedent), add a `PayloadSync`
+   test asserting embedded-base64-matches-source, and add at least minimal logic-level unit tests
+   -- sized as several small, independent loops (one payload at a time), not one big one, since
+   each payload's logic is unrelated to the others. Not urgent (no bug has been traced to any of
+   these gaps), but real, and the highest-value place to start is `HP_DETECT_PY` given how central
+   its output is to the rest of the bootstrap.
 
 *(Item 5 from the pre-existing "cosmetic log noise/path doubling" debrief note was checked
 briefly per standing instruction not to over-invest: no `--distpath`/`--workpath` override or

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This tool is for beginners or unfamiliar users who have been given Python code a
 
 > **You:** Head of Cybersecurity Jim sent me a Python file he AI-vibe-coded to solve all my problems, but I don't know what Python is.
 >
-> **Me:** Try installing [uv](https://github.com/astral-sh/uv/releases/latest/download/uv-x86_64-pc-windows-msvc.zip), or open PowerShell, paste `irm https://astral.sh/uv/install.ps1 | iex` to install it, restart your terminal, then type `uvx autopep723 solve_my_probs.py`.
+> **Me:** Put the Python file in its own folder, open PowerShell in that folder (Shift+right-click -> "Open PowerShell window here"), paste `irm https://astral.sh/uv/install.ps1 | iex` to install uv, restart the terminal, then type `uvx autopep723 solve_my_probs.py`. First run might take a minute or two.
 >
 > **You:** Wow, that was fast! Worked great once I figured out how to open a terminal for the first time (never doing that again).
 >
@@ -505,7 +505,7 @@ blip or a temporary outage.
 
 ---
 
-## Advanced Environment Variables (reference)
+## [REQ-019] Environment-Variable Flags Are Scaffolding, Never a Gate
 
 **Intended run paths are double-click and drag-and-drop, with no environment variables set.** All
 `HP_*` and `PVW_*` environment variables are **test/CI/super-user scaffolding only**. No intended
@@ -514,6 +514,15 @@ never block a Prime-Directive outcome: a flag may add diagnostic/CI behavior or 
 override, or suppress an optional step (so absence == full behavior), but it is never the gate for
 a behavior the Prime Directive needs. The default no-flag run must still reach every fallback tier
 that gets the code running. Requirements and tests therefore exercise the no-flag path.
+
+This is a standing design constraint, not just reference documentation -- it was previously only
+stated in this section's own prose with no requirement number, even though `docs/agent-lessons-
+learned.md` and other internal docs already cited it informally as a load-bearing rule (the "Env-
+var flags are scaffolding" principle). Promoted to `[REQ-019]` so it can be cited unambiguously
+going forward, distinct from `[REQ-001]` (the Prime Directive itself, which this rule protects but
+does not replace).
+
+## Advanced Environment Variables (reference)
 
 Operational knobs, not needed for normal double-click use:
 
@@ -617,6 +626,28 @@ PY
 ```
 
 Update the corresponding `set "HP_*"=...` line under `:define_helper_payloads` with the new base64 text. The batch file comments point back to this section when further guidance is needed.
+
+**Payload inventory and PayloadSync coverage** (added so this is visible at a glance, instead of
+needing to grep the batch file or a research pass to find out): of the 16 embedded `HP_*`
+payloads, 6 have a canonical `tools/` source file *and* a dedicated `PayloadSync` unit test that
+asserts the embedded base64 is byte-for-byte in sync with that source (`HP_COLLECT_SUBMODULES` ->
+`tools/collect_submodules.py`, `HP_EMBED_EXTRACT` -> `tools/embed_extract.ps1`,
+`HP_EMBED_PYVER_CHECK` -> `tools/embed_pyver_check.py`, `HP_FIND_ENTRY` -> `tools/find_entry.py`,
+`HP_HIDDEN_IMPORT_SCAN` -> `tools/hidden_import_scan.py`, `HP_PARSE_WARN` ->
+`tools/parse_warn.py`; each is exercised by the matching `tests/test_*.py` file). The remaining
+10 (`HP_CONDARC`, `HP_DEP_CHECK`, `HP_DETECT_PY`, `HP_DETECT_VISA`, `HP_ENV_STATE`,
+`HP_FAILFAST_PROBE`, `HP_FAST_CHECK`, `HP_PREP_REQUIREMENTS`, `HP_PRINT_PYVER`, `HP_PYPROJ_DEPS`)
+are embedded-only, with no separate canonical source to sync against -- `HP_CONDARC` is static
+config text, not code, so this doesn't apply to it; `HP_FAST_CHECK` and `HP_PREP_REQUIREMENTS` at
+least have their *logic* covered by `tests/test_fast_check_pattern.py` /
+`tests/test_heuristics.py` (extracted and tested in place, just not against a separate source
+file); `HP_DEP_CHECK`, `HP_DETECT_PY`, `HP_DETECT_VISA`, `HP_ENV_STATE`, `HP_FAILFAST_PROBE`, and
+`HP_PYPROJ_DEPS` currently have **no automated test coverage of any kind** despite several of them
+(`HP_DETECT_PY`'s multi-tier version detection, `HP_PYPROJ_DEPS`'s TOML-with-regex-fallback
+parsing) doing genuinely non-trivial logic -- see `CLAUDE.md`'s Active Backlog for the tracked
+follow-up to promote these to the same canonical-source-plus-`PayloadSync`-plus-logic-test pattern
+as the 6 above. Any *new* embedded payload should default to the canonical-source-plus-
+`PayloadSync` pattern from the start rather than adding an 11th embedded-only exception.
 
 ## How CI decides pass/fail
 

--- a/docs/agent-lessons-learned.md
+++ b/docs/agent-lessons-learned.md
@@ -289,7 +289,13 @@ above.
 
 ---
 
-## Env-var flags are scaffolding, not intended run paths (REQ-001)
+## Env-var flags are scaffolding, not intended run paths (REQ-019)
+
+**Note (2026-07-12): this section's own title previously cited "(REQ-001)" ambiguously.**
+`[REQ-001]` in README.md is the Prime Directive itself, not this rule -- this rule *protects*
+REQ-001, it isn't numbered as it. The rule described here now has its own proper number,
+`[REQ-019]`, promoted from README's previously-unnumbered "Advanced Environment Variables"
+section specifically so it stops needing an ambiguous cross-reference like this one.
 
 The intended run paths are **double-click and drag-and-drop with no environment variables**.
 Every `HP_*` / `PVW_*` variable is test/CI/super-user scaffolding. **No Prime-Directive outcome

--- a/docs/plan-pep723-writeback.md
+++ b/docs/plan-pep723-writeback.md
@@ -27,6 +27,46 @@ doesn't depend on `pipreqs` (which this repo already treats with some wariness -
 **entry file only** (not every `.py` file in the folder). Replicating to conda/venv/embed/system
 lanes is explicitly a later step.
 
+## Big picture: how this fits with pipreqs, `autopep723`, and the existing dependency-source chain
+
+Added 2026-07-12 in response to a direct question about how all the pieces relate -- worth stating
+plainly since it's easy to conflate this feature with a bigger discovery-mechanism change it is
+NOT:
+
+- **This is not "running `autopep723` up front."** `autopep723` (the community tool) is not used
+  anywhere in this design, in any capacity -- it was researched purely as prior art/comparison
+  (Part 1's Pass 2, finding 5). This feature calls uv's own native `uv add --script` directly.
+- **REQ-005.1's dependency-source discovery order is completely unchanged**: PEP 723 (if present
+  and valid) > `pyproject.toml` > `requirements.txt` > `requirements.auto.txt` (pipreqs, non-
+  authoritative) > empty. `pipreqs` is not being replaced, backed up, or run differently. This
+  feature does not touch discovery at all.
+- **This feature is a purely post-hoc, one-way promotion step**: it runs *after* dependencies are
+  already resolved and installed (via whichever source was actually authoritative for that run),
+  and writes the *final resolved set* into the entry file's PEP 723 header -- regardless of which
+  tier in REQ-005.1's chain actually supplied it. If PEP 723 was already the source, there's
+  nothing new to add (the "already authoritative" case, Part 2.2 point 7) and the call is a no-op.
+  If `requirements.txt` or pipreqs supplied it, this is the mechanism that promotes that inferred
+  set into the higher-priority, persistent PEP 723 form for next time.
+- **Yes, `requirements.txt`/`requirements.auto.txt` are still left behind too, unchanged, in
+  addition to the new PEP 723 header.** Nothing in this feature deletes or stops writing either
+  file -- they remain exactly as useful as they already are today (a plain-text fallback readable
+  without parsing TOML, and pipreqs's own inference record). No conflict: since PEP 723 is already
+  the *highest*-priority authoritative source per REQ-005.1, having a PEP 723 header present
+  automatically makes it win on the *next* run, with zero new precedence logic needed -- this falls
+  directly out of the existing rule, nothing new to build.
+- **"Append-only, never delete" symmetry with the `requirements.txt` process is already satisfied,
+  for free, by uv's own confirmed behavior** (Part 1, Pass 1: adding a new package never removes or
+  alters an existing entry). No additional robustness needs to be ported over from the
+  `requirements.txt`/pipreqs side -- the two processes already behave the same way on this specific
+  point, coincidentally, without either having been designed to match the other.
+- **Relationship to REQ-004's `runtime.txt` write-back**: this feature is conceptually a sibling
+  of REQ-004's existing "write back `runtime.txt` once the Python version is resolved" behavior --
+  both persist an inferred fact into an authoritative, git-committable file so a future run (by
+  this bootstrapper, or by anyone else who receives the file) starts from a documented, faster
+  starting point instead of re-inferring from scratch. The plan's REQ-005.11 write-up (Part 2.4)
+  should cross-reference REQ-004 explicitly as this pattern's existing precedent, rather than
+  presenting the write-back idea as something novel to this repo.
+
 ---
 
 ## Part 1: Empirical findings (both testing passes)
@@ -219,27 +259,87 @@ where `<packages_file>` is a plain-text file (one requirement-spec-or-bare-name 
 the batch caller has already produced by copying either `requirements.txt` (fresh trigger) or
 `~missing_modules.txt` (warnfix trigger). No parsing of loose CLI args happens on the batch side.
 
-**Helper logic:**
+**Helper logic** (steps 2-3 below added/revised 2026-07-12 per a 3rd-party technical review;
+see the Non-Goals section right after this one for what was deliberately *not* adopted from the
+same review):
 1. Read the packages file; strip blank/`#`-comment lines. If empty, print `SKIP:no_packages`,
    exit 0.
-2. Compute the lockfile sidecar path (`<entry>.py` -> `<entry>.py.lock`, confirmed convention)
+2. **Encoding pre-check (new).** Attempt `open(entry_path, encoding="utf-8").read()` in a
+   `try/except UnicodeDecodeError`. If it fails, print `SKIP:non_utf8`, exit 0, **without ever
+   invoking uv**. Rationale: uv is Rust-based and its own file I/O behavior on a non-UTF-8 source
+   (a legacy Windows-1252/"ANSI" file, or UTF-16LE from an old PowerShell `>` redirect) was not
+   empirically tested in either research pass -- it's genuinely unknown whether uv errors safely
+   or performs a lossy read/write that could silently replace non-ASCII bytes with the Unicode
+   replacement character, corrupting the user's actual source code. Given that ambiguity, a cheap
+   pre-check that sidesteps the question entirely (never hand uv a file we haven't confirmed is
+   UTF-8) is safer than relying on uv's undetermined behavior. This also means the empirical
+   re-verification step in Part 3 should add "does uv corrupt or safely reject a non-UTF-8 file"
+   as an explicit thing to test once -- if it turns out uv already handles this safely, this
+   pre-check becomes a harmless no-op, not a wrong design; if it doesn't, this pre-check is load
+   -bearing. Either way, ship the pre-check regardless of that outcome, since it costs one cheap
+   file read.
+3. **File-lock canary (new, diagnostic-quality, not a correctness fix).** Attempt
+   `open(entry_path, "r+b")` in a `try/except PermissionError`, then immediately close it without
+   writing. If it fails, print `SKIP:file_locked`, exit 0, without invoking uv. **Important
+   framing correction from the original review**: this is not closing a real safety gap -- the
+   existing "any non-zero uv exit is caught by the generic `ERROR:uv_rc_<n>` path and never
+   gates the Prime Directive" design already handles a locked file safely today, just with a less
+   specific log message (uv would presumably fail with some non-zero exit on a locked file, which
+   the catch-all in step 5 below already treats as a safe, non-fatal failure). This canary's only
+   real value is a clearer, more specific skip reason in logs/tests rather than a generic error
+   code -- worth adding since it's cheap, but not worth treating as a show-stopper fix the way the
+   original review framed it. There is an inherent, accepted TOCTOU race (the lock could be
+   acquired between this check and the actual `uv add --script` call) -- this is fine precisely
+   because the fallback for that race is the same already-safe generic error path, not a crash.
+4. Compute the lockfile sidecar path (`<entry>.py` -> `<entry>.py.lock`, confirmed convention)
    and check existence; if present, print `SKIP:lockfile`, exit 0, **without ever invoking uv**.
-3. Run `uv add --script <entry> -p <python> <packages...>` via `subprocess.run`.
+5. Run `uv add --script <entry> -p <python> <packages...>` via `subprocess.run`.
    - Exit 0: print `OK:<n>` (n = package count passed), exit 0.
-   - Exit 2 (confirmed malformed-TOML signal, on both idle-syntax-error and trailing-whitespace
-     cases): **strip the entire existing `# /// script` ... `# ///` block** from the entry file
-     (tolerant regex matching both fence lines with optional trailing whitespace), then retry the
-     *same* `uv add --script` call exactly once. If the retry also fails, print
-     `ERROR:strip_retry_failed:<rc>`, exit 1 (operate on an in-memory copy; only write the file
-     if the retry is about to actually run).
+   - Exit 2 (confirmed malformed-TOML signal, on both plain-syntax-error and trailing-whitespace
+     cases -- the latter is specifically **GitHub issue #10918**; cite that issue number in the
+     code comment next to this branch, per this repo's convention of tagging non-obvious
+     constraints with their reason): **strip the entire existing `# /// script` ... `# ///`
+     block** from the entry file, then retry the *same* `uv add --script` call exactly once.
+     **Implementation note, corrected from the original design's "tolerant regex" language**: do
+     NOT implement this as a single `re.DOTALL`-style regex spanning the whole file -- a greedy
+     match risks stripping the user's actual code that follows the block, and a lazy match risks
+     leaving a stray fence line behind (which, per **PR astral-sh/uv#19544**'s "reject duplicate
+     script metadata blocks" change, could itself become a NEW hard-error on a sufficiently recent
+     uv even though it wasn't previously -- cite that PR number in the code comment here too).
+     Instead, iterate the file **line by line**, tracking a simple `in_block` boolean: start
+     dropping lines when a line matches `^# /// script\s*$`-ish, keep dropping through and
+     including the line that matches `^# ///\s*$` (tolerant of trailing whitespace, addressing
+     #10918 directly), then stop. This is a small state machine, not a regex, and is much safer
+     against both under- and over-matching on arbitrary user code. If the retry also fails, print
+     `ERROR:strip_retry_failed:<rc>`, exit 1 (operate on an in-memory copy; only write the file if
+     the retry is about to actually run).
    - Any other non-zero exit: print `ERROR:uv_rc_<n>`, exit 1. Do not attempt further repair --
-     best-effort failure, consistent with "never gating."
-4. **Never treat stderr text as a failure signal by itself** (confirmed benign stderr can occur,
-   e.g. the `VIRTUAL_ENV` warning) -- success/failure is determined solely by the process return
-   code.
-5. Never call `uv add --script` with a package name that wasn't already present in the input
+     best-effort failure, consistent with "never gating." This is also the path a locked file or
+     a read-only file (Windows Read-Only attribute, common on files pulled from a network share or
+     extracted from a strict archive) falls into if the new canary checks above don't catch it
+     first -- already safe by construction, nothing further needed for that case.
+6. **Never treat stderr text as a failure signal by itself** (confirmed benign stderr can occur,
+   e.g. **GitHub issue #15956**'s `VIRTUAL_ENV` warning -- cite that issue number in the code
+   comment near wherever stderr is captured-but-ignored) -- success/failure is determined solely
+   by the process return code.
+7. Never call `uv add --script` with a package name that wasn't already present in the input
    file -- this helper performs zero independent package-name inference; it is purely a
    plumbing/CLI-safety layer over data the caller has already validated as "confirmed installed."
+
+### Non-Goals & Safety (added 2026-07-12, to prevent scope creep once implementation starts)
+
+- **No line-ending normalization, anywhere, ever.** The helper must never rewrite the whole
+  entry file to a consistent line-ending style, even though the inserted header uses LF while
+  the original file's body keeps whatever it already had (Part 1's confirmed mixed-line-ending
+  finding). Normalizing is explicitly out of scope: it risks disrupting the user's own git
+  history (`core.autocrlf` interactions) and breaking Docker/WSL workflows that may depend on the
+  file's existing line endings -- a much bigger, riskier scope expansion than this feature's
+  actual job. Surgical edits only: touch the metadata block, never anything else in the file.
+- **No encoding "fixes."** If the encoding pre-check (helper step 2) fails, the helper skips and
+  moves on -- it does not attempt to detect the actual encoding, transcode the file, or otherwise
+  "help." File-parsing/encoding responsibility for the user's own source stays strictly with
+  whatever the user's own tooling already does; this bootstrapper observes and skips, it does not
+  silently rewrite.
 
 The single stdout result line is read back into a batch variable via the same `for /f
 "usebackq delims=" %%R in ("~pep723_result.txt") do set "HP_PEP723_RESULT=%%R"` pattern already
@@ -260,8 +360,10 @@ established cascade-dispatch convention.
 1. `if not "%HP_ENV_MODE%"=="uv" exit /b 0` -- v1 scope gate, silent (no log line at all, to
    avoid log noise on every single non-uv run).
 2. `if defined HP_SKIP_PEP723_WRITEBACK ( call :log "[INFO] REQ-005: PEP 723 write-back skipped
-   (HP_SKIP_PEP723_WRITEBACK set)." & exit /b 0 )` -- new suppression-only flag (REQ-001 "flags
-   only suppress" rule).
+   (HP_SKIP_PEP723_WRITEBACK set)." & exit /b 0 )` -- new suppression-only flag (per README's now-
+   numbered `[REQ-019]` "flags only suppress" rule -- promoted from an unnumbered reference section
+   to its own requirement, 2026-07-12, specifically so it has a stable number to cite instead of
+   the ambiguous "see the Advanced Environment Variables section" phrasing earlier drafts used).
 3. `if defined HP_CI_SKIP_ENV exit /b 0` -- defensive; technically unreachable given call-site
    ordering, but cheap insurance against a future refactor.
 4. `if not defined HP_UV_EXE exit /b 0` / `if not defined HP_ENTRY exit /b 0` / `if not exist
@@ -272,24 +374,31 @@ established cascade-dispatch convention.
      the install did not fully succeed. `HP_UV_INSTALL_OK` is a **new** variable, set to `1`
      inside the existing uv-install branch on genuine install success, and also set to `1` when
      `HP_DEP_SKIP` short-circuited the install (already-satisfied-by-lock case -- still a
-     "confirmed installed" state). Reset to empty at the top of `:after_env_mode_selection` for
-     cascade re-entrancy correctness (2.0 point 4).
+     "confirmed installed" state). **Must be reset with the literal, explicit form
+     `set "HP_UV_INSTALL_OK="` (nothing after the `=`)** at the top of `:after_env_mode_selection`,
+     alongside the existing `HP_DEP_SKIP`/`HP_DEP_RESULT` resets, for cascade re-entrancy
+     correctness (2.0 point 4) -- called out explicitly here because a provider-cascade downgrade
+     (e.g. uv exhausted, cascading to conda) that fails to clear this variable would let a stale
+     `HP_UV_INSTALL_OK=1` from the *previous*, now-abandoned uv attempt silently satisfy this gate
+     on a later, unrelated trigger.
    - Warnfix trigger: `if exist "~warnfix_repair_failed.flag"` -> skip (all-or-nothing per
      round).
-6. **Existing `.lock` sidecar check** -- implemented inside the Python helper (2.1 step 2), not
+6. **Existing `.lock` sidecar check** -- implemented inside the Python helper (2.1 step 4), not
    in batch. Batch-side callers interpret the helper's `SKIP:lockfile` result and log accordingly
    (no filename in the message, per the `:log` unquoted-metacharacter rule).
-7. **Optional, not load-bearing for v1**: an "already-authoritative, nothing changed" no-op check
-   -- when the run's dep source was already PEP 723 and the resolved set is unchanged from what's
-   already declared, skip the uv call entirely to avoid an unnecessary file touch on every run.
-   Since `uv add --script` is independently confirmed idempotent, correctness does not depend on
-   this optimization -- cutting it for v1 still produces a correct feature, just with one extra
-   no-op uv invocation per run on already-fully-annotated scripts. **Flagged as a nice-to-have,
-   safe to defer to a later pass.**
+7. **REJECTED, not merely deferred: no "already-authoritative, nothing changed" no-op
+   optimization.** The original draft flagged this as an optional nice-to-have (skip the uv call
+   entirely when the resolved set already matches an existing PEP 723 header, to avoid an
+   unnecessary file touch). Per a 2026-07-12 review: **do not build this at all, in v1 or later.**
+   `uv add --script` is independently confirmed idempotent and fast on a no-op case -- the
+   Python-side cost of parsing the existing header, comparing it against the resolved set, and
+   branching on the result is real, ongoing code-maintenance surface for a benefit (skipping one
+   harmless, fast, idempotent uv call) that doesn't justify it. This is a permanent scope
+   decision, not a "not yet."
 
 **`HP_SKIP_PEP723_WRITEBACK` wiring**: declared alongside other `HP_SKIP_*` flags near the top of
-the file; documented in README's "Advanced Environment Variables" table as suppression-only, per
-REQ-001.
+the file; documented in README's "Advanced Environment Variables" table and cross-referenced to
+`[REQ-019]`.
 
 **Log contract (revised for `:log` safety, per 2.0 point 2):**
 - Success: `[INFO] REQ-005: PEP 723 header write-back succeeded via uv add --script.` (no entry
@@ -319,11 +428,25 @@ file mutation, so assertions must read the actual `.py` file, not just log text)
 | `self.pep723.writeback.warnfix` | Entry imports a module warnfix (not pipreqs) will discover, forcing the repair loop to fire during the build. | Both the warnfix repair AND a second write-back succeed; post-run header includes the warnfix-only-discovered module, proving the second trigger point fires. |
 | `self.pep723.writeback.trailing_ws_malformed` (new, from issue #10918) | Entry pre-seeded with an otherwise-valid header whose closing `# ///` fence has trailing whitespace. | Same success assertions as `.malformed` -- proves the strip-and-retry path handles this "looks fine to a human, invalid to a strict parser" case, and that the entire old block (not a stray remnant) got removed. |
 | `self.pep723.writeback.existing_lockfile` (new, from finding #2) | No pre-existing header, but a `<entry>.py.lock` sidecar is pre-created before the run. | Lockfile-skip log line present; entry `.py` file byte-identical before/after (no header written); the `.lock` file itself untouched -- proves the helper truly never invokes `uv add --script` in this case. |
+| `self.pep723.writeback.non_utf8` (new, added 2026-07-12 per technical review) | Entry file's body written with a deliberately non-UTF-8 encoding (e.g. Windows-1252 with a byte sequence like `\x93...\x94` "smart quotes" that isn't valid UTF-8), no pre-existing header. | Skip log line present (`SKIP:non_utf8` surfaced as an `[INFO]` line); entry file byte-identical before/after -- proves the encoding pre-check prevents ever handing a non-UTF-8 file to uv, regardless of what uv itself would have done with it. |
 
 All scenarios need `HP_ENV_MODE` to actually resolve to `uv`; each test should assert that
 precondition explicitly and emit `skip=true` with reason `provider_not_uv` if a given CI lane
 doesn't reach uv (mirroring this suite's existing non-Windows-skip pattern, applied to a
 different precondition).
+
+**Test-fixture encoding, called out explicitly (a real risk specific to the CI harness, not the
+feature itself):** the `.idempotent` and `.skipflag` scenarios assert the entry file is **byte-
+identical** before/after. PowerShell's `Set-Content`/`Out-File` cmdlets do not default to plain
+UTF-8-without-BOM -- depending on PowerShell version they can default to UTF-16LE-with-BOM or
+add a BOM to UTF-8, and always write CRLF. If the test harness stubs the `.py` file using a bare
+`Set-Content`/`Out-File` call, a later `git checkout`/`core.autocrlf` normalization or an
+incidental BOM could make a byte-comparison fail even when the content is logically identical,
+producing a flaky or wrong test independent of the feature actually working. **Every stub-writing
+step in `tests/selfapps_pep723_writeback.ps1` must use an explicit, BOM-free UTF-8 encoding**
+(`Set-Content -Encoding utf8NoBOM` on PowerShell 6+, or the raw `[System.IO.File]::WriteAllText`
+.NET-API pattern this repo already prefers per `docs/agent-lessons-learned.md`'s "Prefer raw .NET
+types" entry) -- do not rely on a cmdlet default.
 
 **CI wiring**: add step(s) invoking the new test file in `.github/workflows/batch-check.yml`,
 gated to lanes where uv is the default provider (`real`/`cache`), explicitly NOT `conda-full`
@@ -332,8 +455,8 @@ empirically (Part 3) rather than assuming.
 
 ### 2.4 Docs to update in the same commit
 
-- `docs/agent-ndjson.md`: the 7 new row IDs, in a new subsection for whichever lane(s) the CI
-  wiring lands on.
+- `docs/agent-ndjson.md`: the 8 new row IDs (7 original + `.non_utf8`), in a new subsection for
+  whichever lane(s) the CI wiring lands on.
 - `docs/agent-interconnect.md`: a new section near the existing `### warnfix install + uv mode`
   and `### dep-check + uv mode lock file interconnection` sections, since this feature is a
   direct sibling dependency of both. Cross-reference: REQ-002 entry selection, REQ-005's
@@ -342,13 +465,25 @@ empirically (Part 3) rather than assuming.
 - `docs/agent-lessons-learned.md`: consider a small addendum to the existing "`:log` echoes
   UNQUOTED" section noting this feature's near-miss (2.0 point 2), only if the implementation
   actually needed the correction (per that doc's "record hazards actually hit" convention).
-- `README.md`: new REQ-005 sub-bullet (or a standalone `[REQ-005.11]`-style section, following the
-  `## [REQ-023] Venv Fallback Canary Probe` format: title, bullets, explicit Log contract, CI test
-  flag, Test NDJSON rows); new row in the "Advanced Environment Variables" table for
-  `HP_SKIP_PEP723_WRITEBACK=1`.
+- `README.md`: new **`[REQ-005.11]`** sub-section (following the `## [REQ-023] Venv Fallback
+  Canary Probe` format: title, bullets, explicit Log contract, CI test flag, Test NDJSON rows) --
+  explicitly cross-reference **REQ-004** (`runtime.txt` write-back) as this feature's existing
+  sibling precedent, per the Big Picture section above, so a reader doesn't have to independently
+  notice the two features share a design pattern; new row in the "Advanced Environment Variables"
+  table for `HP_SKIP_PEP723_WRITEBACK=1`, cross-referenced to `[REQ-019]`.
 - `CLAUDE.md`: move the Active Backlog pointer to this document into Closed Backlog once shipped,
   following the existing Closed Backlog entry style -- what shipped, what was corrected from this
   plan during implementation, "CLOSED by this PR."
+- **Code comments citing specific GitHub issues/PRs**, per this repo's existing "tag non-obvious
+  constraints with their reason" convention (`CLAUDE.md`'s Key Conventions table) -- not optional
+  polish, an explicit implementation requirement: the trailing-whitespace-fence handling in the
+  strip step (helper step 5) must cite **astral-sh/uv#10918**; the "why a line-by-line state
+  machine instead of a DOTALL regex" comment must cite **astral-sh/uv#19544** (the duplicate-
+  block-rejection change that motivates fully removing the old block, not just approximately);
+  the "why stderr is never treated as a failure signal" comment must cite **astral-sh/uv#15956**;
+  and, if the promoted file's future-portability limitation is mentioned anywhere user-facing or
+  in this plan's own README write-up, cite **astral-sh/uv#15156** (the open cache-staleness bug)
+  as the reason it's called out as a known limitation rather than silently ignored.
 
 ---
 
@@ -364,10 +499,34 @@ behavior drift between 0.8.17 and 0.11.28, not just theoretical risk):
    and untouched-file behavior; `requires-python` one-time-write behavior and `-p` control;
    `--no-sync` no-op status; no package-existence validation; the trailing-whitespace-closing-
    fence malformed case (issue #10918); the `<script>.py.lock` filename convention and its
-   auto-rewrite side effect.
+   auto-rewrite side effect; **and, new for this pass, `uv add --script`'s actual behavior against
+   a deliberately non-UTF-8-encoded target file** (Part 2.1 step 2's rationale) -- confirm whether
+   it errors safely, corrupts silently, or does something else, since this directly determines
+   whether the encoding pre-check is purely defensive insurance or an actually-load-bearing fix.
 3. Record findings as a dated addendum to this document (in the style of Part 1's two existing
    dated passes) before writing batch/Python code, so the design's assumptions are re-validated
    against current reality rather than trusted from this document alone.
+
+## Part 3.5: ongoing drift detection, not just a one-time dev check
+
+Part 3's re-verification is a **one-time** pass done once, right before implementation starts --
+but this repo's CI always fetches whatever uv is currently latest (the uv-first REQ-009
+philosophy, no pin), which means **every real CI run of `tests/selfapps_pep723_writeback.ps1`
+after this feature ships is itself an ongoing, automatic re-verification of these same
+assumptions against whatever uv actually is at that moment** -- not a one-time gate that goes
+stale the day after implementation. This is worth stating explicitly as the feature's real
+long-term safety net, and mirrors the "next-pin probe" maintenance pattern already documented in
+`CLAUDE.md`'s Periodic Maintenance Checks section for other never-pinned dependencies (`pipreqs`,
+the embed-tier Python table): an unexpected CI failure in one of these tests down the road is
+itself the signal that uv's behavior has drifted again, not a mysterious flake to explain away.
+**If/when that happens**, the fix loop is: re-run Part 3's scratch-dir re-verification against
+the new uv version, update this document with a new dated addendum (matching Part 1's existing
+two-pass pattern), and patch `tools/pep723_writeback.py` to match -- the same loop this document
+itself has already been through twice. This is also why every design decision in Part 2 that
+traces back to a specific uv issue/PR number is tagged as such (2.4's "code comments citing
+specific issues" requirement): a future maintainer debugging a CI failure in this area should be
+able to find the relevant upstream issue by name instead of re-deriving the reasoning from
+scratch.
 
 ---
 
@@ -379,11 +538,14 @@ in this repo's "one feature slice per loop" norm. The additions from the code-gr
 push it closer to the edge of a single slice. **Recommended split if the single-loop budget feels
 tight:**
 
-- **Loop 1**: the two hook points, skip-condition logic, `tools/pep723_writeback.py`, and the
-  three simplest/most load-bearing tests (`fresh`, `idempotent`, `skipflag`) -- proves the
-  mechanism works end to end. All doc updates except the Closed Backlog move.
-- **Loop 2**: the four "resilience under adversarial input" tests (`malformed`, `warnfix`,
-  `trailing_ws_malformed`, `existing_lockfile`), CI workflow wiring, and the Closed Backlog move.
+- **Loop 1**: the two hook points, skip-condition logic, `tools/pep723_writeback.py` (including
+  the encoding pre-check and file-lock canary from the 2026-07-12 review -- both are cheap enough
+  to belong in Loop 1, not deferred), and the three simplest/most load-bearing tests (`fresh`,
+  `idempotent`, `skipflag`) -- proves the mechanism works end to end. All doc updates except the
+  Closed Backlog move.
+- **Loop 2**: the five "resilience under adversarial input" tests (`malformed`, `warnfix`,
+  `trailing_ws_malformed`, `existing_lockfile`, `non_utf8`), CI workflow wiring, and the Closed
+  Backlog move.
 
 Loop 1 alone already ships a working, tested feature; Loop 2 hardens it against the specific edge
 cases these two research passes surfaced, rather than being pure test-count padding.


### PR DESCRIPTION
## Summary

Third pass on the PEP 723 write-back plan (following a 3rd-party technical review plus several direct follow-up questions), plus repo-wide housekeeping the same review prompted.

**`docs/plan-pep723-writeback.md` refinements:**
- Added an encoding pre-check (uv's UTF-8 file-handling on a non-UTF-8 source was never empirically tested — the pre-check sidesteps the question rather than guessing) and a file-lock canary check, correctly framed as a diagnostic-quality improvement rather than a correctness fix — the existing "never gating" catch-all already handles a locked or read-only file safely.
- Replaced a "tolerant regex" design for stripping a malformed header with an explicit line-by-line state machine — a DOTALL-style regex risks either eating the user's actual code or leaving a stray fence line that a newer uv could now hard-error on (per a real, cited upstream PR).
- Permanently rejected (not just deferred) an "already authoritative" no-op optimization, since uv's own confirmed idempotency already covers that case for free.
- Added a "Big Picture" section directly answering how this relates to `pipreqs`/`autopep723`: it's unrelated to dependency discovery, a pure post-hoc promotion step, `requirements.txt`/`requirements.auto.txt` stay untouched and left behind exactly as today, and the "append-only, never delete" symmetry with that process is already free from uv's own confirmed merge behavior.
- Added an explicit "ongoing CI drift detection" framing, distinct from the one-time pre-implementation re-verification step — since CI always fetches latest uv, every real test run after this ships is itself a standing regression check against uv's own behavior drift.
- Added a `non_utf8` CI test scenario and explicit BOM/encoding guidance for the test plan's existing byte-identical assertions (PowerShell's `Set-Content`/`Out-File` defaults can silently break a byte comparison).
- Required citing specific upstream GitHub issue/PR numbers in code comments wherever a design decision is driven by one.

**README.md:**
- Promoted the "env-var flags are scaffolding, never a gate" principle out of an unnumbered reference section into its own `[REQ-019]` — it was already being cited elsewhere as if it had a stable requirement number.
- Added a PayloadSync coverage inventory to "Rebuilding embedded helper payloads" so which of the 16 embedded payloads have real byte-equality test coverage (vs. embedded-only, vs. zero coverage of any kind) is visible without a research pass.
- Added a short folder-navigation step to the README's illustrative "Jim" dialogue.

**`docs/agent-lessons-learned.md`:** corrected an ambiguous `(REQ-001)` citation on the flags-are-scaffolding section to the new `[REQ-019]`.

**`CLAUDE.md`:** two new backlog items — three low-risk cross-platform pre-flight checks (a Mac AppleDouble/`__MACOSX` filter for entry detection, and a system-directory guard, both genuinely missing; a third suggested check, a `MAX_PATH` warning, turned out to already exist, so no action needed there); and promoting six embedded-only payloads with confirmed zero test coverage (`HP_DETECT_PY`, `HP_PYPROJ_DEPS`, `HP_DEP_CHECK`, `HP_ENV_STATE`, `HP_DETECT_VISA`, `HP_FAILFAST_PROBE`) to the canonical-source-plus-`PayloadSync` pattern the newer payloads already use.

No `run_setup.bat`/code changes — planning and documentation only.

## Test plan
- [x] `python -m compileall -q .`
- [x] `python -m pyflakes .`
- [x] `python tools/check_delimiters.py run_setup.bat`
- [x] `python -m yamllint .github/workflows/`
- [x] `actionlint -oneline .github/workflows/*.yml`
- [x] ASCII sweep (all touched files clean)
- [x] PowerShell AST parse sweep
- [x] `python -m pytest tests/test_*.py -q` (215 passed, 2 skipped)
- [x] Docs-only change, no behavioral impact


---
_Generated by [Claude Code](https://claude.ai/code/session_015xbWLPbiaKVsobB9FZy8kS)_