### PR TITLE
Fix pep723 writeback malformed scenario: un-commented garbage crashed pipreqs

### DIFF
--- a/tests/selfapps_pep723_writeback.ps1
+++ b/tests/selfapps_pep723_writeback.ps1
@@ -159,7 +159,15 @@ function Write-Utf8NoBom {
 # tools/pep723_writeback.py or a different :pep723_writeback trigger.
 switch ($scenario) {
     'malformed' {
-        Write-Utf8NoBom -Path $appPath -Text "# /// script`nbroken toml (((`n# ///`nimport requests`nprint('hi')`n"
+        # derived requirement: the broken-TOML line MUST carry a leading '#' -- without it,
+        # this stops being a malformed PEP 723 comment block and becomes literal Python source
+        # with an unclosed '(', which crashes pipreqs's ast.parse() with an unhandled
+        # SyntaxError (confirmed via a real CI run) before dependency discovery ever runs, so
+        # requirements.txt stays empty and :pep723_writeback never even attempts uv add
+        # --script. Confirmed via a local repro: the '#'-prefixed form parses fine under
+        # ast.parse (safe for pipreqs) while still making `uv add --script` exit 2 (still
+        # exercises the real strip-and-retry path this scenario exists to test).
+        Write-Utf8NoBom -Path $appPath -Text "# /// script`n# broken toml (((`n# ///`nimport requests`nprint('hi')`n"
     }
     'trailing_ws_malformed' {
         # Trailing whitespace on the closing fence line, built explicitly (not via a


### PR DESCRIPTION
## Summary

PR #351 merged via auto-merge before its first real CI run finished (same pattern as #350 → #351: the pep723 tests only run in the non-gating `uv` lane, so auto-merge doesn't wait on them). That run showed 7 of 8 `self.pep723.writeback.*` scenarios now passing after #351's fix — but `self.pep723.writeback.malformed` still failed (`hasRequiresPy: false`, `stillBroken: true`, completed in ~8s vs. ~50s for the other scenarios).

Root-caused directly against a real `uv` binary: the bug is in the **test's own crafted content**, not production code. `tools/pep723_writeback.py`'s strip-and-retry logic and `run_setup.bat`'s own malformed-PEP-723-header pipreqs-fallback both work correctly — confirmed via local reproduction (`uv add --script` reliably exits 2 on this malformed content, triggering the strip-and-retry path exactly as designed).

The actual defect: the `malformed` scenario's stub wrote a `broken toml (((` line with **no leading `#`**, so it wasn't a malformed PEP 723 *comment* line at all — it was literal Python source with an unclosed `(`. That crashes pipreqs's `ast.parse()` with an unhandled `SyntaxError` before dependency discovery ever completes. With zero packages discovered, `requirements.txt` stayed empty, so `:pep723_writeback`'s fresh trigger correctly found nothing to write back and never even attempted `uv add --script` — matching the anomalously fast ~8s runtime.

Fixed by adding the missing `#` prefix. Confirmed locally that the `#`-prefixed content still makes `uv add --script` exit 2 (the strip-and-retry trigger this scenario exists to test) while no longer crashing `ast.parse`.

## Test plan
- [x] Local repro against a real `uv` 0.8.17 binary: original content → `ast.parse` SyntaxError; `#`-prefixed content → parses clean AND still exits 2 from `uv add --script`, exercising the strip-and-retry path
- [x] `python -m compileall -q .`
- [x] `python -m pyflakes .`
- [x] `python tools/check_delimiters.py run_setup.bat`
- [x] `python -m yamllint .github/workflows/`
- [x] `actionlint -oneline .github/workflows/*.yml`
- [x] PowerShell AST parse sweep (`tests/*.ps1`, `tools/*.ps1`)
- [x] `python -m pytest tests/test_*.py -q` (237 passed, 2 skipped)
- [x] `python tools/check_ndjson_registry.py` (259/259, no mismatches)
- [ ] Real Windows CI (`uv` lane) — confirm all 8/8 pep723 scenarios now pass

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_015xbWLPbiaKVsobB9FZy8kS

---
_Generated by [Claude Code](https://claude.ai/code/session_015xbWLPbiaKVsobB9FZy8kS)_