### PR TITLE
Design two-tier autopep723 integration; fix two bugs in the source spec

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -522,29 +522,20 @@ a fact confirmed with no action needed, or a recurring/periodic check belongs in
    tight -- see the plan doc's Part 4). Not yet scheduled for a specific loop; ready whenever
    picked up. `pip-compile-multi` and `vulture` (researched alongside this) are **not applicable**
    to this repo (see the plan doc's summary) -- not carried forward as backlog items.
-6. **Opt-in "trust me, my script is idempotent" fast-discovery mode (way-later; needs its own
-   dedicated design loop, not a quick add).** Raised via a 3rd-party analysis the owner shared
-   (low confidence, no repo access -- see the new README section for the full non-idempotency
-   argument this responds to) proposing a `FAST_RUN=true`-style flag. The core idea has real merit
-   and fits this repo's existing patterns (opt-in, non-default, mirrors `HP_SKIP_ENTRY_SMOKE`/
-   `HP_SKIP_EXE_SMOKERUN`'s super-user-flag shape and the REQ-018 post-execution checkpoint's
-   consent-gated "run it again" pattern) -- but the 3rd party's own actual proposed mechanism (run
-   the script live, catch a `ModuleNotFoundError`, install, rerun from the top, repeat) is
-   explicitly **not adopted**: it non-idempotently re-executes the script's own side effects on
-   every retry, which is exactly the failure mode REQ-018 was built to prevent, and adopting it
-   even behind an opt-in flag would need the flag to be an extremely well-understood, deliberate
-   choice, not a casual perf toggle. If pursued, the better-scoped version combines with item 5
-   above: gate it behind an explicit, non-default flag with clear risk-acknowledging prompt text
-   (never silently defaulted on, never a Prime-Directive gate per the "Env-var flags are
-   scaffolding" rule in `docs/agent-lessons-learned.md`), bound the retry loop the same way the
-   existing hidden-import-recovery loop is bounded (a hard iteration cap, not unbounded), and use
-   it as an *alternative discovery phase* (uv lane initially, live run-catch-install-`uv add
-   --script`-rerun) rather than skipping the PyInstaller build REQ-007 still needs for the EXE
-   deliverable. This is a genuinely useful idea but is its own multi-part design effort (loop
-   bounding, consent copy, idempotency-risk disclosure, interaction with item 5's write-back) --
-   not scheduled now or soon; revisit if item 5 ships first and this becomes a natural extension
-   of it, or if enough users report the existing build-first flow feels too slow for their
-   genuinely-safe scripts.
+6. **Opt-in "trust me, my script is idempotent" fast-discovery mode -- now has a concrete design,
+   see `docs/plan-autopep723-two-tier.md`'s `HP_PVW_KNOWN_IDEMPOTENT` section.** Originally raised
+   via a low-confidence 3rd-party analysis with no repo access proposing a `FAST_RUN=true`-style
+   flag; that early version's actual proposed mechanism (run the script live, catch a
+   `ModuleNotFoundError`, install, rerun from the top, repeat) was correctly rejected here as
+   non-idempotently re-executing the script's own side effects on every retry -- exactly the
+   failure mode REQ-018 exists to prevent. The concrete replacement design in
+   `plan-autopep723-two-tier.md` resolves this cleanly: it does not re-invent the retry mechanism,
+   it reuses the exit-code-branching logic already built, tested across a dozen-plus scenarios,
+   and shipped in README's "PVW QuickStart" section (item 10 below) -- exit 0/2/other-nonzero, only
+   ever destructive on a genuinely malformed header -- relocated into `run_setup.bat` as an opt-in
+   flag, uv lane only, sequenced to be picked up only after both the automatic write-back (item 5)
+   and the QuickStart commands have shipped and proven out. Not scheduled now; the design work
+   itself is done, only the "when to pick this up" decision remains.
 7. **AV-Safe Build Path (PyInstaller quarantine fallback via Nuitka)** -- full PRD at
    `docs/prd-av-safe-build-path.md`. A large, well-specified, preemptive feature (no real user
    report yet, a documented industry-wide problem) covering a two-tier Nuitka fallback when
@@ -650,6 +641,52 @@ a fact confirmed with no action needed, or a recurring/periodic check belongs in
     Linux); failed-`uv`-install and missing-file error UX are both known-rough, not known-broken
     (though the missing-file case is now confirmed to at least fail into the safe, non-destructive
     branch rather than the strip branch).
+11. **Two-tier `autopep723` integration for `run_setup.bat` itself -- full design at
+    `docs/plan-autopep723-two-tier.md`, deliberately sequenced LAST after items 5 and 10 above
+    both ship and prove out.** Reviewed a user-supplied third-party spec proposing (a) running
+    `autopep723 check` alongside `pipreqs` in the Default Path discovery phase for all users, and
+    (b) an opt-in `HP_PVW_KNOWN_IDEMPOTENT` flag for runtime (execute-mode) discovery inside
+    `run_setup.bat` -- this is the concrete design that supersedes item 10's own deferred "Shape
+    B." Found and fixed two real problems in the source spec before it could be treated as
+    implementation-ready, both via direct testing and source-code reading, not just review:
+    - **The proposed v1 command (`uvx autopep723 check . > requirements.autopep.txt`) is broken as
+      written.** `autopep723` is strictly single-file (confirmed via its own argument parser --
+      no directory/glob mode exists at all); passing `.` hits `Path.read_text()`'s
+      `IsADirectoryError`, silently caught and turned into an empty result with **exit code 0** --
+      confirmed directly, reproducibly. The spec's own "autopep723 fail != lane fail" fallback
+      would never even trigger, since nothing ever reports nonzero. As designed, the merge would
+      be a permanent no-op on every run. Must target the resolved entry file (`%HP_ENTRY%`), never
+      a directory.
+    - **The spec's central claim ("autopep723 check never reports delta, environment-independent")
+      is false as a blanket statement -- confirmed by reading `autopep723`'s actual source
+      (pulled from the local `uv` cache) and by direct reproduction: a venv with only `requests`
+      pre-installed running `autopep723 check` on a script importing `requests` + `click` silently
+      dropped `requests` from the output.** Root cause: `get_builtin_modules()` unions
+      `sys.builtin_module_names` with `pkgutil.iter_modules()`, which walks whatever Python
+      process is actually running the tool -- any package already installed there gets
+      misclassified as "not third-party." Confirmed this is invocation-method-dependent, not
+      universal: `uvx autopep723 check` is immune to an active `VIRTUAL_ENV` (confirmed directly)
+      but still vulnerable to a leaked `PYTHONPATH` (also confirmed directly) -- and a *direct*
+      interpreter invocation (no `uvx`) is not protected at all. Full empirical trail moved to
+      `docs/agent-lessons-learned.md` (new section) since it's a standalone, reusable fact, not
+      specific to this one plan. **Practical resolution**: the source spec's own v1 snippet
+      already used `uvx`, and `run_setup.bat` already clears `PYTHONPATH`/`PYTHONHOME` well before
+      the discovery phase (REQ-010) -- so Tier 1 as corrected is safe as scoped. The spec's own
+      "Future Lanes" section proposing `conda run python -m autopep723 check` (a direct
+      interpreter invocation) is **not** safe and was flagged as needing revision to keep using
+      `uvx` even there, before ever being built. This also resolves, not just caveats, a mystery
+      the requester raised: a collaborator suspected this exact delta bug, lost the specific
+      repro, and couldn't tell if it was a miscommunication -- it wasn't; the bug is real, it's
+      just conditional on invocation method in a way that made it easy to "fix" by accident
+      between test sessions without anyone identifying why.
+
+    What held up unchanged: `uv add --script` over `autopep723 add` for writeback (already
+    established elsewhere), UV-only writeback (no other package manager has an equivalent
+    mechanism), and `HP_PVW_KNOWN_IDEMPOTENT`'s exit-code branching being a relocation of README's
+    already-shipped, already-tested QuickStart logic rather than a new mechanism -- substantially
+    de-risking it relative to a cold proposal. Not implementation-ready (unlike item 5): no
+    code-grounded pass against the live `run_setup.bat` has happened yet; that is the first step
+    whenever this is picked up.
 
 *(Item 5 from the pre-existing "cosmetic log noise/path doubling" debrief note was checked
 briefly per standing instruction not to over-invest: no `--distpath`/`--workpath` override or

--- a/docs/agent-lessons-learned.md
+++ b/docs/agent-lessons-learned.md
@@ -845,3 +845,70 @@ points back here rather than re-deriving these.
 
 None of this is specific to either feature's own design (hook points, dispatch shape, audience) --
 that detail stays in each plan doc, with a pointer back here for the underlying `uv` facts.
+
+---
+
+## `autopep723`'s own import-detection is environment-leaky under direct invocation, safe under `uvx`
+
+Discovered while reviewing a user-supplied third-party design proposing to run `autopep723 check`
+next to `pipreqs` in `run_setup.bat`'s discovery phase (`docs/plan-autopep723-two-tier.md`). The
+third-party document made a blanket claim, backed by an 11-scenario test matrix, that `autopep723
+check` "never reports delta" and is "environment-independent" -- i.e. it always reports the
+complete set of third-party imports regardless of what's already installed. **This claim is false
+as a blanket statement, confirmed by reading `autopep723`'s actual source (pulled from the local
+`uv` cache, not guessed at) and by direct reproduction -- but the truth is narrower and still
+usable.**
+
+`autopep723`'s `get_builtin_modules()` (the function every one of its commands -- `check`, `add`,
+and the default run mode -- calls before filtering "third-party" from "already accounted for")
+does `set(sys.builtin_module_names) | {m.name for m in pkgutil.iter_modules()}`.
+`pkgutil.iter_modules()` walks `sys.path` of **whichever Python process is currently running
+`autopep723` itself** -- so any package already installed in that process's own environment gets
+silently treated as "not third-party" and dropped from the output, even though it's a real
+dependency the target script needs.
+
+**Reproduced directly**: a venv with only `requests` pre-installed, running `autopep723 check` on
+a script that imports both `requests` and `click`, reported only `click` -- `requests` vanished
+from the output with no error, no warning, nothing distinguishing it from "not needed." This is a
+real, silent under-report, not a hypothetical.
+
+**But it depends entirely on invocation method, not on the tool being unreliable in general**:
+- `uvx autopep723 check <file>` (an isolated `uv`-managed tool venv, recreated/reused per-tool
+  rather than sharing the target script's own environment) is **not** fooled by an active
+  `VIRTUAL_ENV` env var pointing at a dirty environment -- confirmed directly: with `VIRTUAL_ENV`
+  set to a venv that already had `requests` installed, `uvx autopep723 check` still correctly
+  reported both `click` and `requests`.
+- It **is** still fooled by a leaked `PYTHONPATH` -- confirmed directly: setting `PYTHONPATH` to a
+  site-packages directory containing `requests` caused `uvx autopep723 check` to drop `requests`
+  from its output, the same silent failure as the direct-invocation case.
+- A **direct** interpreter invocation (`python -m ...`, `%HP_PY% -m autopep723`, `conda run python
+  -m autopep723`, or any invocation sharing the target script's own populated environment) is
+  **not** protected at all -- it reliably reproduces the delta bug for any package already
+  installed in that interpreter's site-packages.
+
+**Practical rule**: only ever invoke `autopep723` (any subcommand) via `uvx`, never via a direct/
+shared interpreter, and only in a context where `PYTHONPATH` is already known-clear. This repo's
+existing `set "PYTHONPATH="` / `set "PYTHONHOME="` near the top of `run_setup.bat` (REQ-010
+isolation, runs long before any discovery-phase code) already satisfies the second condition for
+any `run_setup.bat`-integrated use of `autopep723`. A design that instead proposes invoking it
+directly through a lane's own interpreter (e.g. `conda run python -m autopep723 check` for a
+future conda-lane integration) is **not** safe as written and must be revised to keep using `uvx`
+even there -- see `docs/plan-autopep723-two-tier.md` for where this correction was applied.
+
+**This also resolves an apparent contradiction, not just a caveat**: a user reported working with
+a third party who suspected this exact delta bug, lost the specific reproduction, and could not
+tell whether it was a miscommunication. It wasn't -- the bug is real and reproduces reliably, it
+just depends on invocation method in a way that made it easy to "fix" by accident (switching from
+a direct interpreter to `uvx` between test sessions) without anyone identifying why the behavior
+had changed.
+
+**One more confirmed, load-bearing fact from the same source-reading pass**: `autopep723` has zero
+runtime dependencies of its own (`Requires-Dist` is empty in its distribution metadata), and is
+strictly single-file -- its argument parser (`cli.py`) has no directory, glob, or multi-file mode
+at all. Passing a directory (e.g. `.`) to any subcommand hits `Path.read_text()`'s
+`IsADirectoryError`, which `get_third_party_imports()` catches and turns into an empty result with
+**exit code 0** (not a nonzero failure) -- confirmed directly: `uvx autopep723 check .` prints an
+error to stderr but still emits a valid, empty `# /// script ... # ///` block and exits clean. Any
+design invoking `autopep723` against `run_setup.bat`'s app directory as a whole (rather than the
+specific resolved entry file, e.g. `%HP_ENTRY%`) will silently produce zero discovered
+dependencies on every run, with no error signal a caller could branch on.

--- a/docs/plan-autopep723-two-tier.md
+++ b/docs/plan-autopep723-two-tier.md
@@ -1,0 +1,226 @@
+# Plan: Two-Tier `autopep723` Integration (Default Path discovery + `HP_PVW_KNOWN_IDEMPOTENT`)
+
+**Status:** Design-only, not scheduled, **sequenced last** in the PEP 723 work: after
+`docs/plan-pep723-writeback.md` is implemented AND `docs/plan-pvw-quickstart.md`'s shipped README
+commands have had time to prove out, per the user's own explicit sequencing. Supersedes
+`plan-pvw-quickstart.md`'s "Shape B" (a vaguely-specified, deliberately-deferred `run_setup.bat`
+hook) with a concrete design -- see that doc's own Shape B section, now pointing here.
+**Owner:** Python_vs_Windows maintainer
+**Source material:** a user-supplied third-party spec ("Two-Tier autopep723 Strategy for PVW").
+Not reproduced verbatim here; this doc states what was verified, what was corrected, and why, per
+this repo's established practice of testing third-party claims directly (source code, not just
+behavior) rather than accepting them on authority.
+**Related:** `docs/plan-pep723-writeback.md` and `docs/plan-pvw-quickstart.md` (both prerequisite,
+must ship first); `docs/agent-lessons-learned.md`'s "`autopep723`'s own import-detection is
+environment-leaky under direct invocation, safe under `uvx`" section (the empirical foundation
+this doc's two corrections are built on -- read that first); `CLAUDE.md` Active Backlog (this item
+is linked from there).
+
+---
+
+## Sequencing (explicit, per the request that raised this)
+
+1. `plan-pep723-writeback.md` ships (automatic write-back inside `run_setup.bat`, uv lane).
+2. `plan-pvw-quickstart.md`'s commands, already shipped in README, get real-world use and comfort.
+3. **This doc's Tier 1**: add `autopep723 check` alongside `pipreqs` in the Default Path discovery
+   phase, for all users, non-gating.
+4. **This doc's Tier 2**: `HP_PVW_KNOWN_IDEMPOTENT`, an opt-in flag enabling runtime
+   (execute-mode) discovery inside `run_setup.bat` itself.
+
+Not scheduled for a specific loop. This document exists so the corrected design is available
+whenever the team is ready to pick up step 3.
+
+---
+
+## Two corrections to the source spec, both found via direct testing and source-code reading
+
+The source spec's central empirical claim -- "autopep723 check never reports delta, it's
+environment-independent" -- was the load-bearing justification for its entire discovery-merge
+design. Both of the following were checked directly rather than trusted, per this repo's
+established pattern for third-party claims (see `plan-pep723-writeback.md`'s own multi-pass
+history). One of the two claims does not hold as stated; the other reveals a concrete
+implementation bug in the spec's own proposed code.
+
+### Correction 1: the proposed insertion snippet passes a directory, not a file -- confirmed broken
+
+The spec's own "Scope: v1" code sample runs:
+```powershell
+uvx autopep723 check . > "requirements.autopep.txt"
+```
+`autopep723` is strictly single-file (confirmed via `cli.py`'s argument parser -- no directory,
+glob, or multi-file mode exists anywhere in the tool). Passing `.` hits `Path.read_text()`'s
+`IsADirectoryError` inside `get_third_party_imports()`, which is caught and converted into an
+**empty result with exit code 0** -- not a nonzero failure the spec's own "autopep723 fail != lane
+fail" fallback logic could catch. Confirmed directly:
+```
+$ uvx autopep723 check .
+Warning: '.' does not have a .py extension.
+Error: Error reading .: [Errno 21] Is a directory: '.'
+# /// script
+# requires-python = ">=3.13"
+# ///
+EXIT: 0
+```
+As written, this design would produce an empty `requirements.autopep.txt` on **every single run**,
+silently, with no error signal -- the entire merge-with-pipreqs mechanism would be a permanent
+no-op. **Fix, mandatory before any implementation**: target the actual resolved entry file (this
+repo's `%HP_ENTRY%`), never a directory or `.`.
+
+### Correction 2: "never reports delta" is false as a blanket claim -- but the real behavior is still usable
+
+See `docs/agent-lessons-learned.md`'s full writeup (the empirical trail, both confirmations and
+counter-examples, lives there -- not duplicated here). Summary of the conclusion: `autopep723`'s
+import detection depends on `pkgutil.iter_modules()`'s view of whatever Python process is running
+it, so it silently drops already-installed packages from its "third-party" output when invoked
+through a *direct* interpreter that already has some of the target script's dependencies
+installed. It does **not** do this when invoked via `uvx` (an isolated tool venv), and `uvx` is
+additionally confirmed immune to an active `VIRTUAL_ENV` pointing at a dirty environment -- but
+still vulnerable to a leaked `PYTHONPATH`.
+
+**Net effect on this design specifically**: the source spec's v1 snippet already uses `uvx`, and
+`run_setup.bat` already clears `PYTHONPATH`/`PYTHONHOME` (REQ-010 isolation) well before the
+discovery phase this design would insert into -- so **Tier 1 as corrected (fixing Correction 1)
+is safe from this hazard as scoped.** The spec's own "Scope: Future Lanes" section, however,
+proposes `conda run python -m autopep723 check` for a hypothetical future conda-lane
+integration -- a *direct* interpreter invocation into a potentially non-empty conda environment.
+**That proposal is not safe and must not be implemented as written** -- any future lane extension
+must keep using `uvx`, never a lane's own interpreter, regardless of which lane it targets.
+
+This also resolves, rather than merely caveats, the "lost reproduction" the requester described:
+a collaborator suspected this exact delta bug, lost the specific repro, and couldn't tell if it
+was a miscommunication. It wasn't a miscommunication -- the bug is real and reliably reproducible,
+it is just conditional on invocation method in a way that made it easy to "fix" by accident
+(switching from a direct interpreter to `uvx` between sessions) without anyone identifying why the
+behavior changed.
+
+---
+
+## What holds up, re-confirmed or already established elsewhere
+
+- **`autopep723 add` loses indirect dependencies; `uv add --script` does not** -- already
+  established across this repo's prior testing (`plan-pep723-writeback.md`,
+  `plan-pvw-quickstart.md`, `agent-lessons-learned.md`'s consolidated `uv` section). The source
+  spec's "Why Not Use autopep723 add for Writeback" reasoning matches this repo's own
+  already-adopted decision; no new verification needed, cited here for completeness.
+- **UV-only writeback** (no `conda add --script`/`pip add --script` equivalent exists) -- same,
+  already established.
+- **`HP_PVW_KNOWN_IDEMPOTENT`'s exit-code branching (0 / 2 / other-nonzero) is not a new design --
+  it is the exact mechanism already built, tested across a dozen-plus scenarios, and shipped in
+  README's "PVW QuickStart" section** (the "Just run it (and remember what it needed)" command).
+  Tier 2 below is that same, already-proven logic relocated into `run_setup.bat` as opt-in code,
+  not a new mechanism invented from scratch. This substantially de-risks Tier 2 relative to how it
+  would look if proposed cold.
+- **`autopep723` has zero runtime dependencies of its own** and is strictly single-file --
+  confirmed via its distribution metadata and `cli.py`'s argument parser. Relevant because it
+  means `pkgutil.iter_modules()` (Correction 2) has nothing of `autopep723`'s own to leak, only
+  whatever the invoking environment happens to already have installed.
+- **uvx tool-venv caching is real** (confirmed faster on a second identical invocation), consistent
+  with `uv`'s documented tool-cache behavior. Not independently re-verified in depth here; low risk
+  if the exact magnitude is off, since it doesn't affect correctness.
+
+---
+
+## Tier 1: Default Path discovery augmentation (corrected design)
+
+**Goal**: run `autopep723 check` alongside `pipreqs` during discovery, merge the results (union),
+for all users, on all lanes eventually (v1: uv lane, matching `plan-pep723-writeback.md`'s own v1
+scope decision) -- non-gating, never a cause of lane failure on its own.
+
+**Insertion point**: after pipreqs completes and `requirements.txt` is finalized, before the
+existing dependency-optimization/heuristics steps -- re-verify the exact label names against the
+live `run_setup.bat` at implementation time (this repo's docs consistently warn that line/label
+anchors drift; treat any specific label name here as illustrative, not guaranteed-current).
+
+**Corrected invocation** (fixing Correction 1):
+```
+uvx autopep723 check "%HP_ENTRY%" > "requirements.autopep.txt" 2>>"%LOG%"
+```
+Never `.`, never a bare directory. `%HP_ENTRY%` is this repo's existing resolved-entry-file
+variable (REQ-002) -- reuse it, do not re-derive an entry path independently.
+
+**Failure semantics** (from the source spec, still sound): `autopep723 check` failing (nonzero
+exit -- a genuine failure this time, not the directory-argument false-zero from Correction 1) must
+never propagate to lane failure. Fall back to pipreqs-only results and continue. `pipreqs` failure
+already has its own established fallback path in this repo; `autopep723` is strictly additive on
+top of that, never a replacement for it.
+
+**Merge**: union of pipreqs's and `autopep723 check`'s package lists, deduplicated. A dedicated
+small Python helper (mirroring `tools/prep_requirements.py`'s existing role, not a from-scratch
+design) is the right shape for this -- simple set-union logic, no TOML parsing needed since this
+touches `requirements.txt`, not a PEP 723 header.
+
+**Not yet implementation-ready**: unlike `plan-pep723-writeback.md`, this section has not had a
+code-grounded pass against the live `run_setup.bat` (exact insertion label, exact variable names,
+exact merge-helper shape). That pass is the first step whenever this is picked up, matching the
+pattern `plan-pep723-writeback.md`'s own Part 2 already establishes.
+
+---
+
+## Tier 2: `HP_PVW_KNOWN_IDEMPOTENT` (corrected, cross-referenced to already-shipped logic)
+
+**Goal**: an opt-in flag causing `run_setup.bat` to use runtime (execute-mode) discovery --
+actually running the user's script via `uvx autopep723 <file>` as part of dependency discovery --
+for advanced users who have explicitly declared their script safe to run more than once.
+
+**This reuses README's already-shipped, already-tested exit-code-branching design verbatim, not a
+new mechanism**: exit 0 (ran clean) -> best-effort persist; exit 2 (malformed header) -> the one
+case where backing up, stripping, and retrying is correct; any other nonzero exit -> fill in what's
+missing without stripping, retry once. Every one of these branches, and the reasoning behind each,
+is already documented in README's "PVW QuickStart" section and `docs/plan-pvw-quickstart.md`'s
+"Pass 2" -- this design does not re-derive it, it relocates it.
+
+**What genuinely changes by moving this into `run_setup.bat`, and must be respected:**
+
+- **REQ-018 interaction, addressed by construction, not by exception.** `plan-pvw-quickstart.md`'s
+  original "Shape B" rejection worried about needing to "re-derive a parallel, smaller version" of
+  REQ-018's safety reasoning for a mode that skips verification. The resolution this sequencing
+  provides: `HP_PVW_KNOWN_IDEMPOTENT` is not asking `run_setup.bat` to skip REQ-018's protections
+  for everyone -- it is an opt-in flag whose very name is the user's own explicit, self-declared
+  consent ("I know this script is idempotent"), which is exactly the category REQ-019 ("flags only
+  suppress, or add an alternate opt-in behavior, never gate the default") already permits. The flag
+  does not change behavior for anyone who doesn't set it.
+- **Must become real `run_setup.bat` code, not just a description.** Unlike Tier 1 (which mostly
+  reuses existing batch/Python plumbing), Tier 2 needs its own embedded helper (base64 payload +
+  canonical `tools/` source + `PayloadSync` test, per this repo's established convention -- see
+  `CLAUDE.md`'s "Rebuilding embedded helper payloads" section) implementing the same branch logic
+  README's PowerShell commands already prove out, translated into whatever language/shape fits
+  `run_setup.bat`'s existing dispatch conventions (goto-based, not parenthesized blocks -- see
+  `agent-lessons-learned.md`'s "Provider-cascade dispatch is goto-based on purpose").
+- **Precondition: uv lane only**, matching Tier 1 and `plan-pep723-writeback.md`'s own v1 scope.
+  Non-uv lanes fall back to the Default Path (Tier 1, or plain `pipreqs` if Tier 1 hasn't shipped
+  yet) with no special handling needed.
+- **`check` mode's role here is unchanged from Correction 2's finding**: if execute mode fails for
+  a reason other than a malformed header, `autopep723 check` is used to discover what's missing --
+  same `uvx`-only, `%HP_ENTRY%`-targeted invocation rule from Tier 1 applies here too, for the same
+  reasons.
+
+**Not yet implementation-ready.** This is a design sketch, deliberately less detailed than Tier 1,
+since it depends on Tier 1 (and both prerequisite plans) shipping first per the sequencing above.
+
+---
+
+## Open questions for whenever this is picked up
+
+- Exact `run_setup.bat` insertion label for Tier 1 (re-verify against the live file, not this doc).
+- Exact shape of the merge helper (new `tools/` file vs. extending `prep_requirements.py`).
+- Whether Tier 2's embedded helper should be Python (matching most of this repo's other embedded
+  helpers) or a translated PowerShell approach closer to README's shipped commands -- Python is
+  likely the better fit given `run_setup.bat`'s existing conventions, but the README commands are
+  the proven reference implementation either way.
+- CI test plan for both tiers (not drafted here -- follow the pattern established in
+  `plan-pep723-writeback.md`'s Part 2.3 and `plan-pvw-quickstart.md`'s CI test plan section).
+
+---
+
+## Critical files for implementation (when scheduled)
+
+- `run_setup.bat` -- Tier 1's discovery-phase insertion; Tier 2's new `HP_PVW_KNOWN_IDEMPOTENT`
+  dispatch and embedded-helper payload declaration.
+- A new or extended `tools/` helper for Tier 1's merge logic.
+- A new embedded helper (Tier 2) following the `tools/collect_submodules.py` /
+  `tools/hidden_import_scan.py` canonical-source-plus-`PayloadSync` pattern.
+- `tests/` -- new CI test file(s) for both tiers.
+- `README.md` -- Tier 2's `HP_PVW_KNOWN_IDEMPOTENT` flag documented alongside the existing
+  "Advanced Environment Variables" table; cross-reference the already-shipped PVW QuickStart
+  section rather than re-explaining the branch logic.
+- `CLAUDE.md` -- Active Backlog pointer, mirroring the existing sibling-plan entries' style.

--- a/docs/plan-pvw-quickstart.md
+++ b/docs/plan-pvw-quickstart.md
@@ -17,9 +17,11 @@ what was kept, what was simplified, and why.
 this feature -- shares its core `uv` empirical foundation with this doc, consolidated in
 `docs/agent-lessons-learned.md`); `docs/agent-lessons-learned.md`'s "`uv add --script` / PEP 723
 empirical behavior" section (the shared empirical foundation both this doc and the sibling depend
-on -- read that first); README's `## Why "Build-First, Run-Once"? (Design Rationale)` section (the
-existing audience-split argument this plan leans on directly); `CLAUDE.md` Active Backlog (this
-item is linked from there).
+on -- read that first); `docs/plan-autopep723-two-tier.md` (the concrete successor to this doc's
+own "Shape B," sequenced to be picked up only after this doc's commands have had real-world use);
+README's `## Why "Build-First, Run-Once"? (Design Rationale)` section (the existing audience-split
+argument this plan leans on directly); `CLAUDE.md` Active Backlog (this item is linked from
+there).
 
 ---
 
@@ -235,6 +237,14 @@ recommended as the first move, for reasons specific to this file rather than to 
 **Recorded here as the fallback if real usage later shows a standalone script is insufficient**
 (e.g. if super users specifically want it triggered *from* an existing `run_setup.bat` folder
 without a second file to manage) -- not implemented now, not scheduled.
+
+**Superseded by a concrete design: see `docs/plan-autopep723-two-tier.md`'s `HP_PVW_KNOWN_IDEMPOTENT`
+section.** That doc takes exactly this Shape B idea and gives it a name, a precondition (uv lane
+only), and an explicit answer to the REQ-018 concern above (an opt-in, self-declaring-consent flag
+is REQ-019-compliant by construction, and the retry/branch logic it would embed is not new design
+-- it's this doc's own already-shipped, already-tested exit-code branching, just relocated into
+`run_setup.bat`). Deliberately sequenced to be picked up only after this doc's own commands have
+had real-world use -- see that doc's own "Sequencing" section.
 
 ---
 


### PR DESCRIPTION
## Summary

Reviewed a user-supplied third-party spec ("Two-Tier autopep723 Strategy for PVW") proposing (1) running `autopep723 check` alongside `pipreqs` in `run_setup.bat`'s discovery phase for all users, and (2) an opt-in `HP_PVW_KNOWN_IDEMPOTENT` flag enabling runtime discovery inside `run_setup.bat` itself — the concrete successor to `plan-pvw-quickstart.md`'s deliberately-deferred "Shape B." Explicitly sequenced **last**, after both `plan-pep723-writeback.md` and `plan-pvw-quickstart.md` ship and prove out, per the requester's own stated sequencing.

Found and fixed two real problems in the source spec before treating it as implementation-ready — both via direct testing and reading `autopep723`'s actual source (pulled from the local `uv` cache), not just review:

- **The proposed v1 command is broken as written.** `uvx autopep723 check . > requirements.autopep.txt` passes a directory; `autopep723` is strictly single-file (confirmed via its own argument parser — no directory/glob mode exists at all). This hits `Path.read_text()`'s `IsADirectoryError`, silently caught and turned into an empty result with **exit code 0** — confirmed directly, reproducibly. The spec's own "autopep723 fail != lane fail" fallback would never trigger since nothing ever reports nonzero; as designed, the discovery-merge would be a permanent no-op on every run. Fix: must target the resolved entry file, never a directory.
- **The spec's central claim ("autopep723 check never reports delta, environment-independent") is false as a blanket statement.** Confirmed by reading `get_builtin_modules()` (unions `sys.builtin_module_names` with `pkgutil.iter_modules()`, which walks whatever process is running the tool) and by direct reproduction: a venv with only one of two needed packages pre-installed silently dropped it from the `check` output. Confirmed this is invocation-method-dependent, not universal: `uvx` is immune to an active `VIRTUAL_ENV` (confirmed directly) but still vulnerable to a leaked `PYTHONPATH` (also confirmed directly), and a direct interpreter invocation isn't protected at all. This repo's existing `PYTHONPATH` clear (REQ-010) plus the spec's own use of `uvx` makes the v1 design safe as scoped — but the spec's own "Future Lanes" section proposes a direct `conda run python -m autopep723 check` invocation that is **not** safe and needs revision before ever being built. This also resolves, not just caveats, a bug report the requester's collaborator raised and couldn't reproduce — it's real, just conditional on invocation method in a way that made it easy to "fix" by accident between test sessions.

## What changed

- New `docs/plan-autopep723-two-tier.md` — the corrected design, explicitly sequenced last.
- `docs/agent-lessons-learned.md` — new standalone section on `autopep723`'s environment-leaky import detection (reusable fact, not specific to this one plan).
- `docs/plan-pvw-quickstart.md` — Shape B section now points to the new doc as its concrete successor.
- `CLAUDE.md` — updated backlog items 6 (the earlier, vaguer "idempotent fast-discovery" idea, now concretized) and 10 (cross-reference), plus new item 11 for this plan.

Documentation only — no `run_setup.bat` or other product code changed.

## Test plan

- [x] `python -m compileall -q .`
- [x] `python tools/check_delimiters.py run_setup.bat`
- [x] `python -m yamllint .github/workflows/`
- [x] `actionlint -oneline .github/workflows/*.yml`
- [x] ASCII sweep (clean)
- [x] PowerShell AST parse sweep (clean)
- [x] `python -m pytest tests/test_*.py -q` (215 passed, 2 skipped)
- [x] Read `autopep723`'s actual source (`__init__.py`, `cli.py`, `commands.py`, `validation.py`) rather than trusting the spec's claims about its internals
- [x] Reproduced the directory-argument bug directly (`uvx autopep723 check .`)
- [x] Reproduced the environment-leak delta bug directly across three invocation modes (direct interpreter with pre-installed packages, `uvx` with active `VIRTUAL_ENV`, `uvx` with leaked `PYTHONPATH`)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015xbWLPbiaKVsobB9FZy8kS

---
_Generated by [Claude Code](https://claude.ai/code/session_015xbWLPbiaKVsobB9FZy8kS)_