### PR TITLE
Loop 2: adversarial-input test scenarios for PEP 723 write-back (REQ-005.11)

### DIFF
--- a/.github/workflows/batch-check.yml
+++ b/.github/workflows/batch-check.yml
@@ -387,6 +387,75 @@ jobs:
         run: |
           & tests\selfapps_warnfix.ps1
 
+      # REQ-005.11: PEP 723 header write-back (uv add --script). v1-scoped to HP_ENV_MODE=uv,
+      # so wired to the dedicated uv lane only (non-gating) for this first CI pass rather than
+      # the gating real lane -- lets these brand-new scenarios prove out in real Windows CI
+      # without risking a merge block if an assumption needs adjusting. Promote to real/conda-
+      # full once stable, mirroring how self.cascade.exec graduated from uv-lane-only.
+      - name: "Self-test: PEP 723 write-back FRESH scenario (uv lane only)"
+        if: ${{ matrix.mode == 'uv' }}
+        env:
+          PEP723_SCENARIO: fresh
+        shell: pwsh
+        run: |
+          & tests\selfapps_pep723_writeback.ps1
+
+      - name: "Self-test: PEP 723 write-back IDEMPOTENT scenario (uv lane only)"
+        if: ${{ matrix.mode == 'uv' }}
+        env:
+          PEP723_SCENARIO: idempotent
+        shell: pwsh
+        run: |
+          & tests\selfapps_pep723_writeback.ps1
+
+      - name: "Self-test: PEP 723 write-back SKIPFLAG scenario (uv lane only)"
+        if: ${{ matrix.mode == 'uv' }}
+        env:
+          PEP723_SCENARIO: skipflag
+        shell: pwsh
+        run: |
+          & tests\selfapps_pep723_writeback.ps1
+
+      - name: "Self-test: PEP 723 write-back MALFORMED scenario (uv lane only)"
+        if: ${{ matrix.mode == 'uv' }}
+        env:
+          PEP723_SCENARIO: malformed
+        shell: pwsh
+        run: |
+          & tests\selfapps_pep723_writeback.ps1
+
+      - name: "Self-test: PEP 723 write-back TRAILING_WS_MALFORMED scenario (uv lane only)"
+        if: ${{ matrix.mode == 'uv' }}
+        env:
+          PEP723_SCENARIO: trailing_ws_malformed
+        shell: pwsh
+        run: |
+          & tests\selfapps_pep723_writeback.ps1
+
+      - name: "Self-test: PEP 723 write-back EXISTING_LOCKFILE scenario (uv lane only)"
+        if: ${{ matrix.mode == 'uv' }}
+        env:
+          PEP723_SCENARIO: existing_lockfile
+        shell: pwsh
+        run: |
+          & tests\selfapps_pep723_writeback.ps1
+
+      - name: "Self-test: PEP 723 write-back NON_UTF8 scenario (uv lane only)"
+        if: ${{ matrix.mode == 'uv' }}
+        env:
+          PEP723_SCENARIO: non_utf8
+        shell: pwsh
+        run: |
+          & tests\selfapps_pep723_writeback.ps1
+
+      - name: "Self-test: PEP 723 write-back WARNFIX scenario (uv lane only)"
+        if: ${{ matrix.mode == 'uv' }}
+        env:
+          PEP723_SCENARIO: warnfix
+        shell: pwsh
+        run: |
+          & tests\selfapps_pep723_writeback.ps1
+
       - name: "Self-test: pre-build collect-submodules double-gate (real/conda-full only)"
         if: ${{ matrix.mode == 'real' || matrix.mode == 'conda-full' }}
         shell: pwsh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -507,22 +507,7 @@ a fact confirmed with no action needed, or a recurring/periodic check belongs in
    creation), and the current fixed order is not wrong, just not optimal in either direction.
    Revisit if the network-correlated-embed-failure pattern shows up for real in CI or user
    reports, rather than speculatively building it now.
-5. **PEP 723 dependency write-back via `uv add --script`** -- full implementation plan at
-   `docs/plan-pep723-writeback.md`. Promotes resolved dependencies into a persistent, authoritative
-   PEP 723 header in the user's own entry `.py` file (using uv's native `uv add --script`) instead
-   of leaving them only in non-authoritative `requirements.auto.txt` -- a second, independently-
-   maintained path to declare dependencies that doesn't depend on `pipreqs`. Scope for v1: uv lane
-   only, best-effort/non-gating, entry file only. Two research/testing passes completed (initial
-   design + scratch-dir verification against uv 0.8.17; a follow-up pass that directly compared uv
-   0.8.17 against current uv 0.11.28 and confirmed real version-drift risk -- e.g. the default
-   write changed from a bare package name to a version-bound one between those releases -- plus a
-   web/GitHub-issues research pass and a code-grounded implementation trace of the actual
-   `run_setup.bat` hook points). **Status: implementation-ready**, sized to fit this repo's "one
-   feature slice per loop" norm (with a suggested two-loop split if the single-loop budget feels
-   tight -- see the plan doc's Part 4). Not yet scheduled for a specific loop; ready whenever
-   picked up. `pip-compile-multi` and `vulture` (researched alongside this) are **not applicable**
-   to this repo (see the plan doc's summary) -- not carried forward as backlog items.
-6. **Opt-in "trust me, my script is idempotent" fast-discovery mode -- now has a concrete design,
+5. **Opt-in "trust me, my script is idempotent" fast-discovery mode -- now has a concrete design,
    see `docs/plan-autopep723-two-tier.md`'s `HP_PVW_KNOWN_IDEMPOTENT` section.** Originally raised
    via a low-confidence 3rd-party analysis with no repo access proposing a `FAST_RUN=true`-style
    flag; that early version's actual proposed mechanism (run the script live, catch a
@@ -531,12 +516,12 @@ a fact confirmed with no action needed, or a recurring/periodic check belongs in
    failure mode REQ-018 exists to prevent. The concrete replacement design in
    `plan-autopep723-two-tier.md` resolves this cleanly: it does not re-invent the retry mechanism,
    it reuses the exit-code-branching logic already built, tested across a dozen-plus scenarios,
-   and shipped in README's "PVW QuickStart" section (item 10 below) -- exit 0/2/other-nonzero, only
+   and shipped in README's "PVW QuickStart" section (item 9 below) -- exit 0/2/other-nonzero, only
    ever destructive on a genuinely malformed header -- relocated into `run_setup.bat` as an opt-in
-   flag, uv lane only, sequenced to be picked up only after both the automatic write-back (item 5)
-   and the QuickStart commands have shipped and proven out. Not scheduled now; the design work
-   itself is done, only the "when to pick this up" decision remains.
-7. **AV-Safe Build Path (PyInstaller quarantine fallback via Nuitka)** -- full PRD at
+   flag, uv lane only, sequenced to be picked up only after both the automatic write-back (now
+   shipped -- REQ-005.11, see Closed Backlog) and the QuickStart commands have proven out. Not
+   scheduled now; the design work itself is done, only the "when to pick this up" decision remains.
+6. **AV-Safe Build Path (PyInstaller quarantine fallback via Nuitka)** -- full PRD at
    `docs/prd-av-safe-build-path.md`. A large, well-specified, preemptive feature (no real user
    report yet, a documented industry-wide problem) covering a two-tier Nuitka fallback when
    PyInstaller's build gets AV-quarantined, including a narrow, well-justified Python-3.12 pin
@@ -550,8 +535,9 @@ a fact confirmed with no action needed, or a recurring/periodic check belongs in
    be permanently frozen into every already-distributed copy of `run_setup.bat`, with no way to
    walk it back later even after the reason for it stops being true. Read that section before
    extending Tier B's pinning pattern anywhere else in this codebase.
-8. **Cross-platform pre-flight checks (low-effort, low-risk, deliberately kept OUT of the PEP 723
-   write-back work -- its own small, fast follow-up loop once that ships).** Raised alongside a
+7. **Cross-platform pre-flight checks (low-effort, low-risk, deliberately kept OUT of the PEP 723
+   write-back work as its own small, fast follow-up loop -- REQ-005.11 has now shipped, see
+   Closed Backlog, so this is ready to pick up).** Raised alongside a
    3rd-party review of the PEP 723 plan (2026-07-12): three cheap, read-only checks worth adding
    near the existing early-warning guards (OneDrive detection, path-length guard, REQ-025 disk
    space) in `run_setup.bat`, all "observe and warn, never silently rewrite" per this repo's
@@ -562,7 +548,7 @@ a fact confirmed with no action needed, or a recurring/periodic check belongs in
      cross-platform papercut. Fix is a one-line addition to `is_py()`'s existing filter (already
      excludes `~`-prefixed names; add a `._`-prefix exclusion the same way) plus skipping any
      `__MACOSX` directory in the same walk. Needs a `PayloadSync`-covered re-sync of
-     `HP_FIND_ENTRY` afterward (see item 9) and a `tests/test_find_entry.py` case.
+     `HP_FIND_ENTRY` afterward (see item 8) and a `tests/test_find_entry.py` case.
    - **System-directory guard.** No check currently exists for the script root being under
      `%WINDIR%`/`%PROGRAMFILES%` (a user occasionally drops a script into a system folder thinking
      it "installs" it) -- the bootstrapper would just fail cryptically on write-permission errors
@@ -572,7 +558,7 @@ a fact confirmed with no action needed, or a recurring/periodic check belongs in
      proposed as new work -- **this already exists** (the path-length guard at the top of
      `run_setup.bat`, warning when the script root approaches the 260-char cmd.exe limit). No
      action needed there; noted here only so it isn't rediscovered as a gap later.
-9. **Promote the remaining embedded-only `HP_*` payloads to the canonical-source-plus-
+8. **Promote the remaining embedded-only `HP_*` payloads to the canonical-source-plus-
    `PayloadSync`-plus-logic-test pattern (moderate effort, not urgent, but a real, confirmed test-
    coverage gap).** A payload-inventory audit done alongside the cross-platform-checks review
    (2026-07-12; see README's "Rebuilding embedded helper payloads" section for the full inventory
@@ -594,7 +580,7 @@ a fact confirmed with no action needed, or a recurring/periodic check belongs in
    each payload's logic is unrelated to the others. Not urgent (no bug has been traced to any of
    these gaps), but real, and the highest-value place to start is `HP_DETECT_PY` given how central
    its output is to the rest of the bootstrap.
-10. **PVW QuickStart -- a super-user command set for running/persisting a `.py` file's
+9. **PVW QuickStart -- a super-user command set for running/persisting a `.py` file's
     dependencies with no EXE build, shipped as copy-paste README commands (full design at
     `docs/plan-pvw-quickstart.md`; user-facing commands live in README's "PVW QuickStart" section).**
     Reviewed and independently re-verified a user-supplied third-party "PEP 723 Megacommand"
@@ -641,12 +627,13 @@ a fact confirmed with no action needed, or a recurring/periodic check belongs in
     Linux); failed-`uv`-install and missing-file error UX are both known-rough, not known-broken
     (though the missing-file case is now confirmed to at least fail into the safe, non-destructive
     branch rather than the strip branch).
-11. **Two-tier `autopep723` integration for `run_setup.bat` itself -- full design at
-    `docs/plan-autopep723-two-tier.md`, deliberately sequenced LAST after items 5 and 10 above
-    both ship and prove out.** Reviewed a user-supplied third-party spec proposing (a) running
+10. **Two-tier `autopep723` integration for `run_setup.bat` itself -- full design at
+    `docs/plan-autopep723-two-tier.md`, deliberately sequenced LAST after the write-back
+    (REQ-005.11, shipped) and item 9 (QuickStart) above both ship and prove out.** Reviewed a
+    user-supplied third-party spec proposing (a) running
     `autopep723 check` alongside `pipreqs` in the Default Path discovery phase for all users, and
     (b) an opt-in `HP_PVW_KNOWN_IDEMPOTENT` flag for runtime (execute-mode) discovery inside
-    `run_setup.bat` -- this is the concrete design that supersedes item 10's own deferred "Shape
+    `run_setup.bat` -- this is the concrete design that supersedes item 9's own deferred "Shape
     B." Found and fixed two real problems in the source spec before it could be treated as
     implementation-ready, both via direct testing and source-code reading, not just review:
     - **The proposed v1 command (`uvx autopep723 check . > requirements.autopep.txt`) is broken as
@@ -684,8 +671,9 @@ a fact confirmed with no action needed, or a recurring/periodic check belongs in
     established elsewhere), UV-only writeback (no other package manager has an equivalent
     mechanism), and `HP_PVW_KNOWN_IDEMPOTENT`'s exit-code branching being a relocation of README's
     already-shipped, already-tested QuickStart logic rather than a new mechanism -- substantially
-    de-risking it relative to a cold proposal. Not implementation-ready (unlike item 5): no
-    code-grounded pass against the live `run_setup.bat` has happened yet; that is the first step
+    de-risking it relative to a cold proposal. Not implementation-ready (unlike the write-back,
+    REQ-005.11, which shipped via a code-grounded implementation pass): no code-grounded pass
+    against the live `run_setup.bat` has happened yet for this item; that is the first step
     whenever this is picked up.
 
 *(Item 5 from the pre-existing "cosmetic log noise/path doubling" debrief note was checked
@@ -992,6 +980,45 @@ of a second or third pin actually needing it.
 
 Items completed and shipped:
 
+- **PEP 723 dependency write-back via `uv add --script` (REQ-005.11)**: full design at
+  `docs/plan-pep723-writeback.md`. Promotes a resolved dependency set into the entry file's own
+  PEP 723 header after a fresh, fully-successful uv-mode dependency install or a fully-successful
+  warnfix repair round, so the pin becomes part of the user's own source rather than only a
+  transient `requirements.txt`/lock file this bootstrapper manages. v1 scope: `HP_ENV_MODE=uv`
+  only, best-effort/non-gating (any failure logs a `[WARN]` and the run continues unaffected).
+  Shipped in two loops per the plan's own Part 4 sizing split:
+  - **Loop 1** (PR #349): the two hook points (`:pep723_writeback`, called from `:lock_done` for
+    the fresh trigger and from the warnfix repair block for the warnfix trigger), the
+    `HP_UV_INSTALL_OK` confirmed-installed gate (reset on every `:after_env_mode_selection` entry
+    for REQ-009 cascade re-entrancy), `tools/pep723_writeback.py` (embedded as
+    `HP_PEP723_WRITEBACK`; strip-and-retry-once on uv's exit code 2, encoding pre-check, file-lock
+    canary, `.py.lock` sidecar check), the `HP_SKIP_PEP723_WRITEBACK` opt-out flag (`[REQ-019]`),
+    and the three simplest/most load-bearing test scenarios (`fresh`/`idempotent`/`skipflag`).
+    A same-PR self code-review pass (Codex reviewer was unavailable/rate-limited; 8 parallel
+    finder-angle agents against the diff) found and fixed two real, confirmed correctness bugs
+    before merge: `read_packages()` didn't filter pip-only requirement-file directives (`-e`,
+    `--hash`, ...), which exit uv's clap parser with the SAME code 2 used to detect a malformed
+    existing header -- confirmed directly against a real `uv` binary that this would wrongly
+    strip a perfectly valid header; and the exit-code-2 strip/retry path read the entry file in
+    text mode without `newline=""`, silently collapsing all CRLF in the whole file to LF on both
+    the stripped write and the restore-on-double-failure write, violating the feature's own "no
+    line-ending normalization, anywhere, ever" rule -- also confirmed via direct repro. Also added
+    a `subprocess` timeout on the `uv add --script` call (same bug class already fixed once for
+    `tools/embed_pyver_check.py`) and reordered `:pep723_writeback`'s gate checks so a
+    dependency-free (stdlib-only) app no longer gets a misleading "install did not fully succeed"
+    log line.
+  - **Loop 2**: the five adversarial-input test scenarios (`malformed`, `trailing_ws_malformed`,
+    `existing_lockfile`, `non_utf8`, `warnfix`) and CI wiring. Confirmed via direct local testing
+    (a scratch `pipreqs` 0.4.13 venv, built from wheels since docopt's sdist doesn't build under
+    modern setuptools) that pipreqs crashes with an unhandled `UnicodeDecodeError` on non-UTF-8
+    source regardless of a PEP 263 coding-cookie override -- a pre-existing limitation independent
+    of this feature, not fixed here -- so the `non_utf8` and `warnfix` scenarios set
+    `HP_SKIP_PIPREQS=1` to keep pipreqs away from the crafted entry file entirely. Wired into the
+    non-gating `uv` lane only for this first CI pass (not the gating `real` lane) so these
+    brand-new scenarios can prove out in real Windows CI without risking a merge block; promoting
+    to `real`/`conda-full` is a natural follow-up once stable, mirroring how `self.cascade.exec`
+    graduated from uv-lane-only. `pip-compile-multi` and `vulture` (researched alongside the
+    original design) were **not applicable** to this repo and were not carried forward.
 - **Three small hardening/cleanup items from the reorder's research pass**: (1)
   `:conda_base_update`'s inline `-Command` PowerShell (run_setup.bat, `:conda_base_update`)
   rewritten to raw .NET APIs (`[System.IO.File]::Exists`/`ReadAllText`/`WriteAllText`,

--- a/docs/agent-ndjson.md
+++ b/docs/agent-ndjson.md
@@ -221,14 +221,18 @@ self.embed.fallback.decline, self.embed.fallback.real
 
 ## selfapps-pep723-writeback NDJSON rows (selfapps_pep723_writeback.ps1, uv-first lanes)
 
-**Not yet wired into `batch-check.yml`** (Loop 1 of a two-loop split; CI wiring is Loop 2 --
-see `docs/plan-pep723-writeback.md` Part 4 / CLAUDE.md Active Backlog). Run manually via
-`PEP723_SCENARIO=<fresh|idempotent|skipflag> pwsh tests/selfapps_pep723_writeback.ps1` until
-wired. Each row emits `skip=true, reason=provider_not_uv` when `HP_ENV_MODE` did not resolve to
-uv (e.g. a conda-only run), mirroring the established `Get-CondaBatPath` skip pattern.
+Eight scenarios (`PEP723_SCENARIO` env var; see the file's own header comment for the full
+setup/assertion table). `fresh`/`idempotent`/`skipflag` are Loop 1 (the simplest, most
+load-bearing cases); `malformed`/`trailing_ws_malformed`/`existing_lockfile`/`non_utf8`/`warnfix`
+are Loop 2's adversarial-input scenarios (see `docs/plan-pep723-writeback.md` Part 2.3 / Part 4).
+Each row emits `skip=true, reason=provider_not_uv` when `HP_ENV_MODE` did not resolve to uv
+(e.g. a conda-only run), mirroring the established `Get-CondaBatPath` skip pattern.
 
 ```
-self.pep723.writeback.fresh, self.pep723.writeback.idempotent, self.pep723.writeback.skipflag
+self.pep723.writeback.fresh, self.pep723.writeback.idempotent, self.pep723.writeback.skipflag,
+self.pep723.writeback.malformed, self.pep723.writeback.trailing_ws_malformed,
+self.pep723.writeback.existing_lockfile, self.pep723.writeback.non_utf8,
+self.pep723.writeback.warnfix
 ```
 
 ---

--- a/tests/selfapps_pep723_writeback.ps1
+++ b/tests/selfapps_pep723_writeback.ps1
@@ -3,19 +3,49 @@
 #
 # Scenarios (controlled by PEP723_SCENARIO env var; default: fresh):
 #
-#   fresh      - No existing header; stub imports requests (pipreqs/heuristic resolves
-#                requests+certifi); no requirements.txt/pyproject.toml pre-seeded.
-#                Emits: self.pep723.writeback.fresh
+#   fresh                - No existing header; stub imports requests (pipreqs/heuristic
+#                          resolves requests+certifi); no requirements.txt/pyproject.toml.
+#                          Emits: self.pep723.writeback.fresh
 #
-#   idempotent - Runs the bootstrapper twice in the same scratch dir without deleting or
-#                modifying the entry file. dist\<env>.exe is removed between runs so the
-#                EXE fast path cannot short-circuit run 2 before it reaches :lock_done --
-#                this forces a genuine second uv add --script invocation, not just a
-#                trivially-unchanged file from an early exit.
-#                Emits: self.pep723.writeback.idempotent
+#   idempotent           - Runs the bootstrapper twice in the same scratch dir without
+#                          deleting or modifying the entry file. dist\<env>.exe is removed
+#                          between runs so the EXE fast path cannot short-circuit run 2
+#                          before it reaches :lock_done -- forces a genuine second
+#                          uv add --script invocation, not a trivially-unchanged file from
+#                          an early exit.
+#                          Emits: self.pep723.writeback.idempotent
 #
-#   skipflag   - HP_SKIP_PEP723_WRITEBACK=1; no pre-existing header.
-#                Emits: self.pep723.writeback.skipflag
+#   skipflag              - HP_SKIP_PEP723_WRITEBACK=1; no pre-existing header.
+#                          Emits: self.pep723.writeback.skipflag
+#
+#   malformed             - Entry pre-seeded with a deliberately broken # /// script block.
+#                          Strip-and-retry must succeed and remove the broken content.
+#                          Emits: self.pep723.writeback.malformed
+#
+#   trailing_ws_malformed - Entry pre-seeded with an otherwise-valid header whose closing
+#                          # /// fence has trailing whitespace (astral-sh/uv#10918) --
+#                          looks fine to a human, invalid to uv's strict parser.
+#                          Emits: self.pep723.writeback.trailing_ws_malformed
+#
+#   existing_lockfile     - No pre-existing header, but a <entry>.py.lock sidecar is
+#                          pre-created before the run. Helper must never invoke uv.
+#                          Emits: self.pep723.writeback.existing_lockfile
+#
+#   non_utf8              - Entry's body is written with a deliberately non-UTF-8 byte
+#                          sequence (cp1252 smart quotes) under a PEP 263 coding cookie
+#                          (so Python itself can still compile it). HP_SKIP_PIPREQS=1 and
+#                          a plain requirements.txt are used so pipreqs -- which crashes
+#                          unhandled on non-UTF-8 source regardless of any coding cookie,
+#                          a pre-existing limitation independent of this feature -- never
+#                          touches the file; only the write-back helper's own encoding
+#                          pre-check needs to be exercised here.
+#                          Emits: self.pep723.writeback.non_utf8
+#
+#   warnfix                - Entry imports xlrd (not heuristic-covered, HP_SKIP_PIPREQS=1
+#                          so pipreqs never discovers it) forcing the warnfix repair loop
+#                          to fire during the build; the SECOND (warnfix) trigger point
+#                          must write back the warnfix-only-discovered module.
+#                          Emits: self.pep723.writeback.warnfix
 #
 # v1 scope gate: the feature only runs under HP_ENV_MODE=uv (docs/plan-pep723-writeback.md
 # Part 2.2). Any lane/run that resolves to a non-uv provider (e.g. conda-full, where
@@ -23,8 +53,7 @@
 # the established Get-CondaBatPath skip-pattern used elsewhere in this suite (see
 # docs/agent-interconnect.md "Skip pattern template").
 #
-# Lane: real/cache/uv/contract-uv (any uv-first lane). Not wired into CI yet (Loop 1 of a
-# two-loop split; see CLAUDE.md plan-pep723-writeback.md Part 4) -- run manually for now.
+# Lane: real/cache/uv/contract-uv (any uv-first lane).
 param()
 $ErrorActionPreference = 'Continue'
 $here = $PSScriptRoot
@@ -43,76 +72,70 @@ function Write-NdjsonRow {
     Add-Content -LiteralPath $ciNd -Value $json -Encoding Ascii
 }
 
+# derived requirement: a small wrapper so every call site below only needs a single line
+# with a LITERAL -Id value -- tools/check_ndjson_registry.py's PowerShell scanner
+# (CODE_NAMEDPARAM_ID_RE) matches a literal `-Id '...'` the same way it matches a literal
+# `id = '...'` hashtable key, so this keeps every row id scanner-visible without repeating
+# a 5-key hashtable literal at each of the ~20 call sites this file needs.
+function Write-Pep723Row {
+    param(
+        [Parameter(Mandatory)][string]$Id,
+        [Parameter(Mandatory)]$Pass,
+        [Parameter(Mandatory)][string]$Desc,
+        [Parameter(Mandatory)][hashtable]$Details
+    )
+    Write-NdjsonRow ([ordered]@{ id = $Id; req = 'REQ-005.11'; pass = $Pass; desc = $Desc; details = $Details })
+}
+
+function Test-BytesEqual {
+    param([byte[]]$A, [byte[]]$B)
+    return ($null -ne $A) -and ($null -ne $B) -and ($A.Length -eq $B.Length) -and
+           (Compare-Object $A $B -SyncWindow 0 | Measure-Object).Count -eq 0
+}
+
 $scenario = if ($env:PEP723_SCENARIO) { $env:PEP723_SCENARIO.ToLower() } else { 'fresh' }
 
-# derived requirement: id assignments below are literal strings per branch, not a shared
-# $rowId variable, so tools/check_ndjson_registry.py's regex-based PowerShell scanner
-# (CODE_HASHTABLE_ID_RE, which only matches `id = '<literal>'`) can find every row id --
-# mirrors the established literal-per-branch convention already used in selfapps_warnfix.ps1.
 $workDirName = switch ($scenario) {
-    'idempotent' { '~selftest_pep723_idempotent' }
-    'skipflag'   { '~selftest_pep723_skipflag' }
-    default      { '~selftest_pep723_fresh' }
+    'idempotent'             { '~selftest_pep723_idempotent' }
+    'skipflag'               { '~selftest_pep723_skipflag' }
+    'malformed'               { '~selftest_pep723_malformed' }
+    'trailing_ws_malformed'   { '~selftest_pep723_trailing_ws' }
+    'existing_lockfile'       { '~selftest_pep723_lockfile' }
+    'non_utf8'                { '~selftest_pep723_nonutf8' }
+    'warnfix'                 { '~selftest_pep723_warnfix' }
+    default                   { '~selftest_pep723_fresh' }
 }
 $bootstrapLog = "~pep723_$($scenario)_bootstrap.log"
 
 # Non-Windows skip
 if (-not $IsWindows) {
     $platform = [System.Environment]::OSVersion.Platform.ToString()
-    if ($scenario -eq 'idempotent') {
-        Write-NdjsonRow ([ordered]@{
-            id      = 'self.pep723.writeback.idempotent'
-            req     = 'REQ-005.11'
-            pass    = $true
-            desc    = "PEP 723 write-back $scenario (skipped on non-Windows)"
-            details = [ordered]@{ skip = $true; scenario = $scenario; platform = $platform; reason = 'non-windows-host' }
-        })
-    } elseif ($scenario -eq 'skipflag') {
-        Write-NdjsonRow ([ordered]@{
-            id      = 'self.pep723.writeback.skipflag'
-            req     = 'REQ-005.11'
-            pass    = $true
-            desc    = "PEP 723 write-back $scenario (skipped on non-Windows)"
-            details = [ordered]@{ skip = $true; scenario = $scenario; platform = $platform; reason = 'non-windows-host' }
-        })
-    } else {
-        Write-NdjsonRow ([ordered]@{
-            id      = 'self.pep723.writeback.fresh'
-            req     = 'REQ-005.11'
-            pass    = $true
-            desc    = "PEP 723 write-back $scenario (skipped on non-Windows)"
-            details = [ordered]@{ skip = $true; scenario = $scenario; platform = $platform; reason = 'non-windows-host' }
-        })
+    $skipDetails = [ordered]@{ skip = $true; scenario = $scenario; platform = $platform; reason = 'non-windows-host' }
+    switch ($scenario) {
+        'idempotent'             { Write-Pep723Row -Id 'self.pep723.writeback.idempotent' -Pass $true -Desc "PEP 723 write-back $scenario (skipped on non-Windows)" -Details $skipDetails }
+        'skipflag'               { Write-Pep723Row -Id 'self.pep723.writeback.skipflag' -Pass $true -Desc "PEP 723 write-back $scenario (skipped on non-Windows)" -Details $skipDetails }
+        'malformed'               { Write-Pep723Row -Id 'self.pep723.writeback.malformed' -Pass $true -Desc "PEP 723 write-back $scenario (skipped on non-Windows)" -Details $skipDetails }
+        'trailing_ws_malformed'   { Write-Pep723Row -Id 'self.pep723.writeback.trailing_ws_malformed' -Pass $true -Desc "PEP 723 write-back $scenario (skipped on non-Windows)" -Details $skipDetails }
+        'existing_lockfile'       { Write-Pep723Row -Id 'self.pep723.writeback.existing_lockfile' -Pass $true -Desc "PEP 723 write-back $scenario (skipped on non-Windows)" -Details $skipDetails }
+        'non_utf8'                { Write-Pep723Row -Id 'self.pep723.writeback.non_utf8' -Pass $true -Desc "PEP 723 write-back $scenario (skipped on non-Windows)" -Details $skipDetails }
+        'warnfix'                 { Write-Pep723Row -Id 'self.pep723.writeback.warnfix' -Pass $true -Desc "PEP 723 write-back $scenario (skipped on non-Windows)" -Details $skipDetails }
+        default                   { Write-Pep723Row -Id 'self.pep723.writeback.fresh' -Pass $true -Desc "PEP 723 write-back $scenario (skipped on non-Windows)" -Details $skipDetails }
     }
     exit 0
 }
 
 $batchPath = Join-Path $repo 'run_setup.bat'
 if (-not (Test-Path $batchPath)) {
-    if ($scenario -eq 'idempotent') {
-        Write-NdjsonRow ([ordered]@{
-            id      = 'self.pep723.writeback.idempotent'
-            req     = 'REQ-005.11'
-            pass    = $false
-            desc    = "PEP 723 write-back $scenario`: run_setup.bat not found"
-            details = [ordered]@{ error = 'run_setup.bat not found at ' + $batchPath }
-        })
-    } elseif ($scenario -eq 'skipflag') {
-        Write-NdjsonRow ([ordered]@{
-            id      = 'self.pep723.writeback.skipflag'
-            req     = 'REQ-005.11'
-            pass    = $false
-            desc    = "PEP 723 write-back $scenario`: run_setup.bat not found"
-            details = [ordered]@{ error = 'run_setup.bat not found at ' + $batchPath }
-        })
-    } else {
-        Write-NdjsonRow ([ordered]@{
-            id      = 'self.pep723.writeback.fresh'
-            req     = 'REQ-005.11'
-            pass    = $false
-            desc    = "PEP 723 write-back $scenario`: run_setup.bat not found"
-            details = [ordered]@{ error = 'run_setup.bat not found at ' + $batchPath }
-        })
+    $missingDetails = [ordered]@{ error = 'run_setup.bat not found at ' + $batchPath }
+    switch ($scenario) {
+        'idempotent'             { Write-Pep723Row -Id 'self.pep723.writeback.idempotent' -Pass $false -Desc "PEP 723 write-back $scenario`: run_setup.bat not found" -Details $missingDetails }
+        'skipflag'               { Write-Pep723Row -Id 'self.pep723.writeback.skipflag' -Pass $false -Desc "PEP 723 write-back $scenario`: run_setup.bat not found" -Details $missingDetails }
+        'malformed'               { Write-Pep723Row -Id 'self.pep723.writeback.malformed' -Pass $false -Desc "PEP 723 write-back $scenario`: run_setup.bat not found" -Details $missingDetails }
+        'trailing_ws_malformed'   { Write-Pep723Row -Id 'self.pep723.writeback.trailing_ws_malformed' -Pass $false -Desc "PEP 723 write-back $scenario`: run_setup.bat not found" -Details $missingDetails }
+        'existing_lockfile'       { Write-Pep723Row -Id 'self.pep723.writeback.existing_lockfile' -Pass $false -Desc "PEP 723 write-back $scenario`: run_setup.bat not found" -Details $missingDetails }
+        'non_utf8'                { Write-Pep723Row -Id 'self.pep723.writeback.non_utf8' -Pass $false -Desc "PEP 723 write-back $scenario`: run_setup.bat not found" -Details $missingDetails }
+        'warnfix'                 { Write-Pep723Row -Id 'self.pep723.writeback.warnfix' -Pass $false -Desc "PEP 723 write-back $scenario`: run_setup.bat not found" -Details $missingDetails }
+        default                   { Write-Pep723Row -Id 'self.pep723.writeback.fresh' -Pass $false -Desc "PEP 723 write-back $scenario`: run_setup.bat not found" -Details $missingDetails }
     }
     exit 1
 }
@@ -122,18 +145,62 @@ if (Test-Path $workDir) { Remove-Item -Recurse -Force $workDir }
 New-Item -ItemType Directory -Force -Path $workDir | Out-Null
 Copy-Item -Path $batchPath -Destination $workDir -Force
 
-# derived requirement: a single "import requests" entry lets both pipreqs and the REQ-005.8
-# requests->certifi heuristic resolve a two-package dependency set, giving the write-back
-# helper something non-trivial to persist. Written BOM-free UTF-8 via .NET API, not a bare
-# PowerShell cmdlet default (docs/plan-pep723-writeback.md Part 2.3's explicit encoding
-# warning: Set-Content/Out-File can default to UTF-16LE-with-BOM or an unwanted BOM).
-$appCode = @'
-import requests
-print('hi')
-'@
 $appPath = Join-Path $workDir 'app.py'
-[System.IO.File]::WriteAllText($appPath, $appCode, (New-Object System.Text.UTF8Encoding($false)))
+$utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+
+function Write-Utf8NoBom {
+    param([string]$Path, [string]$Text)
+    [System.IO.File]::WriteAllText($Path, $Text, $utf8NoBom)
+}
+
+# derived requirement: per-scenario stub construction. Each scenario needs a different
+# pre-existing entry-file state (no header / broken header / trailing-ws header /
+# non-UTF-8 body / a different import) to exercise a different branch of
+# tools/pep723_writeback.py or a different :pep723_writeback trigger.
+switch ($scenario) {
+    'malformed' {
+        Write-Utf8NoBom -Path $appPath -Text "# /// script`nbroken toml (((`n# ///`nimport requests`nprint('hi')`n"
+    }
+    'trailing_ws_malformed' {
+        # Trailing whitespace on the closing fence line, built explicitly (not via a
+        # here-string) so it survives regardless of editor/tooling trailing-space trimming.
+        $text = "# /// script`n# dependencies = [`"click`"]`n# ///" + "   " + "`nimport requests`nprint('hi')`n"
+        Write-Utf8NoBom -Path $appPath -Text $text
+    }
+    'non_utf8' {
+        # cp1252 smart-quote bytes (0x93/0x94) are not valid UTF-8; the PEP 263 coding
+        # cookie lets Python itself still compile the file, but the write-back helper's
+        # own strict UTF-8 pre-check must still skip it. HP_SKIP_PIPREQS=1 (set below)
+        # keeps pipreqs -- which does NOT respect the coding cookie and crashes unhandled
+        # on non-UTF-8 source, confirmed directly against a real pipreqs 0.4.13 -- away
+        # from ever reading this file.
+        $bytes = [System.Collections.Generic.List[byte]]::new()
+        $bytes.AddRange([byte[]][System.Text.Encoding]::ASCII.GetBytes("# -*- coding: cp1252 -*-`nimport requests`n# smart quotes: "))
+        $bytes.Add([byte]0x93)
+        $bytes.AddRange([byte[]][System.Text.Encoding]::ASCII.GetBytes('test'))
+        $bytes.Add([byte]0x94)
+        $bytes.AddRange([byte[]][System.Text.Encoding]::ASCII.GetBytes("`nprint('hi')`n"))
+        [System.IO.File]::WriteAllBytes($appPath, $bytes.ToArray())
+        Write-Utf8NoBom -Path (Join-Path $workDir 'requirements.txt') -Text "requests`n"
+    }
+    'warnfix' {
+        # Mirrors tests/selfapps_warnfix.ps1's real_warnfix scenario: xlrd is not covered
+        # by any REQ-005.8 heuristic, and with pipreqs skipped nothing else discovers it,
+        # so the warnfix repair loop is the ONLY path that installs it -- proving the
+        # warnfix trigger (not the fresh trigger, which has no requirements.txt here)
+        # is what fires the second :pep723_writeback call.
+        Write-Utf8NoBom -Path $appPath -Text "import xlrd`n_ = xlrd.__version__`nprint('hi')`n"
+    }
+    default {
+        Write-Utf8NoBom -Path $appPath -Text "import requests`nprint('hi')`n"
+    }
+}
 $entryBytesPreRun = [System.IO.File]::ReadAllBytes($appPath)
+
+$lockSidecarPath = "$appPath.lock"
+if ($scenario -eq 'existing_lockfile') {
+    Write-Utf8NoBom -Path $lockSidecarPath -Text ''
+}
 
 $envLeaf = Split-Path $workDir -Leaf
 $envName = ($envLeaf -replace '[^A-Za-z0-9_-]', '_')
@@ -146,6 +213,17 @@ if ($scenario -eq 'skipflag') {
     $env:HP_SKIP_PEP723_WRITEBACK = '1'
 } else {
     Remove-Item Env:HP_SKIP_PEP723_WRITEBACK -ErrorAction SilentlyContinue
+}
+
+# derived requirement: non_utf8 and warnfix both need pipreqs kept away from the entry
+# file (see the per-scenario comments above); skipflag/fresh/idempotent/malformed/
+# trailing_ws_malformed/existing_lockfile all want pipreqs running normally so dependency
+# discovery still happens for the fresh trigger.
+$prevSkipPipreqs = if (Test-Path Env:HP_SKIP_PIPREQS) { $env:HP_SKIP_PIPREQS } else { $null }
+if ($scenario -eq 'non_utf8' -or $scenario -eq 'warnfix') {
+    $env:HP_SKIP_PIPREQS = '1'
+} else {
+    Remove-Item Env:HP_SKIP_PIPREQS -ErrorAction SilentlyContinue
 }
 
 function Invoke-Bootstrap {
@@ -178,6 +256,11 @@ try {
     } else {
         $env:HP_SKIP_PEP723_WRITEBACK = $prevSkipFlag
     }
+    if ($null -eq $prevSkipPipreqs) {
+        Remove-Item Env:HP_SKIP_PIPREQS -ErrorAction SilentlyContinue
+    } else {
+        $env:HP_SKIP_PIPREQS = $prevSkipPipreqs
+    }
 }
 
 $logPath   = Join-Path $workDir $bootstrapLog
@@ -195,36 +278,26 @@ if ($scenario -eq 'idempotent') {
 $uvEnvPy  = Join-Path $workDir '.uv_env\Scripts\python.exe'
 $isUvMode = Test-Path -LiteralPath $uvEnvPy
 
-$successPhrase  = '[INFO] REQ-005.11: PEP 723 header write-back succeeded via uv add --script.'
-$skipflagPhrase = '[INFO] REQ-005.11: PEP 723 write-back skipped (HP_SKIP_PEP723_WRITEBACK set).'
-$successFired1  = $combined -match [regex]::Escape($successPhrase)
-$skipflagFired1 = $combined -match [regex]::Escape($skipflagPhrase)
+$successPhrase   = '[INFO] REQ-005.11: PEP 723 header write-back succeeded via uv add --script.'
+$skipflagPhrase  = '[INFO] REQ-005.11: PEP 723 write-back skipped (HP_SKIP_PEP723_WRITEBACK set).'
+$lockfilePhrase  = '[INFO] REQ-005.11: PEP 723 write-back skipped (a .py.lock sidecar already exists).'
+$nonUtf8Phrase   = '[INFO] REQ-005.11: PEP 723 write-back skipped (entry file is not UTF-8).'
+$successFired1   = $combined -match [regex]::Escape($successPhrase)
+$skipflagFired1  = $combined -match [regex]::Escape($skipflagPhrase)
+$lockfileFired1  = $combined -match [regex]::Escape($lockfilePhrase)
+$nonUtf8Fired1   = $combined -match [regex]::Escape($nonUtf8Phrase)
 
 if (-not $isUvMode) {
-    if ($scenario -eq 'idempotent') {
-        Write-NdjsonRow ([ordered]@{
-            id      = 'self.pep723.writeback.idempotent'
-            req     = 'REQ-005.11'
-            pass    = $true
-            desc    = "PEP 723 write-back $scenario (v1 scope gate: HP_ENV_MODE did not resolve to uv)"
-            details = [ordered]@{ skip = $true; scenario = $scenario; reason = 'provider_not_uv' }
-        })
-    } elseif ($scenario -eq 'skipflag') {
-        Write-NdjsonRow ([ordered]@{
-            id      = 'self.pep723.writeback.skipflag'
-            req     = 'REQ-005.11'
-            pass    = $true
-            desc    = "PEP 723 write-back $scenario (v1 scope gate: HP_ENV_MODE did not resolve to uv)"
-            details = [ordered]@{ skip = $true; scenario = $scenario; reason = 'provider_not_uv' }
-        })
-    } else {
-        Write-NdjsonRow ([ordered]@{
-            id      = 'self.pep723.writeback.fresh'
-            req     = 'REQ-005.11'
-            pass    = $true
-            desc    = "PEP 723 write-back $scenario (v1 scope gate: HP_ENV_MODE did not resolve to uv)"
-            details = [ordered]@{ skip = $true; scenario = $scenario; reason = 'provider_not_uv' }
-        })
+    $skipDetails2 = [ordered]@{ skip = $true; scenario = $scenario; reason = 'provider_not_uv' }
+    switch ($scenario) {
+        'idempotent'             { Write-Pep723Row -Id 'self.pep723.writeback.idempotent' -Pass $true -Desc "PEP 723 write-back $scenario (v1 scope gate: HP_ENV_MODE did not resolve to uv)" -Details $skipDetails2 }
+        'skipflag'               { Write-Pep723Row -Id 'self.pep723.writeback.skipflag' -Pass $true -Desc "PEP 723 write-back $scenario (v1 scope gate: HP_ENV_MODE did not resolve to uv)" -Details $skipDetails2 }
+        'malformed'               { Write-Pep723Row -Id 'self.pep723.writeback.malformed' -Pass $true -Desc "PEP 723 write-back $scenario (v1 scope gate: HP_ENV_MODE did not resolve to uv)" -Details $skipDetails2 }
+        'trailing_ws_malformed'   { Write-Pep723Row -Id 'self.pep723.writeback.trailing_ws_malformed' -Pass $true -Desc "PEP 723 write-back $scenario (v1 scope gate: HP_ENV_MODE did not resolve to uv)" -Details $skipDetails2 }
+        'existing_lockfile'       { Write-Pep723Row -Id 'self.pep723.writeback.existing_lockfile' -Pass $true -Desc "PEP 723 write-back $scenario (v1 scope gate: HP_ENV_MODE did not resolve to uv)" -Details $skipDetails2 }
+        'non_utf8'                { Write-Pep723Row -Id 'self.pep723.writeback.non_utf8' -Pass $true -Desc "PEP 723 write-back $scenario (v1 scope gate: HP_ENV_MODE did not resolve to uv)" -Details $skipDetails2 }
+        'warnfix'                 { Write-Pep723Row -Id 'self.pep723.writeback.warnfix' -Pass $true -Desc "PEP 723 write-back $scenario (v1 scope gate: HP_ENV_MODE did not resolve to uv)" -Details $skipDetails2 }
+        default                   { Write-Pep723Row -Id 'self.pep723.writeback.fresh' -Pass $true -Desc "PEP 723 write-back $scenario (v1 scope gate: HP_ENV_MODE did not resolve to uv)" -Details $skipDetails2 }
     }
     exit 0
 }
@@ -238,45 +311,29 @@ if ($scenario -eq 'fresh') {
     $hasRequests   = $entryText -match 'requests'
     $hasCertifi    = $entryText -match 'certifi'
     $freshPass = $successFired1 -and $hasBlockStart -and $hasBlockEnd -and $hasRequiresPy -and $hasRequests -and $hasCertifi
-    Write-NdjsonRow ([ordered]@{
-        id      = 'self.pep723.writeback.fresh'
-        req     = 'REQ-005.11'
-        pass    = $freshPass
-        desc    = 'Fresh dependency install wrote a PEP 723 header via uv add --script'
-        details = [ordered]@{
-            scenario       = $scenario
-            exitCode       = $run1Exit
-            successFired   = $successFired1
-            hasBlockStart  = $hasBlockStart
-            hasBlockEnd    = $hasBlockEnd
-            hasRequiresPy  = $hasRequiresPy
-            hasRequests    = $hasRequests
-            hasCertifi     = $hasCertifi
-        }
+    Write-Pep723Row -Id 'self.pep723.writeback.fresh' -Pass $freshPass -Desc 'Fresh dependency install wrote a PEP 723 header via uv add --script' -Details ([ordered]@{
+        scenario       = $scenario
+        exitCode       = $run1Exit
+        successFired   = $successFired1
+        hasBlockStart  = $hasBlockStart
+        hasBlockEnd    = $hasBlockEnd
+        hasRequiresPy  = $hasRequiresPy
+        hasRequests    = $hasRequests
+        hasCertifi     = $hasCertifi
     })
     if (-not $freshPass) { exit 1 }
     exit 0
 }
 
 if ($scenario -eq 'skipflag') {
-    # Byte-identical check against the pre-run snapshot captured right after the stub was
-    # written, BEFORE run_setup.bat ever touched it.
-    $bytesEqual = ($null -ne $entryBytesPreRun) -and ($null -ne $entryBytesAfterRun1) -and
-                  ($entryBytesPreRun.Length -eq $entryBytesAfterRun1.Length) -and
-                  (Compare-Object $entryBytesPreRun $entryBytesAfterRun1 -SyncWindow 0 | Measure-Object).Count -eq 0
+    $bytesEqual = Test-BytesEqual $entryBytesPreRun $entryBytesAfterRun1
     $skipPass = $skipflagFired1 -and $bytesEqual -and (-not $successFired1)
-    Write-NdjsonRow ([ordered]@{
-        id      = 'self.pep723.writeback.skipflag'
-        req     = 'REQ-005.11'
-        pass    = $skipPass
-        desc    = 'HP_SKIP_PEP723_WRITEBACK=1 suppresses write-back; entry file untouched'
-        details = [ordered]@{
-            scenario        = $scenario
-            exitCode        = $run1Exit
-            skipflagFired   = $skipflagFired1
-            successFired    = $successFired1
-            bytesEqual      = $bytesEqual
-        }
+    Write-Pep723Row -Id 'self.pep723.writeback.skipflag' -Pass $skipPass -Desc 'HP_SKIP_PEP723_WRITEBACK=1 suppresses write-back; entry file untouched' -Details ([ordered]@{
+        scenario      = $scenario
+        exitCode      = $run1Exit
+        skipflagFired = $skipflagFired1
+        successFired  = $successFired1
+        bytesEqual    = $bytesEqual
     })
     if (-not $skipPass) { exit 1 }
     exit 0
@@ -285,33 +342,100 @@ if ($scenario -eq 'skipflag') {
 if ($scenario -eq 'idempotent') {
     $successFired2 = $combined2 -match [regex]::Escape($successPhrase)
     $entryBytesAfterRun2 = if (Test-Path -LiteralPath $appPath) { [System.IO.File]::ReadAllBytes($appPath) } else { $null }
-    $bytesEqual = ($null -ne $entryBytesAfterRun1) -and ($null -ne $entryBytesAfterRun2) -and
-                  ($entryBytesAfterRun1.Length -eq $entryBytesAfterRun2.Length) -and
-                  (Compare-Object $entryBytesAfterRun1 $entryBytesAfterRun2 -SyncWindow 0 | Measure-Object).Count -eq 0
+    $bytesEqual = Test-BytesEqual $entryBytesAfterRun1 $entryBytesAfterRun2
     $idempotentPass = $successFired1 -and $successFired2 -and $bytesEqual
-    Write-NdjsonRow ([ordered]@{
-        id      = 'self.pep723.writeback.idempotent'
-        req     = 'REQ-005.11'
-        pass    = $idempotentPass
-        desc    = 'Two full bootstrap runs produce a byte-identical PEP 723 header (uv add --script idempotency)'
-        details = [ordered]@{
-            scenario       = $scenario
-            run1Exit       = $run1Exit
-            run2Exit       = $run2Exit
-            successFired1  = $successFired1
-            successFired2  = $successFired2
-            bytesEqual     = $bytesEqual
-        }
+    Write-Pep723Row -Id 'self.pep723.writeback.idempotent' -Pass $idempotentPass -Desc 'Two full bootstrap runs produce a byte-identical PEP 723 header (uv add --script idempotency)' -Details ([ordered]@{
+        scenario      = $scenario
+        run1Exit      = $run1Exit
+        run2Exit      = $run2Exit
+        successFired1 = $successFired1
+        successFired2 = $successFired2
+        bytesEqual    = $bytesEqual
     })
     if (-not $idempotentPass) { exit 1 }
     exit 0
 }
 
-Write-NdjsonRow ([ordered]@{
-    id      = 'self.pep723.writeback.fresh'
-    req     = 'REQ-005.11'
-    pass    = $false
-    desc    = "Unknown PEP723_SCENARIO value: $scenario"
-    details = [ordered]@{ scenario = $scenario }
-})
+if ($scenario -eq 'malformed') {
+    $hasRequiresPy = $entryText -match 'requires-python'
+    $hasRequests   = $entryText -match 'requests'
+    $stillBroken   = $entryText -match [regex]::Escape('broken toml (((')
+    $malformedPass = $successFired1 -and $hasRequiresPy -and $hasRequests -and (-not $stillBroken)
+    Write-Pep723Row -Id 'self.pep723.writeback.malformed' -Pass $malformedPass -Desc 'Strip-and-retry replaced a broken PEP 723 header with a freshly-written valid one' -Details ([ordered]@{
+        scenario      = $scenario
+        exitCode      = $run1Exit
+        successFired  = $successFired1
+        hasRequiresPy = $hasRequiresPy
+        hasRequests   = $hasRequests
+        stillBroken   = $stillBroken
+    })
+    if (-not $malformedPass) { exit 1 }
+    exit 0
+}
+
+if ($scenario -eq 'trailing_ws_malformed') {
+    $hasRequiresPy = $entryText -match 'requires-python'
+    $hasRequests   = $entryText -match 'requests'
+    $stillHasClick = $entryText -match [regex]::Escape('click')
+    $trailingWsPass = $successFired1 -and $hasRequiresPy -and $hasRequests -and (-not $stillHasClick)
+    Write-Pep723Row -Id 'self.pep723.writeback.trailing_ws_malformed' -Pass $trailingWsPass -Desc 'A closing fence with trailing whitespace (astral-sh/uv#10918) is still recognized as malformed and fully replaced' -Details ([ordered]@{
+        scenario       = $scenario
+        exitCode       = $run1Exit
+        successFired   = $successFired1
+        hasRequiresPy  = $hasRequiresPy
+        hasRequests    = $hasRequests
+        stillHasClick  = $stillHasClick
+    })
+    if (-not $trailingWsPass) { exit 1 }
+    exit 0
+}
+
+if ($scenario -eq 'existing_lockfile') {
+    $bytesEqual = Test-BytesEqual $entryBytesPreRun $entryBytesAfterRun1
+    $lockUntouched = Test-Path -LiteralPath $lockSidecarPath
+    $lockfilePass = $lockfileFired1 -and $bytesEqual -and $lockUntouched -and (-not $successFired1)
+    Write-Pep723Row -Id 'self.pep723.writeback.existing_lockfile' -Pass $lockfilePass -Desc 'A pre-existing .py.lock sidecar prevents the helper from ever invoking uv add --script' -Details ([ordered]@{
+        scenario       = $scenario
+        exitCode       = $run1Exit
+        lockfileFired  = $lockfileFired1
+        successFired   = $successFired1
+        bytesEqual     = $bytesEqual
+        lockUntouched  = $lockUntouched
+    })
+    if (-not $lockfilePass) { exit 1 }
+    exit 0
+}
+
+if ($scenario -eq 'non_utf8') {
+    $bytesEqual = Test-BytesEqual $entryBytesPreRun $entryBytesAfterRun1
+    $nonUtf8Pass = $nonUtf8Fired1 -and $bytesEqual -and (-not $successFired1)
+    Write-Pep723Row -Id 'self.pep723.writeback.non_utf8' -Pass $nonUtf8Pass -Desc 'A non-UTF-8 entry file is skipped by the encoding pre-check without ever invoking uv' -Details ([ordered]@{
+        scenario      = $scenario
+        exitCode      = $run1Exit
+        nonUtf8Fired  = $nonUtf8Fired1
+        successFired  = $successFired1
+        bytesEqual    = $bytesEqual
+    })
+    if (-not $nonUtf8Pass) { exit 1 }
+    exit 0
+}
+
+if ($scenario -eq 'warnfix') {
+    $warnInstallFired = $combined -match [regex]::Escape('[REPAIR] missing modules detected; installing and rebuilding.')
+    $warnRebuildFired = $combined -match [regex]::Escape('[REPAIR] rebuild complete after warnfix.')
+    $hasXlrd = $entryText -match 'xlrd'
+    $warnfixPass = $successFired1 -and $warnInstallFired -and $warnRebuildFired -and $hasXlrd
+    Write-Pep723Row -Id 'self.pep723.writeback.warnfix' -Pass $warnfixPass -Desc 'The warnfix trigger writes back a module only warnfix (not pipreqs) discovered' -Details ([ordered]@{
+        scenario          = $scenario
+        exitCode          = $run1Exit
+        successFired      = $successFired1
+        warnInstallFired  = $warnInstallFired
+        warnRebuildFired  = $warnRebuildFired
+        hasXlrd           = $hasXlrd
+    })
+    if (-not $warnfixPass) { exit 1 }
+    exit 0
+}
+
+Write-Pep723Row -Id 'self.pep723.writeback.fresh' -Pass $false -Desc "Unknown PEP723_SCENARIO value: $scenario" -Details ([ordered]@{ scenario = $scenario })
 exit 1


### PR DESCRIPTION
## Summary

Loop 2 of `docs/plan-pep723-writeback.md` (Loop 1 shipped in #349). Extends
`tests/selfapps_pep723_writeback.ps1` from 3 scenarios to 8 by adding the five
"resilience under adversarial input" scenarios the plan's Part 4 deferred, and wires
all 8 into CI for the first time.

- **`malformed`** / **`trailing_ws_malformed`**: a pre-existing broken (or
  trailing-whitespace-fenced, astral-sh/uv#10918) PEP 723 header must be stripped and
  replaced by the strip-and-retry path, not left as a stray remnant.
- **`existing_lockfile`**: a pre-existing `<entry>.py.lock` sidecar must prevent the
  helper from ever invoking `uv add --script`.
- **`non_utf8`**: a non-UTF-8 entry file (cp1252 smart quotes under a PEP 263 coding
  cookie, so Python itself can still compile it) is skipped by the encoding pre-check.
  Confirmed via a scratch `pipreqs` 0.4.13 venv (built from wheels, since `docopt`'s
  sdist doesn't build under modern setuptools in this sandbox) that pipreqs crashes
  with an **unhandled** `UnicodeDecodeError` on non-UTF-8 source regardless of the
  coding cookie -- a real, pre-existing repo limitation independent of this feature,
  not fixed here -- so this scenario and `warnfix` both set `HP_SKIP_PIPREQS=1` to
  keep pipreqs away from the crafted file entirely.
- **`warnfix`**: an `xlrd` import (not heuristic-covered, not pipreqs-discoverable
  here) forces the warnfix repair loop to fire, proving the SECOND (warnfix) trigger
  point -- previously untested by any CI scenario -- also writes back correctly.

Replaced the old single-`$rowId`-variable dispatch with a `Write-Pep723Row` helper
taking a literal `-Id` per call site, since `tools/check_ndjson_registry.py`'s
PowerShell scanner matches literal `-Id '...'`/`id = '...'` text, not resolved
variables. Also added a shared `Test-BytesEqual` helper to de-duplicate the
byte-comparison check used across four scenarios (found via a self code-review pass,
see below).

Wires all 8 scenarios into the **non-gating `uv` lane only** (not the gating `real`
lane), so these brand-new scenarios can prove out in real Windows CI without risking
a merge block -- promoting to `real`/`conda-full` is a natural follow-up once stable,
mirroring how `self.cascade.exec` graduated from uv-lane-only.

Updates `docs/agent-ndjson.md` with the 5 new row ids, and `CLAUDE.md`: moves the
now-shipped PEP 723 write-back item from Active to Closed Backlog with a Loop 1/Loop 2
shipped-summary, and renumbers the remaining Active Backlog items (6-11 -> 5-10),
fixing every internal cross-reference.

## Code review

Self code-review since the Codex reviewer is currently unavailable (rate-limited).
7 of 8 parallel finder-angle agents hit a session API limit mid-run; the one that
completed (simplification angle) found no correctness bugs, only minor duplication
cleanup, which is fixed in this PR (the `Test-BytesEqual` helper above). No
production code (`run_setup.bat`) is touched by this PR -- only new tests, CI
wiring, and docs.

## Test plan

- [x] `python -m compileall -q .`
- [x] `python -m pyflakes .`
- [x] `python tools/check_delimiters.py run`
- [x] `python -m yamllint .github/workflows/`
- [x] `actionlint -oneline .github/workflows/*.yml`
- [x] ASCII sweep over all touched files (confirmed the only non-ASCII hits in
      `batch-check.yml` are pre-existing lines untouched by this diff)
- [x] PowerShell AST parse sweep over `tests/*.ps1`
- [x] `python -m pytest tests/test_*.py -q` (237 passed, 2 skipped)
- [x] `python tools/check_ndjson_registry.py` -- clean pass, all 5 new row ids resolved
- [ ] Real Windows CI verification of the 8 `selfapps_pep723_writeback.ps1` scenarios --
      this is the actual point of this PR (first real wiring); `run_setup.bat` is
      Windows-only and cannot be exercised end-to-end in this Linux sandbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015xbWLPbiaKVsobB9FZy8kS

---
_Generated by [Claude Code](https://claude.ai/code/session_015xbWLPbiaKVsobB9FZy8kS)_