### PR TITLE
Consolidate duplicated uv/PEP723 findings into agent-lessons-learned.md

### DIFF
--- a/docs/agent-lessons-learned.md
+++ b/docs/agent-lessons-learned.md
@@ -774,3 +774,74 @@ skipped or gated on `HP_FASTPATH_USED`. This is intentional, not an oversight: i
 entry `SyntaxError` before a doomed PyInstaller build even when the cached EXE is about to be
 reused. Cost is negligible (single-file byte-compile, ~50ms) relative to the fast path's overall
 savings. No action needed; recorded here so it isn't re-flagged as a "missing optimization" later.
+
+---
+
+## `uv add --script` / PEP 723 empirical behavior (shared foundation for two features)
+
+Two features in this repo persist resolved dependencies into a script's PEP 723 header via `uv
+add --script`: the automatic, `run_setup.bat`-integrated one (`docs/plan-pep723-writeback.md`) and
+the standalone, manual "PVW QuickStart" one (`docs/plan-pvw-quickstart.md`, partially shipped in
+README's "PVW QuickStart" section). Both depend on the same empirical facts about `uv`'s real
+behavior, established via direct testing across three separate passes (never trusted from
+documentation alone) and originally restated in each plan doc's own words. Consolidated here once
+instead, per this file's own "standalone fact" categorization principle -- each plan doc now
+points back here rather than re-deriving these.
+
+- **`uv add --script` performs a genuine targeted merge, not a rewrite.** Re-adding an
+  already-pinned package by its bare name does not downgrade the pin (confirmed: `flask>=2.0`
+  survived a bare `flask` re-add byte-for-byte). Adding a mix of already-pinned and genuinely new
+  packages in one call preserves every existing pin and adds only the new ones (as bare names, or
+  on newer `uv`, an auto-resolved lower bound -- see the version-drift note below). A hand-added
+  custom TOML key outside `dependencies`/`requires-python` survives untouched. This is what lets
+  both features skip building a hand-rolled TOML differ/merger: feed the full current dependency
+  list to `uv add --script` every time and let `uv`'s own merge logic do the rest.
+- **Exit code `2` reliably and exclusively means "the header itself is unparseable TOML."**
+  Confirmed across every malformed-header test in both features' testing, and confirmed a missing/
+  misnamed file does NOT also produce exit 2 (it's exit 1, "script does not exist"), so the signal
+  isn't accidentally shared with an unrelated failure class. Both features' malformed-header-repair
+  logic is built on this: branch on exit code 2 specifically, not "any nonzero exit," before
+  deciding whether stripping the header is safe.
+- **A closing `# ///` fence with trailing whitespace fails to parse, exit 2 -- astral-sh/uv#10918.**
+  Looks fine to a human, invalid to `uv`'s strict parser. Any header-repair logic must be tolerant
+  of this on the STRIP side (match `# ///` followed by optional trailing whitespace, not requiring
+  an exact end-of-line) even though `uv` itself won't tolerate it on write.
+- **A stray/duplicate leftover fence line can itself become a NEW hard error on newer `uv` --
+  astral-sh/uv#19544** ("reject duplicate script metadata blocks," landed ~0.11.17; previously
+  silently treated as postlude). This is why header-strip logic should be a line-by-line state
+  machine (track an `in_block` boolean, remove the whole block cleanly) rather than a regex that
+  could under- or over-match, especially a lazy regex that could leave a stray fence line behind.
+- **`VIRTUAL_ENV` set in the calling environment produces only a benign stderr warning, never a
+  failure -- astral-sh/uv#15956.** Confirms success/failure must be judged solely by exit code,
+  never by the presence of stderr text.
+- **An existing `<script>.py.lock` sidecar is silently rewritten as a side effect of `uv add
+  --script`, with no flag to suppress it.** Confirmed the exact filename convention
+  (`<script-name>.py` -> `<script-name>.py.lock`) via a real lockfile (mtime + content change).
+  Any feature that calls `uv add --script` on a file that might have a hand-maintained lock should
+  either skip when one exists, or at minimum document that it will be touched.
+- **Open caching issue -- astral-sh/uv#15156 ("Cached Script Dependencies Not Properly
+  Invalidated").** A sequence of `uv add --script` (change deps) then a later `uv run --script`
+  (or ephemeral run) on the SAME filename can serve a stale cached resolution even after the
+  header changed; renaming the file "fixes" it, implying the cache key is filename-derived. Hit
+  this repo's own testing directly: an early attempt to reproduce a design bug returned a
+  misleadingly clean result because of exactly this stale-cache effect, only resolved by using a
+  fresh filename and clearing `~/.cache/uv`. Relevant to any feature whose entire point is
+  persisting a header for a LATER, independent `uv run` to pick up.
+- **`Get-Content -Raw`'s default text handling silently replaces any invalid-UTF-8 byte with the
+  Unicode replacement character (`U+FFFD` / `EF BF BD`) the instant it reads a file** -- confirmed
+  at the raw byte level, not just visually. For a script saved in a legacy encoding, this corrupts
+  an in-memory "original" backup before any risky operation even begins, so a later "restore" can
+  silently hand back an altered file. Reading and writing via `[System.IO.File]::ReadAllText`/
+  `WriteAllText` with `[System.Text.Encoding]::GetEncoding("ISO-8859-1")` round-trips any file's
+  bytes exactly (`ISO-8859-1` maps every byte value to a distinct character 1:1), regardless of
+  the file's real encoding -- the fix PVW QuickStart uses for its own retry/restore mutation.
+  `plan-pep723-writeback.md`'s automatic feature takes a different, simpler path for the same
+  underlying hazard (skip non-UTF-8 files entirely rather than round-tripping), since it never
+  needs to mutate-then-possibly-restore the same way QuickStart's live retry does.
+- **A genuinely new dependency's written form depends on the `uv` version, not just on whether
+  it's new.** `uv` 0.8.17 wrote bare names (`"requests"`); `uv` 0.11.28 wrote an auto-resolved
+  lower bound (`"requests>=2.34.2"`) for the identical operation. Neither feature should assume or
+  document one specific form -- treat whatever `uv` writes as correct by construction.
+
+None of this is specific to either feature's own design (hook points, dispatch shape, audience) --
+that detail stays in each plan doc, with a pointer back here for the underlying `uv` facts.

--- a/docs/plan-pep723-writeback.md
+++ b/docs/plan-pep723-writeback.md
@@ -6,11 +6,16 @@ issues research pass, a second local scratch-dir pass comparing uv 0.8.17 agains
 directly test version-drift risk, and a code-grounded implementation pass tracing the actual
 `run_setup.bat` hook points; 2026-07-14 a third, narrower pass confirming pin/custom-key
 preservation on re-add, prompted by reviewing `docs/plan-pvw-quickstart.md`). No code written yet.
+The empirical findings shared with that sibling doc were later consolidated into
+`docs/agent-lessons-learned.md` -- see Part 1 below.
 **Owner:** Python_vs_Windows maintainer
-**Related:** `CLAUDE.md` Active Backlog (this item is linked from there); `docs/prd-av-safe-build-
-path.md` (a structurally similar large design doc, for format precedent); `docs/plan-pvw-
-quickstart.md` (a standalone, non-`run_setup.bat` sibling feature for a different audience --
-see that document's own "Why this is a separate document" section for how the two relate).
+**Related:** `docs/agent-lessons-learned.md`'s "`uv add --script` / PEP 723 empirical behavior"
+section (the shared empirical foundation this doc and `docs/plan-pvw-quickstart.md` both depend
+on -- read that first); `CLAUDE.md` Active Backlog (this item is linked from there);
+`docs/prd-av-safe-build-path.md` (a structurally similar large design doc, for format precedent);
+`docs/plan-pvw-quickstart.md` (a standalone, non-`run_setup.bat` sibling feature for a different
+audience -- see that document's own "Why this is a separate document" section for how the two
+relate).
 
 ---
 
@@ -74,74 +79,48 @@ NOT:
 
 ## Part 1: Empirical findings (both testing passes)
 
-### Pass 1 (2026-07-11, against uv 0.8.17 only)
+**The core empirical facts about `uv add --script`'s real behavior now live in
+`docs/agent-lessons-learned.md`'s "`uv add --script` / PEP 723 empirical behavior" section** --
+consolidated there because this feature and the sibling `docs/plan-pvw-quickstart.md` both
+depended on the same facts and were independently restating them (targeted-merge/no-downgrade
+behavior on re-add, exit-code-2-means-malformed-TOML, issues #10918/#19544/#15956/#15156, the
+`.lock` sidecar side effect, the `Get-Content -Raw` encoding-corruption hazard, and the
+bare-name-vs-lower-bound version drift). **Read that section first.** What follows here is only
+what's specific to this feature -- findings the sibling doc doesn't share, and this feature's own
+design implications.
 
-- **No version bound written by default** at the time: `uv add --script file.py requests` wrote
-  a bare `"requests"` line, confirmed even with `--offline` against an uncached package.
-- **Idempotent**: re-running with an already-present package produced a byte-identical file.
-- **Merges cleanly into an existing valid header**: a new package is appended alphabetically;
-  an existing `requires-python` line is left completely untouched.
-- **Malformed existing header -> hard error, file left untouched**: exit 2, TOML parse error,
-  zero modification to the file. This makes a strip-then-retry repair sequence *mandatory*, not
-  optional, since uv will never self-repair a broken block.
+### Pass 1 (2026-07-11, against uv 0.8.17 only) -- write-back-specific findings
+
 - **`requires-python` is auto-written only on first-ever header creation**, never touched on
-  later `add` calls; fully controllable via `-p`/`--python "<path>"`.
+  later `add` calls; fully controllable via `-p`/`--python "<path>"`. Matters here specifically
+  because this feature can pass `-p`/`--python` explicitly (the bootstrapper always knows its own
+  interpreter path); the sibling QuickStart feature has no equivalent flag to set.
 - **`--no-sync` is a no-op in script mode** -- no redundant environment gets built as a side
   effect of adding a dependency; this is genuinely a metadata-only operation.
 - **No package-existence validation at add time** -- `uv add --script` happily wrote a
   deliberately nonexistent package name with no error. This bootstrapper must only ever feed it
-  package names it has *already confirmed installed*.
+  package names it has *already confirmed installed* (Part 2.2's "confirmed installed" gate is
+  built on this).
 
-### Pass 2 (2026-07-12): web/docs/GitHub research
+### Pass 2 (2026-07-12): web/docs/GitHub research -- write-back-specific findings
 
-Full agent report is not reproduced verbatim here; the actionable findings are:
+- **`autopep723` does NOT validate `uv add --script`'s write path.** It has its own, independent
+  TOML-writing code and only uses uv as an ephemeral runner (`uv run --with <deps>`), never `uv
+  add`/`uv run --script`. There is no "battle-tested by a popular third-party tool" confidence to
+  lean on here -- confidence rests solely on this repo's own direct testing plus uv's own
+  documented/changelogged behavior.
+- **Two past, now-fixed uv bugs (#13447, #12499)** about comment-deletion and TOML-block-adjacency
+  corruption around the metadata block -- evidence the header-insertion logic has had genuine
+  correctness bugs before, not a reason for present-day concern on its own.
 
-1. **Open uv bug, issue #15156 ("Cached Script Dependencies Not Properly Invalidated")**: a
-   sequence of `uv add --script` (change deps) then `uv run --script` (execute) can see a STALE
-   cached resolution even with `--refresh`/`--force-reinstall`; renaming the file "fixes" it,
-   implying the cache key is filename-derived. **This bootstrapper does not call `uv run
-   --script` on the entry file** (it runs the entry via its own separately-managed `.uv_env`
-   interpreter, or the built PyInstaller EXE), so this bug does not affect this bootstrapper's
-   own immediate execution correctness. It IS a real risk for the exact scenario this feature
-   enables: someone *later* running the promoted, self-describing file directly via `uv run
-   <entry>.py` outside this bootstrapper could hit stale cached results if a same-named file was
-   previously run with different dependencies. Document as a known limitation, don't silently
-   ignore.
-2. **Lockfile side-effect** (confirmed independently in Pass 2's local testing, see below): if a
-   `<entry>.py.lock` file already exists next to the target script, `uv add --script`
-   automatically reads and rewrites/extends that lockfile as an undocumented side effect, with no
-   flag to suppress it by default.
-3. **Version drift is real and was directly demonstrated**, not just theoretical (see local
-   testing below).
-4. **Other confirmed GitHub issues**: #10918 (open) -- a `# ///` closing fence with trailing
-   whitespace fails to parse as valid, meaning a header can become "malformed" from something as
-   innocuous as an editor adding trailing whitespace, not just from bad TOML content (confirmed
-   locally, see below). #15956 (open) -- `uv add --script` prints a benign stderr warning if
-   `VIRTUAL_ENV` is set in the calling environment; not a failure (confirmed locally, see below).
-   #13447 and #12499 were real past bugs (both fixed) about comment-deletion and TOML-block-
-   adjacency corruption around the metadata block -- evidence the header-insertion logic has had
-   genuine correctness bugs before.
-5. **autopep723 does NOT validate `uv add --script`'s write path.** It has its own, independent
-   TOML-writing code and only uses uv as an ephemeral runner (`uv run --with <deps>`), never `uv
-   add`/`uv run --script`. There is no "battle-tested by a popular third-party tool" confidence to
-   lean on here -- confidence rests solely on this repo's own direct testing plus uv's own
-   documented/changelogged behavior.
+### Pass 2 local scratch-dir testing (uv 0.8.17 vs uv 0.11.28) -- write-back-specific findings
 
-### Pass 2 local scratch-dir testing (uv 0.8.17 vs uv 0.11.28, both installed side by side)
-
-- **CONFIRMED VERSION DRIFT, directly observed, not inferred from changelog text alone**: uv
-  0.11.28's default behavior differs from 0.8.17 -- it now writes a version *lower bound*
-  (`"pandas[excel]>=3.0.3"`) where 0.8.17 wrote a bare name (`"pandas[excel]"`). This is the
-  single most important finding of this pass: the "no version bound by default" claim from Pass 1
-  was correct for 0.8.17 specifically and is **already false** for current uv. Since this repo
-  never pins uv's version, production behavior will match whatever the *current* uv does, not the
-  0.8.17 baseline. **Design implication: do not hard-code an assumption about whether a bound is
-  present in the written output -- treat "whatever uv writes" as opaque and correct by
-  construction**, which the original design already avoided asserting as a hard requirement, but
-  this confirms that caution was warranted, not excessive.
 - **Extras syntax (`pandas[excel]`) works correctly on both versions** and is correctly
   recognized as the same logical package on re-add: adding bare `pandas` after `pandas[excel]`
-  was already present did not duplicate or downgrade the entry; the extras+bound form was kept.
+  was already present did not duplicate or downgrade the entry; the extras+bound form was kept
+  (the general form of this finding -- explicit pins and custom keys too, not just extras -- is
+  now in `agent-lessons-learned.md`; this specific extras case is kept here as the original,
+  narrower observation that prompted the broader Pass 3 confirmation below).
 - **CRLF line endings are NOT preserved in the inserted header** on either version: the new `#
   /// script ... # ///` block is written with LF line endings, while the original file's body
   (below the header) keeps its original CRLF endings untouched. This produces a *mixed*
@@ -152,74 +131,33 @@ Full agent report is not reproduced verbatim here; the actionable findings are:
 - **Paths containing spaces work correctly** on both versions, given proper `"..."` quoting of
   the script path argument -- confirms the design's `"%HP_ENTRY%"` quoting approach is necessary
   and sufficient.
-- **CONFIRMED: an existing `.lock` sidecar gets silently rewritten** as an automatic side effect
-  of `uv add --script`, on both versions -- directly reproduced (mtime change, new package
-  content appearing in the lock) with zero flags set. **Confirmed the exact filename convention**:
-  `<script-name>.py` -> `<script-name>.py.lock` (verified directly, not assumed).
-  - **Also tested**: `--frozen` *does* suppress the lockfile rewrite on 0.11.28 (mtime unchanged,
-    new package not written into the lock), while still updating the `.py` header itself and
-    without raising an error -- despite uv's own stderr text calling `--frozen` "a no-op for
-    Python scripts with inline metadata." A quick follow-up check (`uv run --script ... --locked`
-    against the now-out-of-sync lock) did not immediately surface an error either, which is
-    surprising given `--locked`'s documented "assert lockfile unchanged" semantics. **This
-    `--frozen` behavior is interesting but NOT adopted for v1** -- relying on an undocumented,
-    seemingly-inconsistent interaction (a flag whose own warning text calls it a no-op, yet it
-    measurably changes behavior) is riskier than the simpler original design decision: if a
-    `.lock` file already exists, skip the write-back entirely. This respects a user who has
-    opted into uv's stricter locked workflow and avoids scope creep into lockfile maintenance
-    (hash verification, transitive pinning) which is a much bigger commitment than "write the
-    dependency list."
-- **CONFIRMED: trailing whitespace on the closing `# ///` fence causes the same hard error
-  (exit 2, file untouched)** as gross TOML syntax errors, on both versions -- directly reproduces
-  GitHub issue #10918's report. The malformed-header repair path must treat this as just another
-  case of "uv said exit 2" (see Part 2's decision not to build a bespoke pre-validator), not a
-  special case needing its own detection logic.
+- **Also tested for the `.lock` side effect: `--frozen` *does* suppress the lockfile rewrite** on
+  0.11.28 (mtime unchanged, new package not written into the lock), while still updating the `.py`
+  header itself and without raising an error -- despite uv's own stderr text calling `--frozen`
+  "a no-op for Python scripts with inline metadata." A quick follow-up check (`uv run --script
+  ... --locked` against the now-out-of-sync lock) did not immediately surface an error either,
+  which is surprising given `--locked`'s documented "assert lockfile unchanged" semantics. **This
+  `--frozen` behavior is interesting but NOT adopted for v1** -- relying on an undocumented,
+  seemingly-inconsistent interaction (a flag whose own warning text calls it a no-op, yet it
+  measurably changes behavior) is riskier than the simpler original design decision: if a `.lock`
+  file already exists, skip the write-back entirely. This respects a user who has opted into uv's
+  stricter locked workflow and avoids scope creep into lockfile maintenance (hash verification,
+  transitive pinning) which is a much bigger commitment than "write the dependency list."
 - **Duplicate-metadata-block test was inconclusive.** Attempted to reproduce the specific
-  behavior change from PR #19544 ("reject duplicate script metadata blocks," landed ~0.11.17,
-  previously silently treated as postlude). The synthetic test used (two complete, well-formed
-  `# /// script ... # ///` block pairs back to back) produced an identical hard TOML-parse error
-  on *both* 0.8.17 and 0.11.28 -- meaning this specific construction doesn't cleanly isolate the
-  changelog's described behavior difference (the "silently treated as postlude" case likely
-  requires a more specific malformed shape than what was tested here). **Do not treat this as
-  "the risk doesn't exist"** -- it's a genuine gap in this testing pass, not a disproof of the
-  changelog entry. The practical design implication stands regardless: the repair step's block-
-  stripping regex must remove the *entire* old block cleanly, with no stray remnant that could
-  read as a second block under any uv version's rules.
-- **CONFIRMED: `VIRTUAL_ENV` set in the calling environment produces only a benign stderr
-  warning** (`does not match the script environment path ... and will be ignored`), exit code
-  still 0. Confirms the design point that stderr text must never be treated as a failure signal
-  by itself -- only the process exit code should determine success/failure.
+  behavior change from PR #19544 (see `agent-lessons-learned.md`). The synthetic test used (two
+  complete, well-formed `# /// script ... # ///` block pairs back to back) produced an identical
+  hard TOML-parse error on *both* 0.8.17 and 0.11.28 -- meaning this specific construction doesn't
+  cleanly isolate the changelog's described behavior difference (the "silently treated as
+  postlude" case likely requires a more specific malformed shape than what was tested here).
+  **Do not treat this as "the risk doesn't exist"** -- it's a genuine gap in this testing pass,
+  not a disproof of the changelog entry.
 
-### Pass 3 (2026-07-14, against uv 0.8.17): pin-preservation on re-add, prompted by reviewing a
-### third-party "PVW QuickStart" design (see `docs/plan-pvw-quickstart.md`)
+### Pass 3 (2026-07-14): superseded by the lessons-learned consolidation
 
-Reviewing a user-supplied third-party document proposing a hand-rolled TOML-merge script to
-"safely" re-add dependencies without downgrading existing pins raised the question of whether
-`uv add --script` already does this natively -- Pass 2 had only confirmed this for extras syntax
-(`pandas[excel]`), not explicit version pins or custom keys. Tested directly, three scenarios:
-
-- **Re-adding an already-pinned package by its bare name does not downgrade the pin.** A header
-  with `flask>=2.0` and `click==8.1.0`, followed by `uv add --script file.py flask`, produced a
-  **byte-for-byte unchanged file**. This generalizes the Pass 2 extras finding to explicit
-  `>=`/`==` pins, not just extras syntax.
-  - **Practically-neutral (already the plan's own explicit no-op design decision) for THIS
-    feature's own trigger paths, but confirms that decision more strongly than Pass 2 alone did.**
-    Part 2.2 point 7 already commits to never comparing "what's already in the header" against
-    "what to write back" and always calling `uv add --script` with whatever the resolved set is --
-    this finding confirms that decision was safe even in its full generality (bare re-adds of
-    already-pinned packages), not just the narrower extras case Pass 2 had actually tested.
-- **Mixed re-add + genuinely-new-package call preserves old pins and adds only the new one.**
-  `uv add --script file.py flask click requests` (two already-pinned, one new) left `flask>=2.0`
-  and `click==8.1.0` untouched and added `requests` as a bare name in correct alphabetical
-  position.
-- **A hand-added custom TOML key outside `dependencies`/`requires-python` survives an `add`
-  call untouched.** Confirms `uv add --script` performs a genuine targeted merge, not a
-  rewrite-the-whole-block operation, in every dimension tested so far across all three passes.
-
-No design change follows from this pass -- it is confirmation of an already-adopted decision, not
-a new requirement. See `docs/plan-pvw-quickstart.md` for the sibling standalone feature this
-finding was originally investigated for, which -- unlike this feature -- was able to drop a whole
-hand-rolled TOML-merge step entirely as a direct result.
+The pin/custom-key preservation findings originally recorded here (prompted by reviewing the
+`docs/plan-pvw-quickstart.md` design) are now the first bullet of
+`agent-lessons-learned.md`'s consolidated section -- see that instead. No design change followed
+from this pass for this feature; it confirmed an already-adopted decision (Part 2.2 point 7).
 
 ---
 

--- a/docs/plan-pvw-quickstart.md
+++ b/docs/plan-pvw-quickstart.md
@@ -14,9 +14,12 @@ single-paste PowerShell command family for running/persisting a `.py` file's dep
 `run_setup.bat` at all. That document is not reproduced here; this plan states what was verified,
 what was kept, what was simplified, and why.
 **Related:** `docs/plan-pep723-writeback.md` (the automatic, `run_setup.bat`-integrated sibling of
-this feature); README's `## Why "Build-First, Run-Once"? (Design Rationale)` section (the existing
-audience-split argument this plan leans on directly); `CLAUDE.md` Active Backlog (this item is
-linked from there).
+this feature -- shares its core `uv` empirical foundation with this doc, consolidated in
+`docs/agent-lessons-learned.md`); `docs/agent-lessons-learned.md`'s "`uv add --script` / PEP 723
+empirical behavior" section (the shared empirical foundation both this doc and the sibling depend
+on -- read that first); README's `## Why "Build-First, Run-Once"? (Design Rationale)` section (the
+existing audience-split argument this plan leans on directly); `CLAUDE.md` Active Backlog (this
+item is linked from there).
 
 ---
 
@@ -46,47 +49,28 @@ see "Architecture decision" below for the two shapes considered and why the stan
 
 Per this repo's established practice of testing third-party claims rather than accepting them on
 authority (see `docs/plan-pep723-writeback.md`'s own two-pass empirical history), the source
-document's core claims were re-run directly in this session, plus one significant simplification
-was found and verified that the source document did not have available to it.
+document's core claims were re-run directly in this session. **The empirical findings themselves
+(the encoding-corruption bug and its `ISO-8859-1` fix, and `uv add --script`'s native
+targeted-merge behavior that makes the source document's hand-rolled TOML merge unnecessary) now
+live in `docs/agent-lessons-learned.md`'s "`uv add --script` / PEP 723 empirical behavior"
+section, consolidated with the equivalent findings from `plan-pep723-writeback.md`'s own testing
+-- read that section first.** One finding specific to this document, not shared with the sibling
+feature:
 
-1. **`uvx autopep723 <file>` (no subcommand) genuinely executes the script**, confirmed directly:
-   a test file's `print()` output appeared in the terminal and the file was confirmed unchanged
-   afterward. This matches the source document's own finding and independently disproves the same
-   "doesn't execute, needs a trailing `uv run`" claim `docs/plan-pep723-writeback.md`'s Part 1
-   already flagged as false for a related reason.
-2. **The encoding-corruption bug is real and reproduces exactly as described.** Built a file with
-   one intentionally-invalid-UTF-8 byte, read it via PowerShell's default `Get-Content -Raw`, and
-   confirmed the byte is silently replaced with the Unicode replacement character (`EF BF BD`)
-   before the command ever acts on it -- verified at the raw byte level, not just visually. Reading
-   and writing the same file via `[System.IO.File]::ReadAllText`/`WriteAllText` with
-   `[System.Text.Encoding]::GetEncoding("ISO-8859-1")` round-trips it byte-for-byte identical
-   (`cmp` confirms zero difference). This is the same category of hazard
-   `plan-pep723-writeback.md`'s Non-Goals section already reasons about for the *automatic*
-   feature (which sidesteps it by skipping non-UTF-8 files entirely, never attempting a round
-   trip) -- QuickStart's problem is different in kind: it actively mutates the file in place with
-   a retry, so it needs a real round-trip guarantee, not just a skip. The ISO-8859-1 technique is
-   the right tool for that job and is adopted as-is.
-3. **`uv add --script` already does everything the source document's hand-rolled "Option C" TOML
-   merge script was built to achieve -- confirmed with three fresh, targeted tests this session,
-   going further than either document's existing testing:**
-   - Re-running `uv add --script file.py flask` when `flask>=2.0` was already pinned in the header
-     left the file **byte-for-byte unchanged** -- the existing pin was not downgraded to a bare
-     name.
-   - Running `uv add --script file.py flask click requests` (two already-pinned packages plus one
-     genuinely new one) preserved both existing pins exactly (`flask>=2.0`, `click==8.1.0`) and
-     added only `requests`, as a bare name, in its correct alphabetical position.
-   - A hand-added custom TOML key (`[tool.custom]` with its own field) outside the
-     `dependencies`/`requires-python` keys survived an `add` call untouched.
-   - This confirms `docs/plan-pep723-writeback.md`'s existing Pass 2 finding ("adding bare pandas
-     after `pandas[excel]` was already present did not duplicate or downgrade the entry") was not
-     a narrow extras-specific behavior -- it is uv's general merge policy, and it covers explicit
-     version pins (`>=`, `==`) and arbitrary custom keys too, not just extras syntax.
-   - **Design implication:** the source document's Option C script (an inline Python one-liner
-     requiring `--with tomli-w`, TOML-parsing both the old header and a fresh `autopep723 check`
-     scan, name-normalizing both sides, and manually computing a set difference before writing a
-     merged block back by hand) is solving a problem uv's own `add --script` command already
-     solves natively. QuickStart's persistence step does not need to reimplement it -- see
-     "Simplified persistence design" below.
+- **`uvx autopep723 <file>` (no subcommand) genuinely executes the script**, confirmed directly:
+  a test file's `print()` output appeared in the terminal and the file was confirmed unchanged
+  afterward. This matches the source document's own finding and independently disproves the same
+  "doesn't execute, needs a trailing `uv run`" claim `docs/plan-pep723-writeback.md`'s Part 1
+  already flagged as false for a related reason. Not relevant to `plan-pep723-writeback.md`
+  itself, since that feature never runs the entry file this way.
+
+**Design implication carried from the lessons-learned consolidation:** since `uv add --script`'s
+own merge logic already preserves existing pins/custom keys, the source document's Option C
+script (an inline Python one-liner requiring `--with tomli-w`, TOML-parsing both the old header
+and a fresh `autopep723 check` scan, name-normalizing both sides, and manually computing a set
+difference before writing a merged block back by hand) is solving a problem `uv` already solves
+natively. QuickStart's persistence step does not need to reimplement it -- see "Simplified
+persistence design" below.
 
 **Not independently re-verified in this pass** (carried over honestly from the source document,
 not silently dropped): behavior on real Windows PowerShell 5.1 (this session, like the source
@@ -116,18 +100,15 @@ but a header that only declares `flask`. Running the original blind-strip comman
   entire header (pin, `requires-python`, and the custom key all gone) and retried on a bare file.
 - Result: the script ran, but the file was left with **no header at all** where a moment before it
   had a real, correct, hand-maintained one. First reproduction attempt actually returned a
-  misleadingly clean result (the run succeeded with no visible strip) -- traced this to a stale
-  `uv` cache from reusing the same test filename across many earlier, unrelated test runs that
-  same session (the exact symptom astral-sh/uv#15156 describes, already documented in README's
-  caching callout); re-running with a genuinely fresh filename and a cleared `~/.cache/uv`
+  misleadingly clean result (the run succeeded with no visible strip) -- traced this to the
+  `astral-sh/uv#15156` stale-cache effect already noted in `agent-lessons-learned.md` (hit live,
+  not just cited); re-running with a genuinely fresh filename and a cleared `~/.cache/uv`
   reproduced the destructive strip cleanly and repeatably.
 
-**The fix**: branch on the *exit code* of the first attempt, not just success/failure.
-`autopep723`/`uv` reliably use exit code `2` specifically for "the header itself is unparseable
-TOML" -- confirmed directly across every malformed-header test in both this plan and
-`plan-pep723-writeback.md`'s own testing, and separately confirmed that a **missing file** does
-NOT produce exit code 2 (it produces exit 1 with a "script does not exist" message), so the
-distinction is not accidentally overloaded by an unrelated failure class either:
+**The fix**: branch on the *exit code* of the first attempt, not just success/failure -- using the
+exit-code-2-means-malformed-TOML fact from `agent-lessons-learned.md` (confirmed there, across
+both this plan's and `plan-pep723-writeback.md`'s testing, that a missing file does NOT also
+produce exit 2, so the signal isn't accidentally shared with an unrelated failure class):
 
 - **Exit 0** (ran clean): best-effort additive persist now that the run is confirmed working --
   the same discovery-then-`uv add --script` recipe from "Simplified persistence design" below,
@@ -153,7 +134,8 @@ time on an already-complete header produces a byte-identical file. One accepted,
 carried forward from the source document's own equivalent design decision: the "some other reason"
 branch's fill-in is not rolled back if the retry still fails for an unrelated reason (e.g. a real
 bug in the script) -- safe because `uv add --script`'s writes are already independently confirmed
-atomic (see finding 3 below), so the header at worst ends up *more* correct, never corrupted.
+atomic (see `agent-lessons-learned.md`), so the header at worst ends up *more* correct, never
+corrupted.
 
 **Design consequence carried into README, not left implicit:** this changes the previous "never
 touches your file in the common case where nothing goes wrong" framing -- the new default command
@@ -178,8 +160,8 @@ diffing logic at all. The full recipe:
    step either, since `check`'s own output format is this repo's own tool's fixed, predictable
    shape, not arbitrary user input).
 3. Feed the **entire** extracted name list to `uv add --script <file> <names...>` in one call --
-   not just the "new" subset. uv's own merge logic (finding 3) already leaves every
-   already-present, already-pinned entry untouched and only adds genuinely new ones. No set
+   not just the "new" subset. uv's own merge logic (`agent-lessons-learned.md`) already leaves
+   every already-present, already-pinned entry untouched and only adds genuinely new ones. No set
    difference, no old-header parsing, needs to happen in QuickStart's own code at all.
 
 This removes an entire class of surface area the source document's Option C carried (a second TOML
@@ -207,8 +189,9 @@ matching what's now shipped as README commands:
   that same installer is deliberately **not** used inside `run_setup.bat` itself; a live terminal
   session has none of the PATH-propagation/restart problems a background batch process does, so
   there is no conflict between the two decisions, just two different execution contexts), read the
-  target file with the ISO-8859-1 round-trip technique (finding 2) so a crash or a header repair
-  can always restore the original bytes exactly, run `uvx autopep723 <file>` (ephemeral), then
+  target file with the ISO-8859-1 round-trip technique (`agent-lessons-learned.md`) so a crash or
+  a header repair can always restore the original bytes exactly, run `uvx autopep723 <file>`
+  (ephemeral), then
   branch on the exit code per "Pass 2" above: exit 0 does a best-effort additive persist; exit 2
   (genuinely malformed TOML) is the one case where stripping and retrying from scratch is correct;
   any other nonzero exit tries an additive fill-in without ever stripping anything, then retries


### PR DESCRIPTION
## Summary

Follow-up to a review request comparing `docs/plan-pep723-writeback.md` and `docs/plan-pvw-quickstart.md`: both docs independently restated the same empirical facts about `uv add --script`'s real behavior, since both features (the automatic `run_setup.bat`-integrated write-back, and the standalone manual QuickStart commands) depend on the same underlying `uv` behavior for two different audiences.

- **Moved the shared empirical facts into a new section of `docs/agent-lessons-learned.md`** ("`uv add --script` / PEP 723 empirical behavior") — this fits that file's own existing "standalone hazard/fact" categorization principle exactly. Consolidated: the targeted-merge/no-downgrade behavior on re-add, exit-code-2-reliably-means-malformed-TOML, GitHub issues astral-sh/uv#10918/#19544/#15956/#15156, the `.lock` sidecar silent-rewrite side effect, the `Get-Content -Raw` encoding-corruption hazard and its `ISO-8859-1` fix, and the bare-name-vs-auto-resolved-lower-bound version drift.
- **Trimmed both plan docs down to a pointer plus only what's genuinely feature-specific**: `plan-pep723-writeback.md` keeps its code-grounded hook-point detail and the CRLF-mixing/paths-with-spaces/`--frozen`-exploration findings unique to its own testing; `plan-pvw-quickstart.md` keeps its architecture decision, the Pass 2 destructive-strip bug narrative, and its own unique finding (`autopep723 <file>` genuinely executes the script, which the sibling feature never does).
- Updated both docs' `Status`/`Related` header lines and fixed several now-stale `(finding N)` cross-references left over from the trim (the numbered findings list they pointed to no longer exists in that form).

Documentation only — no `run_setup.bat` or other product code changed.

## Test plan

- [x] `python -m compileall -q .`
- [x] `python tools/check_delimiters.py run_setup.bat`
- [x] `python -m yamllint .github/workflows/`
- [x] `actionlint -oneline .github/workflows/*.yml`
- [x] ASCII sweep (clean)
- [x] PowerShell AST parse sweep (clean)
- [x] `python -m pytest tests/test_*.py -q` (215 passed, 2 skipped)
- [x] Grepped both trimmed docs for stale `finding N` / numbered cross-references after the edit and fixed each one found

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015xbWLPbiaKVsobB9FZy8kS

---
_Generated by [Claude Code](https://claude.ai/code/session_015xbWLPbiaKVsobB9FZy8kS)_