### PR TITLE
fix: requirement-9 swap-verification check tested the wrong file

### DIFF
--- a/.github/workflows/batch-check.yml
+++ b/.github/workflows/batch-check.yml
@@ -558,10 +558,10 @@ jobs:
           & tests\selfapps_nuitka_tiera_hidden_skip.ps1
 
       # AV-Safe Build Path requirement 9 (P1): the elective "want an optimized build too?"
-      # upsell after a normal successful PyInstaller build. Three scenarios in one file/lane
-      # (uv, non-gating) -- 'accept' depends on a real Nuitka build succeeding (same reasoning
-      # as the Tier A steps above); 'forcefail'/'decline' are deterministic but kept in the same
-      # lane for consistency with the shared NDJSON row id.
+      # upsell after a normal successful PyInstaller build. Four scenarios in one file/lane
+      # (uv, non-gating) -- 'accept'/'swapfail' depend on a real Nuitka build succeeding (same
+      # reasoning as the Tier A steps above); 'forcefail'/'decline' are deterministic but kept in
+      # the same lane for consistency with the shared NDJSON row id.
       - name: "Self-test: optimized-build offer, accept (uv lane, non-gating)"
         if: ${{ matrix.mode == 'uv' }}
         shell: pwsh
@@ -575,6 +575,14 @@ jobs:
         shell: pwsh
         env:
           OPTBUILD_SCENARIO: forcefail
+        run: |
+          & tests\selfapps_optimized_build.ps1
+
+      - name: "Self-test: optimized-build offer, swap failure leaves original untouched (uv lane, non-gating)"
+        if: ${{ matrix.mode == 'uv' }}
+        shell: pwsh
+        env:
+          OPTBUILD_SCENARIO: swapfail
         run: |
           & tests\selfapps_optimized_build.ps1
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -875,6 +875,32 @@ of a second or third pin actually needing it.
 
 Items completed and shipped:
 
+- **Refinement-pass fix on shipped requirement 9: the post-swap "did it work" check tested the
+  wrong file, silently misreporting a failed swap as success.** Found via a self-directed
+  refinement/code-review pass on the just-merged PR #370 (`:offer_optimized_build`), requested
+  directly by the owner ("do some more refinement iterations on latest work"). The original check
+  was `if not exist "dist\%ENVNAME%.exe"` after `move /y "dist\%HP_OPTBUILD_TMP%"
+  "dist\%ENVNAME%.exe"` -- but `dist\%ENVNAME%.exe` is the DESTINATION, the already-working
+  original EXE this subroutine exists to (maybe) replace, so it already exists BEFORE the move
+  runs, success or failure alike. A same-volume `move /y` onto an existing destination is an
+  atomic rename-replace: on success the SOURCE is consumed; on failure (e.g. an AV/indexer lock on
+  the destination -- the exact hazard class already documented for `:try_embed_fallback`'s own
+  `rd`/`move` swap, see `docs/agent-lessons-learned.md`) the whole operation is rejected and the
+  source is left untouched, with the destination unaffected either way -- so the old
+  destination-existence check could never actually detect a failed swap. A real failure would have
+  been silently misreported as `[INFO] Optimized build succeeded and verified...`,
+  `HP_NUITKA_FALLBACK_USED` would be wrongly set (incorrectly disabling
+  `:hidden_import_recover`'s auto-recovery for what is still a PyInstaller-built EXE), and the
+  leftover temp file would never be cleaned up (the old failure branch didn't route through the
+  shared `:optbuild_cleanup` label either). Fixed by checking whether the SOURCE is gone instead,
+  and by routing this failure through `:optbuild_cleanup` like every other failure branch (fixes
+  the temp-file leak too). New test hook `HP_TEST_FORCE_OPTBUILD_SWAP_FAIL` (skips the real
+  `move`, deliberately leaving the temp file in place to reproduce the exact "source still exists
+  after move" failure signature without depending on an artificial OS-level file lock) and a new
+  `swapfail` scenario in `tests/selfapps_optimized_build.ps1` (uv lane, non-gating, real Nuitka
+  build + verify, like `accept`) prove the fix. See `docs/agent-interconnect.md`'s requirement 9
+  section for the full trace. CLOSED by this pass.
+
 - **AV-Safe Build Path requirement 9 (P1): the elective "want an optimized build too?" upsell
   after a normal successful PyInstaller build.** Owner explicitly greenlit this ("go ahead and
   do requirement 9 ... I personally want the optimized build") in the same message that

--- a/docs/agent-interconnect.md
+++ b/docs/agent-interconnect.md
@@ -149,6 +149,31 @@ the original. Every failure branch (`goto :optbuild_cleanup`) deletes only the t
 leaves `dist\%ENVNAME%.exe` completely untouched -- see the subroutine's own header comment in
 `run_setup.bat` for the full branch-by-branch trace.
 
+**Real bug found and fixed via a refinement-pass code review, same day as PR #370 merged: the
+post-swap "did it work" check tested the wrong file.** The original code checked `if not exist
+"dist\%ENVNAME%.exe"` after the `move /y` to decide whether the swap succeeded -- but
+`dist\%ENVNAME%.exe` is the DESTINATION, which is the already-working original EXE this whole
+subroutine exists to (maybe) replace, so it already exists BEFORE the move runs, success or
+failure alike. A same-volume `move /y` onto an existing destination is an atomic rename-replace:
+on success the SOURCE (`dist\%HP_OPTBUILD_TMP%`) is consumed; on failure (e.g. an AV/indexer lock
+on the destination -- the exact hazard class already documented immediately below for
+`:try_embed_fallback`'s own `rd`/`move` swap) the whole operation is rejected and the source is
+left untouched, with the destination unaffected either way. The old destination-existence check
+could therefore never actually detect a failed swap -- a real failure would be silently
+misreported as `[INFO] Optimized build succeeded and verified...`, `HP_NUITKA_FALLBACK_USED`
+would be wrongly set (incorrectly disabling `:hidden_import_recover`'s auto-recovery for what is
+still a PyInstaller-built EXE, per the section above), and the leftover temp file at
+`dist\%HP_OPTBUILD_TMP%` would never be cleaned up (the old failure branch didn't route through
+`:optbuild_cleanup` either). Fixed by checking whether the SOURCE is gone instead, and by routing
+this failure through the shared `:optbuild_cleanup` label like every other failure branch (which
+also fixes the temp-file leak as a side effect). New test hook
+`HP_TEST_FORCE_OPTBUILD_SWAP_FAIL` (skips the real `move` and deliberately leaves the temp file in
+place, reproducing the exact "source still exists after move" failure signature without depending
+on an artificial OS-level file lock) and a new `swapfail` scenario in
+`tests/selfapps_optimized_build.ps1` (uv lane, non-gating, real Nuitka build + verify, like
+`accept`) prove the fix: the original EXE is left completely untouched and still runs, the
+leftover temp file is cleaned up, and the success message never logs.
+
 **Gated on the SAME `HP_NUITKA_FALLBACK_USED` flag Tier A sets, but for the opposite reason.**
 Tier A's hidden-import-recovery guard (section above) checks the flag to SKIP a PyInstaller-only
 repair mechanism against a Nuitka EXE. This subroutine checks the flag to SKIP OFFERING THE PROMPT

--- a/docs/agent-ndjson.md
+++ b/docs/agent-ndjson.md
@@ -380,7 +380,7 @@ this feature builds to a distinct temp filename, verifies the new build actually
 then swaps it into `dist\<env>.exe` -- on any failure at any stage the original, already-working
 EXE is left completely untouched.
 
-Three scenarios (`OPTBUILD_SCENARIO` env var), all in this one file/lane:
+Four scenarios (`OPTBUILD_SCENARIO` env var), all in this one file/lane:
 - `accept` (`HP_TEST_OPTBUILD_ANSWER=Y`, no forced failure): a REAL Nuitka build runs, is
   verified, and is swapped into place. Same non-gating reasoning as `self.exe.build.tiera` --
   depends on a real Nuitka build succeeding, which could not be verified locally.
@@ -388,11 +388,22 @@ Three scenarios (`OPTBUILD_SCENARIO` env var), all in this one file/lane:
   build is forced to fail deterministically (no real Nuitka attempt); asserts the original
   PyInstaller-built `dist\<env>.exe` is left completely untouched and still runs (re-executed
   directly by the test after the bootstrap completes, not just checked for existence).
+- `swapfail` (`HP_TEST_OPTBUILD_ANSWER=Y` + `HP_TEST_FORCE_OPTBUILD_SWAP_FAIL=1`): a REAL Nuitka
+  build runs and verifies successfully (same as `accept`), but the final move-into-place step is
+  forced to fail. Regression test for a real bug found via a refinement-pass code review (see
+  Closed Backlog): the original "did the swap succeed" check tested whether `dist\<env>.exe` (the
+  destination) existed -- but that file already exists BEFORE the move (it's the already-working
+  original), so a genuinely failed `move /y` (e.g. an AV/indexer lock on the destination -- the
+  same hazard class already documented for `:try_embed_fallback`'s own swap in
+  `docs/agent-lessons-learned.md`) was silently misreported as success. Asserts the original EXE
+  is left completely untouched and still runs, the leftover temp file is cleaned up (also part of
+  the fix -- the old failure branch never routed through the shared `:optbuild_cleanup` label),
+  and the "succeeded and verified" message is never logged.
 - `decline` (neither env var set): falls through to the ambient `HP_CI_LANE` auto-decline, the
   same mechanism `selfapps_postexec_checkpoint.ps1`'s own `self.checkpoint.decline` scenario
   relies on; asserts the prompt is shown but no build is ever attempted.
 
-All three deliberately kept in one file/lane rather than split across gating/non-gating lanes by
+All four deliberately kept in one file/lane rather than split across gating/non-gating lanes by
 determinism, matching this repo's established multi-scenario pattern (e.g.
 `selfapps_pyinstaller_fail.ps1`'s `PYI_FAIL_SCENARIO`) -- promote once proven stable, matching
 this repo's established graduation pattern.

--- a/docs/demo-bootstrapper-output.md
+++ b/docs/demo-bootstrapper-output.md
@@ -229,7 +229,7 @@ point and attempted a PyInstaller rebuild against a Nuitka-built EXE. The real C
 
 ---
 
-## Scenario 4: Requirement 9 -- elective "want an optimized build too?" offer -- ALL THREE CONFIRMED
+## Scenario 4: Requirement 9 -- elective "want an optimized build too?" offer -- 4a/4b/4c CONFIRMED, 4d new/pending
 
 **What's tested:** `self.optbuild.offer` (`tests/selfapps_optimized_build.ps1`, uv lane,
 non-gating), three scenarios sharing one row id.
@@ -365,6 +365,31 @@ block remains sourced from `run_setup.bat` rather than a real log capture:
 [WARN] Optimized build did not complete; your app is still ready to use as-is.
 [WARN] Hint: if you have Visual Studio 2022 (or newer) with the 'Desktop development with C++' workload installed, this should use it automatically -- no extra setup needed. If not, installing the free Visual Studio Build Tools with that workload can help.
 ```
+
+### 4d. `swapfail` -- verified build, but the final swap step fails -- new scenario, real bug fixed, not yet CI-confirmed
+
+Found via a refinement-pass code review of the just-merged PR #370: the original "did the swap
+succeed" check (`if not exist "dist\<env>.exe"` after `move /y`) tested the DESTINATION -- but
+that file is the already-working original EXE this whole subroutine exists to maybe replace, so
+it already exists before the move runs, success or failure alike. A genuinely failed swap (e.g.
+an AV/indexer lock on the destination) would have been silently misreported as success, telling
+the user their app now uses the optimized build when it actually doesn't, and incorrectly
+disabling the hidden-import auto-recovery loop for what is still a PyInstaller-built EXE. Fixed by
+checking whether the SOURCE (the temp file) is gone instead, which correctly distinguishes success
+from failure regardless of whether the destination pre-existed. New test hook
+`HP_TEST_FORCE_OPTBUILD_SWAP_FAIL` and a new `swapfail` scenario reproduce this deterministically
+(skip the real `move`, leave the temp file in place) without depending on an artificial file lock.
+Not yet run in real CI as of this doc update -- expected message, sourced from `run_setup.bat`:
+
+```
+*** Your app is ready. ***
+*** Want to build an optimized version too? ... ***
+[INFO] Optimized build: accepted; building now (this may take a minute or two).
+[WARN] Optimized build verified successfully but could not be swapped into place; your app is still ready to use as-is.
+```
+
+See `docs/agent-interconnect.md`'s requirement 9 section and `CLAUDE.md`'s Closed Backlog for the
+full trace.
 
 ---
 

--- a/run_setup.bat
+++ b/run_setup.bat
@@ -332,6 +332,14 @@ rem deterministically (without attempting a real Nuitka build), so the "original
 rem completely untouched on failure" guarantee can be tested without depending on a real,
 rem environment-dependent Nuitka build outcome. Mirrors HP_TEST_FORCE_NUITKA_FAIL.
 set "HP_TEST_FORCE_OPTBUILD_FAIL=%HP_TEST_FORCE_OPTBUILD_FAIL%"
+rem HP_TEST_FORCE_OPTBUILD_SWAP_FAIL=1: CI-only; forces the requirement-9 post-verification
+rem swap (move /y the verified temp EXE into place) to fail deterministically, by skipping the
+rem real move and leaving the temp file in place -- reproducing the exact "source still exists
+rem after move" signature a genuine failed swap (e.g. an AV/indexer lock on the destination)
+rem would leave, without depending on an artificial OS-level file lock. Proves the original EXE
+rem is left untouched and HP_NUITKA_FALLBACK_USED is never set when the swap itself fails, even
+rem though the build and verification both succeeded.
+set "HP_TEST_FORCE_OPTBUILD_SWAP_FAIL=%HP_TEST_FORCE_OPTBUILD_SWAP_FAIL%"
 rem HP_SKIP_PEP723_WRITEBACK=1: REQ-005.11/[REQ-019] opt-out -- skip the PEP 723 header
 rem write-back (uv add --script) that otherwise runs after a fresh dependency install or a
 rem successful warnfix repair in uv mode. Suppression-only, per [REQ-019]: absence never
@@ -2891,12 +2899,22 @@ if not "%HP_OPTBUILD_VERIFY_EXIT%"=="0" (
 )
 rem Verified good: swap it into place. A same-drive move is a fast rename on NTFS; /y overwrites
 rem the existing (already-verified) dist\%ENVNAME%.exe.
-move /y "dist\%HP_OPTBUILD_TMP%" "dist\%ENVNAME%.exe" >nul 2>&1
-if not exist "dist\%ENVNAME%.exe" (
-  call :log "[WARN] Optimized build verified successfully but could not be swapped into place; rebuilding is recommended."
-  set "HP_OPTBUILD_TMP="
-  set "HP_OPTBUILD_VERIFY_EXIT="
-  exit /b 0
+if defined HP_TEST_FORCE_OPTBUILD_SWAP_FAIL (
+  call :log "[TEST] HP_TEST_FORCE_OPTBUILD_SWAP_FAIL: simulating a failed swap (temp file deliberately left in place)."
+) else (
+  move /y "dist\%HP_OPTBUILD_TMP%" "dist\%ENVNAME%.exe" >nul 2>&1
+)
+rem A same-volume "move /y" onto an ALREADY-EXISTING destination is an atomic rename-replace:
+rem on success the source is consumed (gone); on failure (e.g. an AV/indexer lock on the
+rem destination -- the exact hazard class already documented for :try_embed_fallback's own
+rem rd/move swap in docs/agent-lessons-learned.md) the whole operation is rejected and the
+rem source is left untouched. Checking "does the destination exist" is NOT a valid success
+rem proxy here (unlike embed's fresh-destination case): the destination is the already-working
+rem original EXE, so it already exists before this line runs, success or failure alike. The
+rem correct check is whether the SOURCE is now gone.
+if exist "dist\%HP_OPTBUILD_TMP%" (
+  call :log "[WARN] Optimized build verified successfully but could not be swapped into place; your app is still ready to use as-is."
+  goto :optbuild_cleanup
 )
 set "HP_NUITKA_FALLBACK_USED=1"
 call :log "[INFO] Optimized build succeeded and verified: dist\%ENVNAME%.exe now uses the fallback build system."
@@ -2906,6 +2924,7 @@ exit /b 0
 :optbuild_cleanup
 if exist "dist\%HP_OPTBUILD_TMP%" del "dist\%HP_OPTBUILD_TMP%" >nul 2>&1
 set "HP_OPTBUILD_TMP="
+set "HP_OPTBUILD_VERIFY_EXIT="
 exit /b 0
 :try_fast_exe
 set "HP_FASTPATH_USED="

--- a/tests/selfapps_optimized_build.ps1
+++ b/tests/selfapps_optimized_build.ps1
@@ -15,16 +15,28 @@
 #   forcefail - HP_TEST_OPTBUILD_ANSWER=Y + HP_TEST_FORCE_OPTBUILD_FAIL=1: the optimized build is
 #               forced to fail deterministically (no real Nuitka attempt). Asserts the ORIGINAL
 #               PyInstaller-built dist\<env>.exe is left completely untouched and still runs.
+#   swapfail  - HP_TEST_OPTBUILD_ANSWER=Y + HP_TEST_FORCE_OPTBUILD_SWAP_FAIL=1: a REAL Nuitka
+#               build runs and verifies successfully (same as 'accept'), but the final move-into-
+#               place step is forced to fail (temp file deliberately left in place instead of
+#               being moved). Regression test for a real bug found via refinement review: the
+#               original "did the swap succeed" check tested whether dist\<env>.exe (the
+#               destination) existed -- but that file already exists BEFORE the move (it's the
+#               already-working original), so the check could never actually detect a failed
+#               move; a failed swap was silently misreported as success. Asserts the ORIGINAL EXE
+#               is left completely untouched and still runs, the leftover temp file is cleaned up
+#               (also part of the fix -- the old failure branch never routed through the shared
+#               cleanup label), and the "succeeded and verified" message is NOT logged.
 #   decline   - No HP_TEST_OPTBUILD_ANSWER set: falls through to the ambient HP_CI_LANE
 #               auto-decline (same mechanism selfapps_postexec_checkpoint.ps1's own
 #               self.checkpoint.decline scenario relies on). Asserts the prompt is shown but no
 #               build is attempted at all.
 #
-# All three scenarios in one file/lane for simplicity, matching this repo's established pattern
+# All four scenarios in one file/lane for simplicity, matching this repo's established pattern
 # for multi-scenario tests (e.g. selfapps_pyinstaller_fail.ps1's PYI_FAIL_SCENARIO). Kept entirely
-# in the uv lane (non-gating) so the 'accept' scenario's real-Nuitka-build dependency doesn't need
-# separate lane wiring from its two deterministic siblings; promote once proven stable, matching
-# this repo's established graduation pattern (see CLAUDE.md's "CI lane gating maturity" check).
+# in the uv lane (non-gating) so the 'accept'/'swapfail' scenarios' real-Nuitka-build dependency
+# doesn't need separate lane wiring from their two fully-deterministic siblings; promote once
+# proven stable, matching this repo's established graduation pattern (see CLAUDE.md's "CI lane
+# gating maturity" check).
 #
 # Emits: self.optbuild.offer
 param()
@@ -84,12 +96,16 @@ $bootstrapLog = "~optbuild_${scenario}_bootstrap.log"
 $prevSkipPipreqs   = if (Test-Path Env:HP_SKIP_PIPREQS)             { $env:HP_SKIP_PIPREQS }             else { $null }
 $prevOptAnswer     = if (Test-Path Env:HP_TEST_OPTBUILD_ANSWER)     { $env:HP_TEST_OPTBUILD_ANSWER }     else { $null }
 $prevForceOptFail  = if (Test-Path Env:HP_TEST_FORCE_OPTBUILD_FAIL) { $env:HP_TEST_FORCE_OPTBUILD_FAIL } else { $null }
+$prevForceSwapFail = if (Test-Path Env:HP_TEST_FORCE_OPTBUILD_SWAP_FAIL) { $env:HP_TEST_FORCE_OPTBUILD_SWAP_FAIL } else { $null }
 $env:HP_SKIP_PIPREQS = '1'
 if ($scenario -eq 'accept') {
     $env:HP_TEST_OPTBUILD_ANSWER = 'Y'
 } elseif ($scenario -eq 'forcefail') {
     $env:HP_TEST_OPTBUILD_ANSWER = 'Y'
     $env:HP_TEST_FORCE_OPTBUILD_FAIL = '1'
+} elseif ($scenario -eq 'swapfail') {
+    $env:HP_TEST_OPTBUILD_ANSWER = 'Y'
+    $env:HP_TEST_FORCE_OPTBUILD_SWAP_FAIL = '1'
 }
 # 'decline' scenario: deliberately leaves both unset, relying on the ambient HP_CI_LANE
 # auto-decline the same way selfapps_postexec_checkpoint.ps1's self.checkpoint.decline does.
@@ -186,6 +202,37 @@ try {
             statusState        = $statusState
             log                = $bootstrapLog
         })
+    } elseif ($scenario -eq 'swapfail') {
+        $acceptedLogged = $combined -match [regex]::Escape('Optimized build: accepted')
+        $swapFailLogged = $combined -match [regex]::Escape('could not be swapped into place')
+        $noSuccessMsg   = -not ($combined -match [regex]::Escape('Optimized build succeeded and verified'))
+
+        # Same cmd /c fix as the accept/forcefail scenarios above -- see the accept block's comment.
+        $originalStillRuns = $false
+        if ($exeExists) {
+            try {
+                Push-Location (Join-Path $workDir 'dist')
+                try {
+                    $out = cmd /c "`"$envName.exe`"" 2>&1
+                    $originalStillRuns = ($LASTEXITCODE -eq 0) -and ($out -join "`n") -match [regex]::Escape('optbuild-app-ok')
+                } finally { Pop-Location }
+            } catch { $originalStillRuns = $false }
+        }
+
+        $pass = $promptShown -and $acceptedLogged -and $swapFailLogged -and $noSuccessMsg -and $exeExists -and $tmpExeGone -and $originalStillRuns -and ($statusState -eq 'ok')
+        Write-OptBuildRow -Pass $pass -Desc 'AV-Safe Build Path requirement 9 (swapfail): a verified optimized build whose final swap fails leaves the original PyInstaller EXE completely untouched and cleans up the leftover temp file' -Details ([ordered]@{
+            scenario           = $scenario
+            bootstrapExit      = $runExit
+            promptShown        = [bool]$promptShown
+            acceptedLogged     = [bool]$acceptedLogged
+            swapFailLogged     = [bool]$swapFailLogged
+            noSuccessMsg       = [bool]$noSuccessMsg
+            exeExists          = [bool]$exeExists
+            tmpExeGone         = [bool]$tmpExeGone
+            originalStillRuns  = [bool]$originalStillRuns
+            statusState        = $statusState
+            log                = $bootstrapLog
+        })
     } else {
         $declinedLogged = $combined -match [regex]::Escape('Optimized build: declined')
         $noBuildAttempt = -not ($combined -match [regex]::Escape('Optimized build: accepted'))
@@ -204,9 +251,10 @@ try {
         })
     }
 } finally {
-    if ($null -eq $prevSkipPipreqs)  { Remove-Item Env:HP_SKIP_PIPREQS -ErrorAction SilentlyContinue }             else { $env:HP_SKIP_PIPREQS = $prevSkipPipreqs }
-    if ($null -eq $prevOptAnswer)    { Remove-Item Env:HP_TEST_OPTBUILD_ANSWER -ErrorAction SilentlyContinue }     else { $env:HP_TEST_OPTBUILD_ANSWER = $prevOptAnswer }
-    if ($null -eq $prevForceOptFail) { Remove-Item Env:HP_TEST_FORCE_OPTBUILD_FAIL -ErrorAction SilentlyContinue } else { $env:HP_TEST_FORCE_OPTBUILD_FAIL = $prevForceOptFail }
+    if ($null -eq $prevSkipPipreqs)   { Remove-Item Env:HP_SKIP_PIPREQS -ErrorAction SilentlyContinue }                  else { $env:HP_SKIP_PIPREQS = $prevSkipPipreqs }
+    if ($null -eq $prevOptAnswer)     { Remove-Item Env:HP_TEST_OPTBUILD_ANSWER -ErrorAction SilentlyContinue }          else { $env:HP_TEST_OPTBUILD_ANSWER = $prevOptAnswer }
+    if ($null -eq $prevForceOptFail)  { Remove-Item Env:HP_TEST_FORCE_OPTBUILD_FAIL -ErrorAction SilentlyContinue }      else { $env:HP_TEST_FORCE_OPTBUILD_FAIL = $prevForceOptFail }
+    if ($null -eq $prevForceSwapFail) { Remove-Item Env:HP_TEST_FORCE_OPTBUILD_SWAP_FAIL -ErrorAction SilentlyContinue } else { $env:HP_TEST_FORCE_OPTBUILD_SWAP_FAIL = $prevForceSwapFail }
 }
 
 if (-not $pass) { exit 1 }


### PR DESCRIPTION
## Summary

Found via a refinement-pass code review of the just-merged PR #370 (AV-Safe Build Path
requirement 9, `:offer_optimized_build`).

- The post-swap "did it work" check tested `if not exist "dist\<env>.exe"` -- but that file is
  the DESTINATION, the already-working original EXE this subroutine exists to maybe replace, so
  it already exists BEFORE the `move /y` runs, success or failure alike. A same-volume `move /y`
  onto an existing destination is an atomic rename-replace: on success the SOURCE is consumed; on
  failure (e.g. an AV/indexer lock on the destination -- the exact hazard class already documented
  for `:try_embed_fallback`'s own `rd`/`move` swap) the whole operation is rejected and the source
  is left untouched, with the destination unaffected either way. The old check could therefore
  never actually detect a failed swap -- a real failure would have been silently misreported as
  `[INFO] Optimized build succeeded and verified...`, `HP_NUITKA_FALLBACK_USED` would be wrongly
  set (incorrectly disabling `:hidden_import_recover`'s auto-recovery for what is still a
  PyInstaller-built EXE), and the leftover temp file would never be cleaned up (the old failure
  branch didn't route through the shared `:optbuild_cleanup` label either).
- Fixed by checking whether the SOURCE (the temp file) is gone instead, and routing this failure
  through `:optbuild_cleanup` like every other failure branch (which also fixes the temp-file
  leak).
- New `HP_TEST_FORCE_OPTBUILD_SWAP_FAIL` test hook and a new `swapfail` scenario in
  `tests/selfapps_optimized_build.ps1` (real Nuitka build + verify, forced swap failure) reproduce
  the exact "source still exists after move" failure signature deterministically, without
  depending on an artificial OS-level file lock.
- Updated `docs/agent-interconnect.md`, `docs/agent-ndjson.md`, `CLAUDE.md`'s Closed Backlog, and
  `docs/demo-bootstrapper-output.md` with the full trace.

## Test plan

- [x] `python -m compileall -q .`
- [x] `python -m pyflakes .`
- [x] `python tools/check_delimiters.py run_setup.bat`
- [x] `python -m yamllint .github/workflows/`
- [x] `actionlint -oneline .github/workflows/*.yml`
- [x] ASCII sweep on touched files
- [x] PowerShell AST parse sweep
- [x] `python -m pytest tests/test_*.py -q` (366 passed, 2 skipped)
- [x] All 8 real CI lanes green on commit `118d0e8` (`cache`, `real`, `conda-full`, `uv`,
  `contract-uv`, `contract-uv-fail`, `uv-dl-fallback`, `justme-test`), including:
  - New `self.optbuild.offer` `swapfail` scenario: `acceptedLogged`, `swapFailLogged`,
    `noSuccessMsg`, `exeExists`, `tmpExeGone`, `originalStillRuns` all `true`, `statusState: ok`
  - The other three `self.optbuild.offer` scenarios (`accept`/`forcefail`/`decline`) and
    `self.exe.tiera.hidden_skip` still pass
  - NDJSON registry cross-check clean, no doc/code drift
  - `Model quick-fix (inline)` ran with `HAS_FAILURES: false` -- no auto-fix needed


---
_Generated by [Claude Code](https://claude.ai/code/session_015xbWLPbiaKVsobB9FZy8kS)_