### PR TITLE
Fix PR #350 CI failures: wrong certifi assertion + missing continue-on-error

### DIFF
--- a/.github/workflows/batch-check.yml
+++ b/.github/workflows/batch-check.yml
@@ -392,8 +392,15 @@ jobs:
       # the gating real lane -- lets these brand-new scenarios prove out in real Windows CI
       # without risking a merge block if an assumption needs adjusting. Promote to real/conda-
       # full once stable, mirroring how self.cascade.exec graduated from uv-lane-only.
+      # derived requirement: each of these 8 steps has its own continue-on-error: true, not
+      # just the job-level one -- confirmed directly via a real CI run that GitHub Actions'
+      # job-level continue-on-error does NOT make sibling steps in the same job resilient to
+      # an earlier step's failure; without a per-step flag, one failing scenario here silently
+      # skipped every step after it in the SAME job, including pre-existing, unrelated tests
+      # (selfapps_warnfix.ps1, selfapps_collect.ps1, selfapps_hidden_import.ps1, ...).
       - name: "Self-test: PEP 723 write-back FRESH scenario (uv lane only)"
         if: ${{ matrix.mode == 'uv' }}
+        continue-on-error: true
         env:
           PEP723_SCENARIO: fresh
         shell: pwsh
@@ -402,6 +409,7 @@ jobs:
 
       - name: "Self-test: PEP 723 write-back IDEMPOTENT scenario (uv lane only)"
         if: ${{ matrix.mode == 'uv' }}
+        continue-on-error: true
         env:
           PEP723_SCENARIO: idempotent
         shell: pwsh
@@ -410,6 +418,7 @@ jobs:
 
       - name: "Self-test: PEP 723 write-back SKIPFLAG scenario (uv lane only)"
         if: ${{ matrix.mode == 'uv' }}
+        continue-on-error: true
         env:
           PEP723_SCENARIO: skipflag
         shell: pwsh
@@ -418,6 +427,7 @@ jobs:
 
       - name: "Self-test: PEP 723 write-back MALFORMED scenario (uv lane only)"
         if: ${{ matrix.mode == 'uv' }}
+        continue-on-error: true
         env:
           PEP723_SCENARIO: malformed
         shell: pwsh
@@ -426,6 +436,7 @@ jobs:
 
       - name: "Self-test: PEP 723 write-back TRAILING_WS_MALFORMED scenario (uv lane only)"
         if: ${{ matrix.mode == 'uv' }}
+        continue-on-error: true
         env:
           PEP723_SCENARIO: trailing_ws_malformed
         shell: pwsh
@@ -434,6 +445,7 @@ jobs:
 
       - name: "Self-test: PEP 723 write-back EXISTING_LOCKFILE scenario (uv lane only)"
         if: ${{ matrix.mode == 'uv' }}
+        continue-on-error: true
         env:
           PEP723_SCENARIO: existing_lockfile
         shell: pwsh
@@ -442,6 +454,7 @@ jobs:
 
       - name: "Self-test: PEP 723 write-back NON_UTF8 scenario (uv lane only)"
         if: ${{ matrix.mode == 'uv' }}
+        continue-on-error: true
         env:
           PEP723_SCENARIO: non_utf8
         shell: pwsh
@@ -450,6 +463,7 @@ jobs:
 
       - name: "Self-test: PEP 723 write-back WARNFIX scenario (uv lane only)"
         if: ${{ matrix.mode == 'uv' }}
+        continue-on-error: true
         env:
           PEP723_SCENARIO: warnfix
         shell: pwsh

--- a/tests/selfapps_pep723_writeback.ps1
+++ b/tests/selfapps_pep723_writeback.ps1
@@ -309,8 +309,15 @@ if ($scenario -eq 'fresh') {
     $hasBlockEnd   = $entryText -match [regex]::Escape('# ///')
     $hasRequiresPy = $entryText -match 'requires-python'
     $hasRequests   = $entryText -match 'requests'
-    $hasCertifi    = $entryText -match 'certifi'
-    $freshPass = $successFired1 -and $hasBlockStart -and $hasBlockEnd -and $hasRequiresPy -and $hasRequests -and $hasCertifi
+    # derived requirement: certifi is NOT asserted here. Confirmed via a real CI run that
+    # the REQ-005.8.2 requests->certifi heuristic augments ~reqs_conda.txt/~reqs_pip.txt
+    # (conda/pip-targeted translated files), not requirements.txt itself -- and
+    # requirements.txt is the packages source :pep723_writeback's fresh trigger actually
+    # reads. certifi still gets installed (pip/uv resolve it as requests' own transitive
+    # dependency), just never explicitly in requirements.txt, so it correctly never
+    # appears in the written header either -- this is accurate, not a gap: a PEP 723
+    # header should declare direct dependencies, not hand-pin every transitive one.
+    $freshPass = $successFired1 -and $hasBlockStart -and $hasBlockEnd -and $hasRequiresPy -and $hasRequests
     Write-Pep723Row -Id 'self.pep723.writeback.fresh' -Pass $freshPass -Desc 'Fresh dependency install wrote a PEP 723 header via uv add --script' -Details ([ordered]@{
         scenario       = $scenario
         exitCode       = $run1Exit
@@ -319,7 +326,6 @@ if ($scenario -eq 'fresh') {
         hasBlockEnd    = $hasBlockEnd
         hasRequiresPy  = $hasRequiresPy
         hasRequests    = $hasRequests
-        hasCertifi     = $hasCertifi
     })
     if (-not $freshPass) { exit 1 }
     exit 0


### PR DESCRIPTION
## Summary

PR #350 (Loop 2 of REQ-005.11, PEP 723 write-back adversarial scenarios) merged via auto-merge before its first real CI run finished, since the new tests only run in the non-gating `uv` lane. That first run surfaced two real bugs, both fixed here:

- **Wrong test assertion**: `self.pep723.writeback.fresh` asserted `requirements.txt` would contain `certifi` after installing `requests`. It doesn't — the REQ-005.8.2 heuristic (`requests`→`certifi`) augments `~reqs_conda.txt`/`~reqs_pip.txt`, not `requirements.txt` itself, and `requirements.txt` is the packages source `:pep723_writeback`'s fresh trigger actually reads. `certifi` still installs correctly (pip/uv resolve it as `requests`' own transitive dependency); it just never appears explicitly in `requirements.txt` or the written PEP 723 header, which is correct behavior — a header should declare direct dependencies, not hand-pin every transitive one. Removed the incorrect assertion.
- **Missing step-level `continue-on-error`**: none of the 8 new pep723 CI steps in `batch-check.yml` had it, so the first failing scenario silently skipped every subsequent step in the same job — including pre-existing, unrelated tests (`selfapps_warnfix.ps1`, `selfapps_collect.ps1`, `selfapps_hidden_import.ps1`). Job-level `continue-on-error` does not protect sibling steps from an earlier step's failure; only a per-step flag does. Added `continue-on-error: true` to all 8 steps, matching the 9 other sites in this file already using the same idiom.

## Test plan
- [x] `python -m compileall -q .`
- [x] `python -m pyflakes .`
- [x] `python tools/check_delimiters.py run_setup.bat`
- [x] `python -m yamllint .github/workflows/`
- [x] `actionlint -oneline .github/workflows/*.yml`
- [x] PowerShell AST parse sweep (`tests/*.ps1`, `tools/*.ps1`)
- [x] `python -m pytest tests/test_*.py -q` (237 passed, 2 skipped)
- [x] `python tools/check_ndjson_registry.py` (259/259, no mismatches)
- [ ] Real Windows CI (`uv` lane) — confirm all 8 pep723 scenarios execute and pass, and unrelated tests no longer get cascade-skipped

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_015xbWLPbiaKVsobB9FZy8kS

---
_Generated by [Claude Code](https://claude.ai/code/session_015xbWLPbiaKVsobB9FZy8kS)_