### PR TITLE
Fix destructive strip in PVW QuickStart's default run command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -603,36 +603,53 @@ a fact confirmed with no action needed, or a recurring/periodic check belongs in
    each payload's logic is unrelated to the others. Not urgent (no bug has been traced to any of
    these gaps), but real, and the highest-value place to start is `HP_DETECT_PY` given how central
    its output is to the rest of the bootstrap.
-10. **PVW QuickStart -- a standalone, non-`run_setup.bat` super-user command for running/persisting
-    a `.py` file's dependencies with no EXE build (full design at
-    `docs/plan-pvw-quickstart.md`).** Reviewed and independently re-verified a user-supplied
-    third-party "PEP 723 Megacommand" document proposing a single-paste PowerShell command family
-    (install uv, run via `uvx autopep723`, optionally persist deps back into the file's PEP 723
-    header). Confirmed the core claims directly (script execution, an encoding-corruption bug in
-    naive `Get-Content` reads and its `ISO-8859-1`-round-trip fix), and found a genuine
-    simplification the source document didn't have: `uv add --script` already preserves existing
-    pins and custom TOML keys on re-add (confirmed with fresh tests, not just trusted -- see
-    `plan-pep723-writeback.md`'s new "Pass 3" entry), so the source document's hand-rolled
-    TOML-merge "Option C" script (needing `tomli-w` and manual diffing) is unnecessary --
-    `autopep723 check` for discovery piped straight into `uv add --script` gets the same
-    safety natively. **Deliberately sequenced to ship AFTER `plan-pep723-writeback.md`** (that
-    plan is already implementation-ready and serves this repo's primary beginner audience; this
-    one is a secondary, opt-in, already-know-your-own-code audience -- see the new plan doc's own
-    "Sequencing decision" section for the full reasoning, including how implementing write-back
-    first avoids re-deriving the same uv-version confidence twice). **Architecture decision:**
-    ship as a standalone `pvw_quickstart.ps1`, not a `run_setup.bat` dispatch hook -- folding it
-    into `run_setup.bat` would mean either bypassing REQ-018's build-first-run-once safety
-    reasoning for a whole new execution mode or re-deriving a parallel copy of that reasoning just
-    for itself, for a feature whose entire value proposition is skipping that ceremony; the
-    hook-in shape (an opt-in `HP_QUICKSTART_MODE` flag) is recorded in the plan doc as a
-    deliberately-deferred fallback, not implemented. **README placement, not written yet:** a new,
-    not-near-the-top section, positioned either right after `## [REQ-015] Idempotent Git Config
-    Merge` or inside/after `## Python_vs_Windows and the "Deno for Python" Question` -- final call
-    deferred to implementation time; see the plan doc's own "README placement" section for the
-    reasoning behind both candidates. Open gaps carried over honestly from the source document,
-    not yet closed: real Windows PowerShell 5.1 is untested (this whole investigation, like the
-    source document's own, ran via `pwsh` on Linux); failed-`uv`-install and missing-file error UX
-    are both known-rough, not known-broken.
+10. **PVW QuickStart -- a super-user command set for running/persisting a `.py` file's
+    dependencies with no EXE build, shipped as copy-paste README commands (full design at
+    `docs/plan-pvw-quickstart.md`; user-facing commands live in README's "PVW QuickStart" section).**
+    Reviewed and independently re-verified a user-supplied third-party "PEP 723 Megacommand"
+    document proposing a single-paste PowerShell command family. Confirmed the core claims directly
+    (script execution, an encoding-corruption bug in naive `Get-Content` reads and its
+    `ISO-8859-1`-round-trip fix), and found a genuine simplification the source document didn't
+    have: `uv add --script` already preserves existing pins and custom TOML keys on re-add
+    (confirmed with fresh tests, not just trusted -- see `plan-pep723-writeback.md`'s "Pass 3"
+    entry), so the source document's hand-rolled TOML-merge "Option C" script (needing `tomli-w`
+    and manual diffing) is unnecessary -- `autopep723 check` for discovery piped straight into
+    `uv add --script` gets the same safety natively.
+
+    **Found and fixed a real, reproduced destructive-strip bug before shipping the default
+    command** (plan doc's "Pass 2"): the first version treated any nonzero exit from the initial
+    run identically -- strip the whole PEP 723 header and retry. Reproduced directly: a file with a
+    real pin, a custom TOML key, and a header merely missing one recently-added import triggered
+    the same blind strip as a genuinely malformed header, destroying the pin and custom key even
+    though the header itself was valid. Fixed by branching on the *exit code* (confirmed reliably
+    distinct: `2` means the header is unparseable TOML; any other nonzero means something else
+    failed, most commonly a valid-but-incomplete header) -- exit 0 does a best-effort additive
+    persist, exit 2 is the one case where stripping is correct, any other nonzero fills in what's
+    missing without ever stripping. Re-verified against the original reproduction case plus five
+    more scenarios (malformed header, double failure, missing file, non-UTF-8, idempotency) against
+    the exact command as shipped in README. This also changed the command's own contract: the
+    default "just run it" command now additively persists a header on every successful run, not
+    just on request -- README's text was updated to state this plainly rather than leave a stale
+    "never touches your file" claim in place.
+
+    **Deliberately sequenced to ship its design work AFTER `plan-pep723-writeback.md`** (that plan
+    is already implementation-ready and serves this repo's primary beginner audience; this one is a
+    secondary, opt-in, already-know-your-own-code audience -- see the plan doc's own "Sequencing
+    decision" section). **Architecture decision:** the shipped form is copy-paste README commands,
+    not a `run_setup.bat` dispatch hook -- folding it into `run_setup.bat` would mean either
+    bypassing REQ-018's build-first-run-once safety reasoning for a whole new execution mode or
+    re-deriving a parallel copy of that reasoning just for itself, for a feature whose entire value
+    proposition is skipping that ceremony; the hook-in shape (an opt-in `HP_QUICKSTART_MODE` flag)
+    is recorded in the plan doc as a deliberately-deferred fallback, not implemented. A standalone
+    downloadable `pvw_quickstart.ps1` file (same logic, packaged as a script instead of copy-paste
+    text) also remains not-yet-built -- see the plan doc's own "Critical files" list. **README
+    placement (shipped):** landed directly after `## Python_vs_Windows and the "Deno for Python"
+    Question`, before `## Known Limitations` -- not near the top, per the original request. Open
+    gaps carried over honestly from the source document, not yet closed: real Windows PowerShell
+    5.1 is untested (this whole investigation, like the source document's own, ran via `pwsh` on
+    Linux); failed-`uv`-install and missing-file error UX are both known-rough, not known-broken
+    (though the missing-file case is now confirmed to at least fail into the safe, non-destructive
+    branch rather than the strip branch).
 
 *(Item 5 from the pre-existing "cosmetic log noise/path doubling" debrief note was checked
 briefly per standing instruction not to over-invest: no `--distpath`/`--workpath` override or

--- a/README.md
+++ b/README.md
@@ -760,33 +760,71 @@ imports and either runs it in a throwaway environment or writes what it found in
 PEP 723 header.
 
 Every command below was tested directly against real `uv`/`autopep723` runs (not just read in
-docs) before being written here, including the two failure-handling paths (a broken existing
-header, and a non-ASCII byte in the file) -- see `docs/plan-pvw-quickstart.md` for the full
-verification trail if you want it. The one part that could not be tested in that pass is real
-Windows PowerShell 5.1 specifically (verified via `pwsh` 7 instead, which shares the same `.NET`
-APIs these commands rely on) -- if you hit something odd on an older PowerShell, that's the first
-place to look.
+docs) before being written here, including every failure-handling path (a genuinely broken
+header, a header that's merely incomplete, and a non-ASCII byte in the file) -- see
+`docs/plan-pvw-quickstart.md` for the full verification trail if you want it. The one part that
+could not be tested in that pass is real Windows PowerShell 5.1 specifically (verified via `pwsh`
+7 instead, which shares the same `.NET` APIs these commands rely on) -- if you hit something odd
+on an older PowerShell, that's the first place to look.
 
-### Just run it
+### Just run it (and remember what it needed)
 
 Open PowerShell in the folder with your script (Shift+right-click -> "Open PowerShell window
 here"), then paste:
 
 ```powershell
-irm https://astral.sh/uv/install.ps1 | iex; $env:Path = "$env:USERPROFILE\.local\bin;$env:Path"; $enc = [System.Text.Encoding]::GetEncoding("ISO-8859-1"); $f = "solve_my_probs.py"; $original = [System.IO.File]::ReadAllText((Get-Item $f).FullName, $enc); uvx autopep723 $f; if ($LASTEXITCODE -ne 0) { Write-Host "First attempt hit a snag with the file's dependency header - retrying with a clean version..."; [System.IO.File]::WriteAllText("$((Get-Item $f).FullName).bak", $original, $enc); $c = $original -replace "(?ms)^# /// script\r?\n.*?^# ///[ \t]*\r?\n?", ""; [System.IO.File]::WriteAllText((Get-Item $f).FullName, $c, $enc); uvx autopep723 $f; if ($LASTEXITCODE -ne 0) { Write-Host "Retry also failed - restoring your original file untouched."; [System.IO.File]::WriteAllText((Get-Item $f).FullName, $original, $enc) }; Remove-Item -ErrorAction SilentlyContinue "$f.bak" }
+irm https://astral.sh/uv/install.ps1 | iex; $env:Path = "$env:USERPROFILE\.local\bin;$env:Path"; $enc = [System.Text.Encoding]::GetEncoding("ISO-8859-1"); $f = "solve_my_probs.py"; $original = [System.IO.File]::ReadAllText((Get-Item $f).FullName, $enc); function Persist($f) { $chk = (uvx autopep723 check $f) -join "`n"; if ($LASTEXITCODE -ne 0) { return $false }; $names = [regex]::Matches($chk, '^#\s*"([^"]+)",?\s*$', 'Multiline') | ForEach-Object { $_.Groups[1].Value }; if ($names.Count -eq 0) { return $true }; uv add --script $f $names; return ($LASTEXITCODE -eq 0) }; uvx autopep723 $f; $rc = $LASTEXITCODE; if ($rc -eq 0) { if (Persist $f) { Write-Host "Ran successfully and remembered what it needed." } else { Write-Host "Ran successfully, but could not update the dependency header - nothing was changed there." } } elseif ($rc -eq 2) { Write-Host "Header is malformed - retrying with a clean version..."; [System.IO.File]::WriteAllText("$((Get-Item $f).FullName).bak", $original, $enc); $c = $original -replace "(?ms)^# /// script\r?\n.*?^# ///[ \t]*\r?\n?", ""; [System.IO.File]::WriteAllText((Get-Item $f).FullName, $c, $enc); uvx autopep723 $f; if ($LASTEXITCODE -eq 0) { if (Persist $f) { Write-Host "Ran successfully after repair and remembered a fresh header." } else { Write-Host "Ran successfully after repair, but could not update the header." } } else { Write-Host "Retry also failed - restoring your original file untouched."; [System.IO.File]::WriteAllText((Get-Item $f).FullName, $original, $enc) }; Remove-Item -ErrorAction SilentlyContinue "$f.bak" } else { Write-Host "Run failed with an existing header in place - trying to fill in any missing dependencies..."; Persist $f | Out-Null; uvx autopep723 $f; if ($LASTEXITCODE -eq 0) { Write-Host "Ran successfully after filling in missing dependencies." } else { Write-Host "Run still failed - this looks like a script-level issue, not a dependency gap, so nothing further was attempted." } }
 ```
 
 Change `solve_my_probs.py` to your file's name and run again if you're pasting this more than
-once. What it does: installs `uv`, scans your script's imports, provisions exactly what it needs,
-and runs it -- once. If your file already has a broken or stale PEP 723 header from a previous
-edit, it backs the file up to disk first, strips the broken header, and retries once, clean; if
-that also fails (e.g. the network drops mid-resolve), it restores your original file exactly and
-stops. It reads and writes the file byte-for-byte (not through a UTF-8-only text conversion), so a
-file saved in an older encoding is never silently corrupted along the way, and it never touches
-your file at all in the common case where nothing goes wrong. If you ever see a `<yourfile>.bak`
-file sitting next to your script afterward, that's the safety-net copy made right before the risky
-step -- it means something interrupted the run before cleanup could finish (a closed terminal, a
-lost connection); rename it back over the current file to get back to exactly where you started.
+once. What it does: installs `uv`, runs your script via a throwaway environment, and -- once the
+run actually succeeds -- remembers what it needed by writing (or updating) the file's own PEP 723
+header, the same **additive-merge, never-delete** approach `run_setup.bat` itself uses for
+`runtime.txt`/`requirements.txt`: an existing exact pin (`flask>=2.0`) or hand-added TOML key is
+never touched, only genuinely new dependencies get added.
+
+It only ever resets the header from scratch in one specific situation, and it's not "the run
+failed" in general: it's when the header itself is unparseable TOML (a real syntax error, not
+just an incomplete list) -- that's the one case where "keep what's there" genuinely isn't
+possible, so it backs up, replaces, and retries clean. Any *other* kind of failure -- most
+commonly a valid header that's just missing a recently-added import -- is treated as "add what's
+missing," never "start over." Concretely, it branches on *why* the first attempt failed, not just
+whether it failed:
+
+- **Ran clean:** best-effort remembers what it needed, now that the run has actually confirmed it
+  works.
+- **Header is genuinely malformed:** the one case where starting over is correct -- backs up,
+  strips the broken header, retries clean, and remembers a fresh header if the retry succeeds.
+- **Ran but failed for some other reason** (most often a valid header just missing an import):
+  fills in what's missing *without* touching anything else already in the header, then retries
+  once.
+
+If you ever see a `<yourfile>.bak` file sitting next to your script afterward, that's the
+safety-net copy made right before the one destructive step above (a genuinely malformed header) --
+it means something interrupted the run before cleanup could finish (a closed terminal, a lost
+connection); rename it back over the current file to get back to exactly where you started. It's
+never created for the other two outcomes, since neither one ever removes anything from the file to
+begin with.
+
+**One thing to know if you rename the file later:** `uv` has an open caching issue
+([astral-sh/uv#15156](https://github.com/astral-sh/uv/issues/15156)) where running the same
+filename with a different dependency set can occasionally serve a stale cached resolution --
+relevant here because this command's whole point is to leave behind a header a later, independent
+`uv run` will pick up. If a promoted file behaves oddly after you've changed its imports, renaming
+the file or clearing `~/.cache/uv` resolves it; it's a known upstream quirk, not something wrong
+with your file.
+
+It reads and writes the file byte-for-byte (not through a UTF-8-only text conversion), so a file
+saved in an older encoding is never silently corrupted along the way -- an unreadable file safely
+falls into the "some other reason" branch above and is left untouched, exactly like any other
+non-dependency failure.
+
+**Fine print:** in the "ran but failed for some other reason" branch, if the retry (after filling
+in what looked missing) *also* fails -- for instance the script has a real bug unrelated to any
+dependency -- that fill-in is not rolled back. This is deliberate, not an oversight: `uv add
+--script`'s writes are already confirmed atomic (never partial), so the header at worst ends up
+*more* correct (whatever was genuinely missing really was needed) even though the script itself
+still needs a real fix -- never silently wrong data, just not undone.
 
 The same thing, spaced out if you'd rather read it before pasting:
 
@@ -796,18 +834,51 @@ $env:Path = "$env:USERPROFILE\.local\bin;$env:Path"
 $enc = [System.Text.Encoding]::GetEncoding("ISO-8859-1")
 $f = "solve_my_probs.py"
 $original = [System.IO.File]::ReadAllText((Get-Item $f).FullName, $enc)
+
+function Persist($f) {
+    $chk = (uvx autopep723 check $f) -join "`n"
+    if ($LASTEXITCODE -ne 0) { return $false }
+    $names = [regex]::Matches($chk, '^#\s*"([^"]+)",?\s*$', 'Multiline') | ForEach-Object { $_.Groups[1].Value }
+    if ($names.Count -eq 0) { return $true }
+    uv add --script $f $names
+    return ($LASTEXITCODE -eq 0)
+}
+
 uvx autopep723 $f
-if ($LASTEXITCODE -ne 0) {
-    Write-Host "First attempt hit a snag with the file's dependency header - retrying with a clean version..."
+$rc = $LASTEXITCODE
+
+if ($rc -eq 0) {
+    if (Persist $f) {
+        Write-Host "Ran successfully and remembered what it needed."
+    } else {
+        Write-Host "Ran successfully, but could not update the dependency header - nothing was changed there."
+    }
+} elseif ($rc -eq 2) {
+    Write-Host "Header is malformed - retrying with a clean version..."
     [System.IO.File]::WriteAllText("$((Get-Item $f).FullName).bak", $original, $enc)
     $c = $original -replace "(?ms)^# /// script\r?\n.*?^# ///[ \t]*\r?\n?", ""
     [System.IO.File]::WriteAllText((Get-Item $f).FullName, $c, $enc)
     uvx autopep723 $f
-    if ($LASTEXITCODE -ne 0) {
+    if ($LASTEXITCODE -eq 0) {
+        if (Persist $f) {
+            Write-Host "Ran successfully after repair and remembered a fresh header."
+        } else {
+            Write-Host "Ran successfully after repair, but could not update the header."
+        }
+    } else {
         Write-Host "Retry also failed - restoring your original file untouched."
         [System.IO.File]::WriteAllText((Get-Item $f).FullName, $original, $enc)
     }
     Remove-Item -ErrorAction SilentlyContinue "$f.bak"
+} else {
+    Write-Host "Run failed with an existing header in place - trying to fill in any missing dependencies..."
+    Persist $f | Out-Null
+    uvx autopep723 $f
+    if ($LASTEXITCODE -eq 0) {
+        Write-Host "Ran successfully after filling in missing dependencies."
+    } else {
+        Write-Host "Run still failed - this looks like a script-level issue, not a dependency gap, so nothing further was attempted."
+    }
 }
 ```
 
@@ -820,12 +891,14 @@ changes nothing:
 uvx autopep723 check solve_my_probs.py
 ```
 
-### Make it remember, without losing pins you already set
+### Make it remember, without actually running it
 
-The command above runs your script but forgets what it found the moment it's done. If you'd
-rather the file remember its dependencies for next time -- and keep any exact version pin
-(`flask>=2.0`) or hand-added TOML key you already have, adding only genuinely new dependencies --
-paste this instead:
+The command above already remembers what it needed once it confirms the run works. Use this one
+instead if you want to update the header *without* executing the script at all -- for example,
+to check dependencies into the file for someone else before you're ready to run it yourself, or
+to prep a file for `run_setup.bat` ahead of time. Same additive-merge guarantee: it keeps any
+exact version pin (`flask>=2.0`) or hand-added TOML key you already have, adding only genuinely
+new dependencies -- paste this instead:
 
 ```powershell
 $f = "solve_my_probs.py"; $chk = (uvx autopep723 check $f) -join "`n"; if ($LASTEXITCODE -eq 0) { $names = [regex]::Matches($chk, '^#\s*"([^"]+)",?\s*$', 'Multiline') | ForEach-Object { $_.Groups[1].Value }; if ($names.Count -gt 0) { uv add --script $f $names } else { Write-Host "No dependencies detected (or the file could not be fully analyzed)." } } else { Write-Host "Could not analyze script - nothing changed." }
@@ -859,15 +932,13 @@ form. Safe to run more than once -- confirmed idempotent on repeat runs, across 
 it fails because your file's *existing* header is malformed rather than missing, run the command
 above first (it repairs a broken header), then try this one again.
 
-**Two things worth knowing if you use this regularly:** if a `<yourfile>.py.lock` file already
-exists next to your script (from separate `uv` usage), `uv add --script` will silently rewrite it
-as a side effect of adding a dependency -- expected `uv` behavior, not a bug in this command, but
-worth knowing if you maintain that lockfile by hand. Separately, `uv` has an open caching issue
-([astral-sh/uv#15156](https://github.com/astral-sh/uv/issues/15156)) where running the same
-filename with a different dependency set can occasionally serve a stale cached resolution on a
-later `uv run` -- exactly the scenario this command's whole point is to set up. If a promoted file
-behaves oddly after you've changed its imports, renaming the file or clearing `~/.cache/uv`
-resolves it; it's a known upstream quirk, not something wrong with your file.
+**Worth knowing if you use this regularly:** if a `<yourfile>.py.lock` file already exists next to
+your script (from separate `uv` usage), `uv add --script` will silently rewrite it as a side
+effect of adding a dependency -- expected `uv` behavior, not a bug in this command, but worth
+knowing if you maintain that lockfile by hand. The same caching quirk noted above (renaming a file
+after changing its imports can serve a stale cached resolution -- astral-sh/uv#15156) applies here
+too, for the same reason: this command exists specifically to leave behind a header a later `uv
+run` will pick up.
 
 **Fine print:** this whole section is for a script you already trust, or one you're consciously
 iterating on and accept re-running. If you were handed a `.py` file and don't know whether it's

--- a/docs/plan-pvw-quickstart.md
+++ b/docs/plan-pvw-quickstart.md
@@ -1,9 +1,13 @@
 # Plan: PVW QuickStart -- a standalone, no-EXE super-user path
 
-**Status:** Design-only, not scheduled. Sequenced to land *after* `docs/plan-pep723-writeback.md`
-(see "Sequencing decision" below). One local verification pass completed (2026-07-14, uv 0.8.17 /
-autopep723 0.2.0, this repo's Linux sandbox) against both the source document and this plan's own
-proposed simplification.
+**Status:** The user-facing commands are shipped directly in README's "PVW QuickStart" section
+(copy-paste PowerShell, no download required); a standalone downloadable `pvw_quickstart.ps1`
+file is still not built -- see "Architecture decision" below, unchanged by this update. Two local
+verification passes completed (2026-07-14, uv 0.8.17 / autopep723 0.2.0, this repo's Linux
+sandbox): an initial pass against the source document and this plan's own proposed simplification,
+and a same-day follow-up pass (see "Pass 2: default command redesigned around exit-code branching"
+below) that replaced the default run command's retry logic after a real, reproduced destructive
+bug was found in the original design.
 **Owner:** Python_vs_Windows maintainer
 **Source material:** a user-supplied third-party document ("The PEP 723 Megacommand") proposing a
 single-paste PowerShell command family for running/persisting a `.py` file's dependencies without
@@ -92,6 +96,72 @@ remain open items -- see "Open gaps, carried over honestly" below.
 
 ---
 
+## Pass 2: default command redesigned around exit-code branching (same day, found via a real
+## reproduced bug, not a hypothetical)
+
+The originally-shipped default run command (this plan's own Shape A, and the source document's
+own Tier 1) treated *any* nonzero exit from the first run attempt identically: strip the entire
+existing `# /// script ... # ///` block and retry clean. This is correct for a genuinely malformed
+header, but wrong for the much more common failure it doesn't distinguish from: a **valid** header
+that is simply missing a recently-added import, which fails with `ModuleNotFoundError` -- a
+different problem with the same symptom (nonzero exit). The blind-strip design could not tell them
+apart and destroyed the second case as if it were the first.
+
+**Reproduced directly, not assumed.** Built a file with a real pin (`flask>=2.0`), a hand-added
+custom TOML key (`[tool.custom]`), and a script body that imports both `flask` and `requests` --
+but a header that only declares `flask`. Running the original blind-strip command against it:
+
+- First attempt: `ModuleNotFoundError: No module named 'requests'`, exit 1.
+- The blind-strip logic could not distinguish this from a malformed header, so it stripped the
+  entire header (pin, `requires-python`, and the custom key all gone) and retried on a bare file.
+- Result: the script ran, but the file was left with **no header at all** where a moment before it
+  had a real, correct, hand-maintained one. First reproduction attempt actually returned a
+  misleadingly clean result (the run succeeded with no visible strip) -- traced this to a stale
+  `uv` cache from reusing the same test filename across many earlier, unrelated test runs that
+  same session (the exact symptom astral-sh/uv#15156 describes, already documented in README's
+  caching callout); re-running with a genuinely fresh filename and a cleared `~/.cache/uv`
+  reproduced the destructive strip cleanly and repeatably.
+
+**The fix**: branch on the *exit code* of the first attempt, not just success/failure.
+`autopep723`/`uv` reliably use exit code `2` specifically for "the header itself is unparseable
+TOML" -- confirmed directly across every malformed-header test in both this plan and
+`plan-pep723-writeback.md`'s own testing, and separately confirmed that a **missing file** does
+NOT produce exit code 2 (it produces exit 1 with a "script does not exist" message), so the
+distinction is not accidentally overloaded by an unrelated failure class either:
+
+- **Exit 0** (ran clean): best-effort additive persist now that the run is confirmed working --
+  the same discovery-then-`uv add --script` recipe from "Simplified persistence design" below,
+  just triggered automatically on success instead of only via a separate opt-in command.
+- **Exit 2** (header itself is malformed): the one case where starting over is actually correct --
+  back up, strip, retry, persist a fresh header on success, restore the original byte-for-byte if
+  the retry also fails.
+- **Any other nonzero exit** (header parsed fine, something else failed -- most commonly a valid
+  header missing a recently-added import): fill in what's missing via the same additive persist
+  helper *without stripping anything*, then retry once. If that still fails, it's treated as a
+  genuine script-level problem, not a dependency gap, and nothing further is attempted
+  automatically.
+
+**Re-verified after the fix, same reproduction file plus five more scenarios (all against the
+final command as it now appears in README, not just the design):** the pin, `requires-python`, and
+custom key all survive; only `requests` gets added; the script runs. A genuinely malformed header
+(TOML syntax error) still correctly triggers strip-and-retry. A double failure (malformed header +
+a genuinely nonexistent package) still restores the original file byte-for-byte with the `.bak`
+cleaned up. A missing/misnamed file falls through to the safe "some other reason" branch rather
+than the destructive one (confirmed exit code is 1, not 2). A non-UTF-8 file falls through the
+same safe branch and is left untouched. Idempotency holds: running the finished command a second
+time on an already-complete header produces a byte-identical file. One accepted, deliberate gap
+carried forward from the source document's own equivalent design decision: the "some other reason"
+branch's fill-in is not rolled back if the retry still fails for an unrelated reason (e.g. a real
+bug in the script) -- safe because `uv add --script`'s writes are already independently confirmed
+atomic (see finding 3 below), so the header at worst ends up *more* correct, never corrupted.
+
+**Design consequence carried into README, not left implicit:** this changes the previous "never
+touches your file in the common case where nothing goes wrong" framing -- the new default command
+*does* touch the file on a successful run now, by design, additively. README's text was updated to
+say so plainly rather than quietly changing the claim underneath an unchanged sentence.
+
+---
+
 ## Simplified persistence design (this plan's contribution beyond the source document)
 
 Because `uv add --script` already preserves existing pins and custom keys on its own (see finding
@@ -128,25 +198,31 @@ Two shapes were considered, matching the two options raised when this plan was r
 ### Shape A (recommended): standalone `pvw_quickstart.ps1`, documented and optionally downloadable
 
 A single PowerShell script, independent of `run_setup.bat`, that a super user pastes or downloads
-and runs directly in a terminal they've already opened in the script's folder. Two modes:
+and runs directly in a terminal they've already opened in the script's folder. Three modes,
+matching what's now shipped as README commands:
 
-- **Default (run only, no persistence):** hardened version of the source document's Tier 1 --
-  install uv via the official installer (`irm https://astral.sh/uv/install.ps1 | iex`, already
-  this repo's own documented recommendation for an *interactive terminal* context -- see
-  `CLAUDE.md`'s "Known Findings" entry explaining why that same installer is deliberately **not**
-  used inside `run_setup.bat` itself; a live terminal session has none of the PATH-propagation/
-  restart problems a background batch process does, so there is no conflict between the two
-  decisions, just two different execution contexts), read the target file with the ISO-8859-1
-  round-trip technique (finding 2) so a crash or a bad-header retry can always restore the
-  original bytes exactly, run `uvx autopep723 <file>` (ephemeral, no persistence), and on a
-  non-zero exit, strip any existing `# /// script ... # ///` block using the **same line-by-line
-  state-machine approach** `plan-pep723-writeback.md`'s Part 2.1 step 5 already specifies for the
-  automatic feature (not the source document's own DOTALL-ish regex, which that same section
-  already reasons is riskier -- see astral-sh/uv#10918 and astral-sh/uv#19544, both already cited
-  there) and retry once. On a second failure, restore the original bytes and stop -- never leave
-  the file in a partially-stripped state.
-- **Opt-in `-Persist` switch:** after a successful run (or independently, without running), does
-  the discovery-then-`uv add --script` recipe above.
+- **Default (run, and additively remember what it needed):** install uv via the official installer
+  (`irm https://astral.sh/uv/install.ps1 | iex`, already this repo's own documented recommendation
+  for an *interactive terminal* context -- see `CLAUDE.md`'s "Known Findings" entry explaining why
+  that same installer is deliberately **not** used inside `run_setup.bat` itself; a live terminal
+  session has none of the PATH-propagation/restart problems a background batch process does, so
+  there is no conflict between the two decisions, just two different execution contexts), read the
+  target file with the ISO-8859-1 round-trip technique (finding 2) so a crash or a header repair
+  can always restore the original bytes exactly, run `uvx autopep723 <file>` (ephemeral), then
+  branch on the exit code per "Pass 2" above: exit 0 does a best-effort additive persist; exit 2
+  (genuinely malformed TOML) is the one case where stripping and retrying from scratch is correct;
+  any other nonzero exit tries an additive fill-in without ever stripping anything, then retries
+  once. The malformed-header repair path uses the **same line-by-line state-machine approach**
+  `plan-pep723-writeback.md`'s Part 2.1 step 5 already specifies for the automatic feature (not a
+  DOTALL-ish regex, which that same section already reasons is riskier -- see astral-sh/uv#10918
+  and astral-sh/uv#19544, both already cited there), and only that one path ever writes a `.bak`
+  backup or removes anything from the file.
+- **Read-only check:** `uvx autopep723 check <file>` -- prints what would be detected, changes
+  nothing. No repair/persist logic involved at all.
+- **Persist-only, without running:** the discovery-then-`uv add --script` recipe below, for when a
+  super user wants the header updated without executing the script's side effects yet (the default
+  mode already does this automatically after a successful run, so this mode exists specifically
+  for the "don't run it" case).
 
 This is what the user's own framing leaned toward ("just run this and bail out") and is the
 default recommendation here: it costs `run_setup.bat` nothing (zero lines changed, zero new
@@ -250,36 +326,38 @@ already knows how to do (Windows runners, matrix jobs, NDJSON rows):
    the code.
 
 Scenario list to adapt once implementation starts (mirrors `plan-pep723-writeback.md`'s own test
-table shape for consistency): happy path no header; existing valid pinned header (persist mode);
-malformed header (retry path); non-UTF-8 source file (round-trip path); missing/misnamed file;
-`-Persist` custom-key preservation; `-Persist` idempotency (run twice, byte-identical result).
+table shape for consistency, extended per Pass 2's exit-code branching): happy path no header;
+existing valid pinned header, no missing imports (default mode does nothing beyond confirming);
+**valid-but-incomplete header with a pin and a custom key** (Pass 2's own reproduction case -- the
+one that must NOT strip); genuinely malformed header (retry path, the one case that DOES strip);
+double failure (malformed header + a genuinely nonexistent package -- must restore byte-for-byte);
+non-UTF-8 source file (must fall into the safe non-stripping branch, not the retry branch);
+missing/misnamed file (must also fall into the safe branch -- confirm its exit code is never 2);
+persist-only mode's custom-key preservation; persist-only mode's idempotency (run twice,
+byte-identical result); default mode's idempotency on an already-complete header.
 
 ---
 
 ## Critical files for implementation (when scheduled)
 
 - `pvw_quickstart.ps1` (new, repo root or a `tools/`-adjacent location TBD at implementation time)
-  -- the standalone script itself, self-contained like `run_setup.bat` is, but far smaller.
-- `README.md` -- new user-facing section; see "README placement" below for where.
+  -- the standalone script itself, self-contained like `run_setup.bat` is, but far smaller. Would
+  wrap the same logic already shipped as README copy-paste commands, not a new design.
+- `README.md` -- the "PVW QuickStart" section already exists and ships the full command set; a
+  standalone script would be an additional, optional download of the same logic, not a rewrite.
 - `tests/` -- new CI test file(s) once a shape is chosen; no existing test file is a close enough
   structural match to extend rather than create fresh.
 - `CLAUDE.md` -- Active Backlog pointer, mirroring the existing `plan-pep723-writeback.md` entry's
   style.
 
-## README placement (backlog, not written yet)
+## README placement (shipped)
 
-Positioned **not near the top** of the README, per explicit request -- this is opt-in super-user
-material, not the beginner-facing quickstart the top of the README already owns. Two candidate
-locations, either acceptable, final call deferred to implementation time once the surrounding
-prose can be read in context:
-
-- Directly after `## [REQ-015] Idempotent Git Config Merge`, since QuickStart is itself an
-  explicitly-idempotent-by-design tool (repeated `-Persist` runs converge, per finding 3) and
-  a reader already primed on "idempotent" by that section's own title is a natural next stop.
-- Inside or directly after `## Python_vs_Windows and the "Deno for Python" Question`, since that
-  section already draws the exact audience distinction ("known-stateless scripts, or a developer
-  who already knows their own code") this whole plan is built on -- QuickStart could be introduced
-  as a concrete instance of that column, rather than a hypothetical one.
+Landed directly after `## Python_vs_Windows and the "Deno for Python" Question`, before `## Known
+Limitations` -- the second of the two candidate locations this plan originally listed, chosen
+because that section already draws the exact audience distinction ("known-stateless scripts, or a
+developer who already knows their own code") this whole plan is built on, so QuickStart reads as a
+concrete instance of that column rather than a hypothetical one. Still **not near the top** of the
+README, per the original request -- the beginner-facing quickstart at the top is untouched.
 
 Recorded in `CLAUDE.md`'s Active Backlog (see that file) so this placement decision isn't lost
 before the section is actually written.


### PR DESCRIPTION
## Summary

Follow-up to #344/#345, fixing a real bug the user flagged: the default "Just run it" command's retry logic was destructive in a case that isn't obvious from reading it.

- **The bug**: the original default command treated *any* nonzero exit from the first run attempt the same way -- strip the whole PEP 723 header and retry clean. That's correct for a genuinely malformed header, but wrong for the far more common case it couldn't tell apart from it: a *valid* header that's just missing a recently-added import (`ModuleNotFoundError`), which fails with the same symptom for a completely different reason.
- **Reproduced directly** (not assumed): built a file with a real pin (`flask>=2.0`), a hand-added custom TOML key, and a header missing one import the code actually needs. The old command's blind strip destroyed the pin and the custom key even though the header itself was perfectly valid -- confirmed after tracing an initial misleading "clean" result back to a stale `uv` cache from reusing a test filename (the exact symptom of `astral-sh/uv#15156`, already documented in this section).
- **The fix**: branch on the *exit code* of the first attempt instead of just success/failure. Confirmed directly that exit code `2` reliably and *exclusively* means "the header itself is unparseable TOML" (also confirmed a missing/misnamed file does NOT produce exit 2, so the distinction isn't accidentally shared with an unrelated failure class). Exit 0 does a best-effort additive persist; exit 2 is now the *only* case that strips and retries; any other nonzero exit fills in what's missing via the same additive-merge helper *without ever stripping anything*, then retries once. This is the same additive-merge, never-delete posture `run_setup.bat` already uses for `runtime.txt`/`requirements.txt` -- now applied to the default QuickStart command, not just the separate persist-only one.
- **Consequence, stated plainly, not hidden**: the default command now touches the file on every successful run (an additive persist), not just on request. This changes the section's previous "never touches your file" claim, so the README text was updated to say so.
- **Re-verified end-to-end against the exact command as it now appears in README**: the original reproduction case, a genuinely malformed header, a double failure (malformed header + nonexistent package -- must restore byte-for-byte), a missing file, a non-UTF-8 file, and idempotency on an already-complete header.
- **Re-verified single-line/multiline equivalence for every command pair in the section**, per the request to double-check duplicated code -- found and fixed a false negative in my own verification script (an ambiguous anchor line matched the wrong block), not an actual content mismatch; confirmed all pairs are token-identical and produce byte-identical results.
- **Proofread the full PVW QuickStart section** and updated `docs/plan-pvw-quickstart.md` (new "Pass 2" section) and `CLAUDE.md`'s backlog entry to describe the fixed design and shipped README placement.

Documentation only -- no `run_setup.bat` or other product code changed.

## Test plan

- [x] `python -m compileall -q .`
- [x] `python tools/check_delimiters.py run_setup.bat`
- [x] `python -m yamllint .github/workflows/`
- [x] `actionlint -oneline .github/workflows/*.yml`
- [x] ASCII sweep (clean)
- [x] PowerShell AST parse sweep (clean)
- [x] `python -m pytest tests/test_*.py -q` (215 passed, 2 skipped)
- [x] Reproduced the destructive-strip bug against the original design, then confirmed the fix against six scenarios (reproduction case, malformed header, double failure, missing file, non-UTF-8, idempotency), all using fresh unique filenames and a cleared `uv` cache to avoid the stale-cache confound that caused a false negative on the first attempt
- [x] Extracted every single-line/multiline command pair verbatim from the final README and confirmed token-stream equivalence and byte-identical run results for both

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015xbWLPbiaKVsobB9FZy8kS

---
_Generated by [Claude Code](https://claude.ai/code/session_015xbWLPbiaKVsobB9FZy8kS)_