### PR TITLE
Add PVW QuickStart CI dry-run test (isolated proof before Tier 1/2 integration)

### DIFF
--- a/.github/workflows/batch-check.yml
+++ b/.github/workflows/batch-check.yml
@@ -470,6 +470,29 @@ jobs:
         run: |
           & tests\selfapps_pep723_writeback.ps1
 
+      # derived requirement: dry-run test for the README "PVW QuickStart" copy-paste
+      # commands (uv/autopep723, no run_setup.bat involved) -- an isolated proof that the
+      # underlying tool mechanics work before docs/plan-autopep723-two-tier.md's Tier 1/2
+      # reuse them inside the bootstrapper. Own per-step continue-on-error, matching the
+      # sibling PEP 723 write-back steps above (see that block's own comment for why).
+      - name: "Self-test: PVW QuickStart check-only command (uv lane only)"
+        if: ${{ matrix.mode == 'uv' }}
+        continue-on-error: true
+        env:
+          QUICKSTART_SCENARIO: check
+        shell: pwsh
+        run: |
+          & tests\selfapps_pvw_quickstart.ps1
+
+      - name: "Self-test: PVW QuickStart just-run-it command (uv lane only)"
+        if: ${{ matrix.mode == 'uv' }}
+        continue-on-error: true
+        env:
+          QUICKSTART_SCENARIO: run
+        shell: pwsh
+        run: |
+          & tests\selfapps_pvw_quickstart.ps1
+
       - name: "Self-test: pre-build collect-submodules double-gate (real/conda-full only)"
         if: ${{ matrix.mode == 'real' || matrix.mode == 'conda-full' }}
         shell: pwsh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -924,6 +924,49 @@ of a second or third pin actually needing it.
 
 Items completed and shipped:
 
+- **PVW QuickStart CI dry-run test (`tests/selfapps_pvw_quickstart.ps1`, new, uv lane only)**:
+  requested directly by the maintainer as "a good isolated dry run for the next two before any
+  bootstrapper integration" -- i.e. proof, in real CI, that the underlying `uv`/`autopep723`
+  mechanics README's "PVW QuickStart" section documents actually work as written, BEFORE
+  `docs/plan-autopep723-two-tier.md`'s Tier 1 and Tier 2 build bootstrapper-integrated logic on
+  top of the same mechanics. Two scenarios (`QUICKSTART_SCENARIO=check`/`run`), each copying the
+  relevant README command close to verbatim (the "spaced out" form for `run`, filename
+  substituted only) -- including README's own `irm https://astral.sh/uv/install.ps1 | iex`
+  uv-acquisition line, so the test is self-contained and does not depend on any other CI step's
+  PATH state (`run_setup.bat`'s own uv download is process-local PATH, invisible to a separate
+  PowerShell CI step). Not a `run_setup.bat` test at all -- standalone `uv`/`autopep723` usage
+  only. `check` validates the read-only `uvx autopep723 check <file>` command (exit 0, dependency
+  discovered, file byte-for-byte unchanged) -- this is the exact call Tier 1 will make against
+  `%HP_ENTRY%`. `run` validates the full persist-on-success one-liner (script's own stdout came
+  through, proving real execution; success message printed; PEP 723 header now contains the
+  dependency; no `.bak` left behind on the clean-header path) -- this is the exact logic Tier 2's
+  `HP_PVW_KNOWN_IDEMPOTENT` relocates into `run_setup.bat`. Verified locally before shipping: the
+  underlying `uv`/`autopep723` round-trip (check -> extract dependency names via regex -> `uv add
+  --script`) reproduced directly against a real `uv` 0.8.17 binary, then the actual `.ps1` file's
+  own logic re-verified end-to-end via `pwsh` (both scenarios, `pass:true`, real NDJSON rows) --
+  the only piece that could not be locally verified is the `irm | iex` uv-acquisition line itself,
+  blocked by this sandbox's proxy restrictions on `releases.astral.sh`/`github.com` (identical
+  limitation to every other network-dependent CI step in this repo, e.g. Miniconda/embed-Python
+  downloads -- not something local testing has ever been able to cover). **Found and fixed one
+  real scanner-compatibility bug before shipping**: the first draft computed the NDJSON row id
+  once into a `$ndjsonId` variable and passed it via `-Id $ndjsonId` at both call sites --
+  `tools/check_ndjson_registry.py`'s PowerShell scanner only matches a LITERAL `-Id '...'` string
+  at the call site (documented in `selfapps_pep723_writeback.ps1`'s own `Write-Pep723Row` comment,
+  which this file should have followed from the start), so the scanner reported both new rows as
+  "registered in docs but no matching code emission site found" on the very first
+  `check_ndjson_registry.py` run. Fixed by branching on `$scenario` and using a literal `-Id`
+  string in each branch instead -- confirmed the registry check goes clean afterward. Wired into
+  `batch-check.yml` as two new non-gating steps (own `continue-on-error: true` each, matching the
+  sibling PEP 723 write-back steps' established per-step pattern) right after the write-back
+  block. `docs/agent-ndjson.md` updated with the two new row IDs in the same commit. Deliberately
+  does not add explicit `upload-artifact` path entries for this test's scratch directories (unlike
+  most sibling tests) -- there is no `run_setup.bat` bootstrap log to capture here, and the NDJSON
+  `details` field already carries the load-bearing evidence (exit codes, stdout matches, the exact
+  success/failure message); the full-tree `diag-selftest-*` artifact still captures everything at
+  a coarser level if ever needed. Distinct from the still-not-built "standalone downloadable
+  `pvw_quickstart.ps1` file" mentioned in Active Backlog item 8's history (a packaged script FOR
+  END USERS to run themselves) -- this is a CI test, not a user-facing deliverable. CLOSED by this
+  PR.
 - **`embed_pyver_check.py`'s unreachable "fellback" tag for above-ceiling requests (Active
   Backlog item 2)**: `main()`'s second early-return (after `resolve_table_entry`, firing when the
   resolved `minor` equals `LATEST_MINOR`) previously always wrote `"unchanged|{minor}"`, even

--- a/docs/agent-ndjson.md
+++ b/docs/agent-ndjson.md
@@ -235,6 +235,20 @@ self.pep723.writeback.existing_lockfile, self.pep723.writeback.non_utf8,
 self.pep723.writeback.warnfix
 ```
 
+## selfapps-pvw-quickstart NDJSON rows (selfapps_pvw_quickstart.ps1, uv lane only)
+
+Two scenarios (`QUICKSTART_SCENARIO` env var). A dry-run test for README's "PVW QuickStart"
+copy-paste commands (standalone uv/autopep723 usage, no `run_setup.bat` involved) -- see that
+file's own header comment for the full setup/assertion detail. Both scenarios include their own
+`irm https://astral.sh/uv/install.ps1 | iex` uv-acquisition line (copied from README), so this
+test is self-contained and does not depend on any other CI step's PATH state. Skips with
+`skip=true, reason=non-windows-host` on non-Windows (mirrors this suite's usual convention, even
+though the underlying uv/autopep723 CLI mechanics are cross-platform in principle).
+
+```
+self.pvw_quickstart.check, self.pvw_quickstart.run
+```
+
 ---
 
 ## Key facts for debugging missing rows

--- a/tests/selfapps_pvw_quickstart.ps1
+++ b/tests/selfapps_pvw_quickstart.ps1
@@ -1,0 +1,163 @@
+# ASCII only
+# selfapps_pvw_quickstart.ps1 - Dry-run test for the README "PVW QuickStart" copy-paste
+# commands, run as close to verbatim (and as close to what a real user would paste) as
+# possible -- NOT a run_setup.bat test. This does not touch the bootstrapper at all; it
+# exercises the standalone uv/autopep723 commands documented in README's "PVW QuickStart
+# (Super-User Fast Path)" section directly, including their own `irm .../install.ps1 | iex`
+# uv-acquisition line, so this test is self-contained and does not depend on any other CI
+# step's PATH state.
+#
+# Purpose: an isolated proof that the underlying autopep723/uv mechanics actually work as
+# documented in this exact CI environment, BEFORE building any bootstrapper integration on
+# top of them (docs/plan-autopep723-two-tier.md's Tier 1 reuses the "check" command below;
+# Tier 2's HP_PVW_KNOWN_IDEMPOTENT reuses the "run" command's persist-on-success logic
+# verbatim). If this test ever breaks, that is a signal the underlying tool behavior
+# (autopep723's output format, uv add --script's semantics) has changed upstream, which
+# either tier would inherit.
+#
+# Scenarios (controlled by QUICKSTART_SCENARIO env var; default: check):
+#
+#   check - README's "Check what it would install, without running or changing anything"
+#           command: `uvx autopep723 check <file>`. Read-only; asserts exit 0, the
+#           discovered dependency name appears in the output, and the file itself is left
+#           byte-for-byte unchanged. Emits: self.pvw_quickstart.check
+#
+#   run   - README's "Just run it (and remember what it needed)" command, copied verbatim
+#           (the "spaced out" form) from the README, filename substituted only. Asserts the
+#           script's own stdout came through (proving a real execution happened, not a
+#           mock), the wrapper's success message printed, the file's own PEP 723 header now
+#           contains the dependency, and no .bak file was left behind (the clean-header
+#           path never creates one). Emits: self.pvw_quickstart.run
+#
+# Lane: uv only (matches where autopep723/uv add --script are already exercised elsewhere
+# in this suite -- selfapps_pep723_writeback.ps1). Non-gating.
+param()
+$ErrorActionPreference = 'Continue'
+$here = $PSScriptRoot
+$repo = Split-Path -Path $here -Parent
+$nd   = Join-Path $here '~test-results.ndjson'
+$ciNd = Join-Path $repo 'ci_test_results.ndjson'
+if (-not (Test-Path $nd))   { New-Item -ItemType File -Path $nd   -Force | Out-Null }
+if (-not (Test-Path $ciNd)) { New-Item -ItemType File -Path $ciNd -Force | Out-Null }
+
+function Write-NdjsonRow {
+    param([hashtable]$Row)
+    $lane = [Environment]::GetEnvironmentVariable('HP_CI_LANE')
+    if ($lane -and -not $Row.ContainsKey('lane')) { $Row['lane'] = $lane }
+    $json = $Row | ConvertTo-Json -Compress -Depth 8
+    Add-Content -LiteralPath $nd   -Value $json -Encoding Ascii
+    Add-Content -LiteralPath $ciNd -Value $json -Encoding Ascii
+}
+
+function Write-QuickstartRow {
+    param(
+        [Parameter(Mandatory)][string]$Id,
+        [Parameter(Mandatory)]$Pass,
+        [Parameter(Mandatory)][string]$Desc,
+        [Parameter(Mandatory)][hashtable]$Details
+    )
+    Write-NdjsonRow ([ordered]@{ id = $Id; pass = $Pass; desc = $Desc; details = $Details })
+}
+
+$scenario = if ($env:QUICKSTART_SCENARIO) { $env:QUICKSTART_SCENARIO.ToLower() } else { 'check' }
+
+# Non-Windows skip (matches this suite's convention -- production target is Windows-only,
+# even though the underlying uv/autopep723 CLI mechanics are cross-platform in principle).
+# derived requirement: literal -Id per branch, not a variable -- tools/check_ndjson_registry.py's
+# PowerShell scanner only matches a literal `-Id '...'` string at the call site (see
+# selfapps_pep723_writeback.ps1's own Write-Pep723Row comment for the same convention).
+if (-not $IsWindows) {
+    $platform = [System.Environment]::OSVersion.Platform.ToString()
+    if ($scenario -eq 'run') {
+        Write-QuickstartRow -Id 'self.pvw_quickstart.run' -Pass $true -Desc "PVW QuickStart $scenario (skipped on non-Windows)" -Details ([ordered]@{ skip = $true; scenario = $scenario; platform = $platform; reason = 'non-windows-host' })
+    } else {
+        Write-QuickstartRow -Id 'self.pvw_quickstart.check' -Pass $true -Desc "PVW QuickStart $scenario (skipped on non-Windows)" -Details ([ordered]@{ skip = $true; scenario = $scenario; platform = $platform; reason = 'non-windows-host' })
+    }
+    exit 0
+}
+
+$workDir = Join-Path $here "~selftest_pvw_quickstart_$scenario"
+if (Test-Path $workDir) { Remove-Item -Recurse -Force $workDir }
+New-Item -ItemType Directory -Force -Path $workDir | Out-Null
+Push-Location $workDir
+try {
+    # README's own first line: acquire uv exactly as a real user pasting the command would.
+    # Self-contained on purpose -- does not depend on any earlier CI step's uv acquisition
+    # (run_setup.bat's own uv download is process-local PATH, not visible to this step).
+    irm https://astral.sh/uv/install.ps1 | iex
+    $env:Path = "$env:USERPROFILE\.local\bin;$env:Path"
+
+    $f = "solve_my_probs.py"
+    # A single real, importable third-party dependency (requests) -- simple, stable,
+    # already used elsewhere in this repo's own test fixtures.
+    Set-Content -LiteralPath $f -Value "import requests`nprint('hello-quickstart-demo')`n" -Encoding Ascii -NoNewline
+
+    if ($scenario -eq 'check') {
+        # README: "Check what it would install, without running or changing anything"
+        $before = [System.IO.File]::ReadAllBytes((Get-Item $f).FullName)
+        $chk = (uvx autopep723 check $f) -join "`n"
+        $rc = $LASTEXITCODE
+        $after = [System.IO.File]::ReadAllBytes((Get-Item $f).FullName)
+        $unchanged = ($before.Length -eq $after.Length) -and ((Compare-Object $before $after -SyncWindow 0 | Measure-Object).Count -eq 0)
+        $foundDep = $chk -match 'requests'
+        $pass = ($rc -eq 0) -and $foundDep -and $unchanged
+        Write-QuickstartRow -Id 'self.pvw_quickstart.check' -Pass $pass -Desc 'PVW QuickStart check-only command discovers deps without modifying the file' -Details ([ordered]@{ exitCode = $rc; foundDep = [bool]$foundDep; fileUnchanged = $unchanged; output = $chk })
+    } else {
+        # README: "Just run it (and remember what it needed)" -- spaced-out form, copied
+        # verbatim from README.md's "PVW QuickStart" section, filename substituted only.
+        $enc = [System.Text.Encoding]::GetEncoding("ISO-8859-1")
+        $original = [System.IO.File]::ReadAllText((Get-Item $f).FullName, $enc)
+
+        function Persist($f) {
+            $chk = (uvx autopep723 check $f) -join "`n"
+            if ($LASTEXITCODE -ne 0) { return $false }
+            $names = [regex]::Matches($chk, '^#\s*"([^"]+)",?\s*$', 'Multiline') | ForEach-Object { $_.Groups[1].Value }
+            if ($names.Count -eq 0) { return $true }
+            uv add --script $f $names
+            return ($LASTEXITCODE -eq 0)
+        }
+
+        $runOutput = uvx autopep723 $f
+        $rc = $LASTEXITCODE
+        $message = $null
+
+        if ($rc -eq 0) {
+            if (Persist $f) {
+                $message = "Ran successfully and remembered what it needed."
+            } else {
+                $message = "Ran successfully, but could not update the dependency header - nothing was changed there."
+            }
+        } elseif ($rc -eq 2) {
+            $message = "Header is malformed - retrying with a clean version..."
+            [System.IO.File]::WriteAllText("$((Get-Item $f).FullName).bak", $original, $enc)
+            $c = $original -replace "(?ms)^# /// script\r?\n.*?^# ///[ \t]*\r?\n?", ""
+            [System.IO.File]::WriteAllText((Get-Item $f).FullName, $c, $enc)
+            uvx autopep723 $f
+            if ($LASTEXITCODE -eq 0) {
+                if (Persist $f) { $message = "Ran successfully after repair and remembered a fresh header." }
+                else { $message = "Ran successfully after repair, but could not update the header." }
+            } else {
+                $message = "Retry also failed - restoring your original file untouched."
+                [System.IO.File]::WriteAllText((Get-Item $f).FullName, $original, $enc)
+            }
+            Remove-Item -ErrorAction SilentlyContinue "$f.bak"
+        } else {
+            $message = "Run failed with an existing header in place - trying to fill in any missing dependencies..."
+            Persist $f | Out-Null
+            uvx autopep723 $f
+            if ($LASTEXITCODE -eq 0) { $message = "Ran successfully after filling in missing dependencies." }
+            else { $message = "Run still failed - this looks like a script-level issue, not a dependency gap, so nothing further was attempted." }
+        }
+
+        $finalContent = Get-Content -LiteralPath $f -Raw
+        $scriptRan = $runOutput -match 'hello-quickstart-demo'
+        $depPersisted = $finalContent -match 'requests'
+        $noBakLeftBehind = -not (Test-Path "$f.bak")
+        $pass = $scriptRan -and $depPersisted -and $noBakLeftBehind -and ($message -eq "Ran successfully and remembered what it needed.")
+        Write-QuickstartRow -Id 'self.pvw_quickstart.run' -Pass $pass -Desc 'PVW QuickStart just-run-it command executes the script and persists what it needed' -Details ([ordered]@{ exitCode = $rc; scriptRan = [bool]$scriptRan; depPersisted = [bool]$depPersisted; noBakLeftBehind = $noBakLeftBehind; message = $message })
+    }
+} finally {
+    Pop-Location
+}
+
+exit 0


### PR DESCRIPTION
## Summary
- New `tests/selfapps_pvw_quickstart.ps1` (uv lane only, non-gating): a dry-run test for README's "PVW QuickStart" copy-paste commands, requested directly to serve as "a good isolated dry run for the next two before any bootstrapper integration" -- proving the underlying `uv`/`autopep723` mechanics work in real CI *before* `docs/plan-autopep723-two-tier.md`'s Tier 1 (default-path discovery augmentation) and Tier 2 (`HP_PVW_KNOWN_IDEMPOTENT`) build bootstrapper-integrated logic on top of the same mechanics.
- Two scenarios, each copying the relevant README command close to verbatim (including README's own `irm https://astral.sh/uv/install.ps1 | iex` line, so the test is self-contained and doesn't depend on any other CI step's PATH state):
  - `check` -- validates `uvx autopep723 check <file>` (Tier 1's exact building block): exit 0, dependency discovered, file byte-for-byte unchanged.
  - `run` -- validates the full persist-on-success one-liner (Tier 2's exact building block): script's own stdout came through (proving real execution), success message printed, PEP 723 header now contains the dependency, no `.bak` left behind.
- Not a `run_setup.bat` test at all -- standalone `uv`/`autopep723` usage only.
- Verified locally end-to-end (both scenarios pass with real NDJSON output) except the `irm | iex` uv-acquisition line itself, blocked by this sandbox's proxy restrictions on `releases.astral.sh`/`github.com` -- same limitation as every other network-dependent CI step in this repo (Miniconda/embed-Python downloads, etc.).
- Found and fixed a real scanner-compatibility bug before shipping: `tools/check_ndjson_registry.py`'s PowerShell scanner only matches a literal `-Id '...'` string at the call site, not a variable -- the first draft computed the row id once and passed it via a variable at both call sites, which the scanner correctly flagged as unresolvable. Fixed by branching on scenario and using a literal `-Id` string in each branch.
- Wired into `batch-check.yml` as two new non-gating steps (own `continue-on-error: true` each, matching the sibling PEP 723 write-back steps' pattern). `docs/agent-ndjson.md` updated with the two new row IDs.

## Test plan
- [x] `python -m compileall -q .`
- [x] `python tools/check_delimiters.py run_setup.bat`
- [x] `python -m yamllint .github/workflows/` / `actionlint -oneline .github/workflows/*.yml`
- [x] ASCII sweep on touched files
- [x] PowerShell AST parse sweep (`tests/*.ps1`, `tools/*.ps1`)
- [x] `python -m pytest tests/test_*.py -q` (330 passed, 2 skipped)
- [x] `python tools/check_ndjson_registry.py` (PASS, no mismatches)
- [x] Local end-to-end dry run of both scenarios via `pwsh` against a crafted temp project, confirming real `pass:true` NDJSON output for both
- [x] Directly reproduced the underlying `uv`/`autopep723` round-trip (check -> extract dependency names -> `uv add --script`) against a real `uv` 0.8.17 binary before writing the PowerShell wrapper
- [ ] Real Windows CI (`uv` lane, non-gating)

Co-Authored-By: Claude <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_015xbWLPbiaKVsobB9FZy8kS)_