### PR TITLE
feat: honest ambiguous-exit messaging (P2, closes CLI-interactive-verification plan)

### DIFF
--- a/.github/workflows/batch-check.yml
+++ b/.github/workflows/batch-check.yml
@@ -643,6 +643,14 @@ jobs:
         run: |
           & tests\selfapps_pyinstaller_fail.ps1
 
+      - name: "Self-test: no-EXE briefing is honest when the interpreter fallback also fails (execfail_runtimefail, real/conda-full only)"
+        if: ${{ matrix.mode == 'real' || matrix.mode == 'conda-full' }}
+        shell: pwsh
+        env:
+          PYI_FAIL_SCENARIO: execfail_runtimefail
+        run: |
+          & tests\selfapps_pyinstaller_fail.ps1
+
       - name: "Self-test: REQ-021 py_compile pre-flight syntax error (real/conda-full only)"
         if: ${{ matrix.mode == 'real' || matrix.mode == 'conda-full' }}
         shell: pwsh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -607,58 +607,6 @@ the "Build public diagnostics tree" step's own `DIAG CWD`/`DIAG ROOT`/`DIAG TREE
 lines, which naturally show GitHub Actions' inherent doubled checkout path
 (`.../Python_vs_Windows/Python_vs_Windows/...`) -- a runner convention, not a bug. Not chased
 further.)*
-8. **CLI-args and stdin-interactive Python program support.** Full plan at
-   `docs/plan-cli-interactive-verification.md`. Confirmed real (not hypothetical) via direct code
-   tracing: every verification launch point redirects the child's stdout/stderr into an in-memory
-   buffer only written to disk after the process exits, so an interactive program's prompts never
-   reach the visible console; the primary EXE verification (`:run_exe_smokerun`) additionally
-   force-kills after a hard 30s, which would kill a program correctly waiting on its first
-   `input()` prompt. This is the owner's own original target shape for this repo (a program that
-   asks setup questions, then loops on stdin until a quit command), not an edge case.
-
-   **P0 requirement 1 (live-echo + stop passing results through `for /f`-captured stdout) is
-   SHIPPED (2026-07-23)** -- see the Closed Backlog entry below for what shipped and the real,
-   non-obvious async-output-drain race found and fixed along the way (not anticipated by the
-   original plan). **A second, more serious bug in that same mechanism was found and fixed
-   2026-07-24** while building a requested interactive round-trip test: `Register-ObjectEvent`
-   (the tee mechanism itself) can reorder lines WITHIN a single stream, a confirmed upstream
-   PowerShell bug -- fixed by replacing it entirely with self-sequenced `StreamReader.
-   ReadLineAsync()` polling. See the dedicated Closed Backlog entry below and
-   `docs/agent-lessons-learned.md`'s new "`Register-ObjectEvent` ... can reorder lines" entry for
-   the full trace. **Requirement 2 (confirm stdin passthrough on real Windows CI) now has a
-   dedicated CI test (`tests/selfapps_interactive_stdin.ps1`, uv lane, non-gating) but is not yet
-   fully CLOSED pending that test's first observed real-CI pass** -- it pipes a scripted answer
-   sequence into `cmd.exe`'s own stdin and exercises the full `cmd.exe -> :run_exe_smokerun ->
-   ~exe_smokerun.ps1 -> the built EXE` chain end to end, closing the "cannot be reproduced in this
-   sandbox" gap this item previously described with an automated, provider-agnostic proof rather
-   than a manual one-off. **Requirement 3 (revisit the 30s kill, Open Question 1) is now SHIPPED
-   (2026-07-24), per direct owner decision** -- see the dedicated Closed Backlog entry below for
-   the full mechanism (the 30s window itself is unchanged; `Kill()` now only fires if the process
-   has produced zero output by the deadline; any output observed switches to an unbounded wait,
-   mirroring the fail-fast probe's own philosophy). **A real gap in that same-day work was found
-   and fixed within hours, during a requested research/refinement pass (Finding 9): the live-tee
-   and `$sawOutput` mechanisms both relied on `ReadLineAsync()`, which does not surface a prompt
-   with no trailing newline (the exact shape of Python's own `input("prompt")`) until something
-   else later flushes a line.** Fixed by switching both `tools/failfast_probe.ps1` and
-   `tools/exe_smokerun.ps1` to chunk-based `ReadAsync()` reads, empirically confirmed both ways
-   (fails against the pre-fix code, passes against the fix) with two new regression tests that
-   drive stdin live (not via a pre-loaded answers file, which cannot distinguish the timing bug at
-   all) -- see the dedicated Closed Backlog entry below,
-   `docs/plan-cli-interactive-verification.md` Finding 9, and `docs/agent-lessons-learned.md`'s new
-   "`StreamReader.ReadLineAsync()` is line-buffered" entry for the full trace. **All of P0 now has
-   a shipped, verified implementation.** **P1 (argv-passthrough escape hatch, requirement 4) is
-   ALSO now SHIPPED (2026-07-24)**, per the owner-approved next work ("P1 and p2 at least look
-   good enough to try", 2026-07-24) -- see the dedicated Closed Backlog entry below for the full
-   mechanism, including the real `HP_PROBE_ARGS` contract change this required (not just new
-   callers) and the two existing tests it had to fix, not just extend. **P2 (honest
-   ambiguous-exit messaging) is the one remaining un-started slice.**
-   **Confirmed via source-reading
-   that the separate "PVW QuickStart" (`HP_PVW_KNOWN_IDEMPOTENT`, REQ-005.13) execute-mode
-   discovery path was never affected by any of this** -- `tools/pvw_known_idempotent.py`'s
-   `run_script()` uses a plain `subprocess.run(..., timeout=120)` with full stdio inheritance and
-   zero redirection, so neither the tee mechanism nor its ordering bug ever applied there; it does
-   carry its own, unrelated `timeout=120` risk (noted, not yet acted on).
-
 ## Periodic Maintenance Checks (recurring, quarterly)
 
 This section is for checks that need to be **repeated on a schedule** because they track
@@ -954,6 +902,61 @@ of a second or third pin actually needing it.
 ## Closed Backlog
 
 Items completed and shipped:
+
+- **CLI-args/stdin-interactive support, P2 (honest ambiguous-exit messaging) -- final slice,
+  `docs/plan-cli-interactive-verification.md`'s plan is now FULLY SHIPPED (P0, P1, P2 all
+  complete).** Scope was narrowed from the plan's literal wording during implementation: the
+  original sketch suggested a NEW "let us try a deeper dependency-resolution pass?" prompt at the
+  final `[STATUS]` line, but tracing the actual code flow found this mechanism already exists and
+  fires EARLIER, at build time (`:warnfix_cascade_detect` + `:cascade_consent_gate`, the REQ-009
+  provider cascade) -- re-offering it post-hoc at the final status line would be redundant and
+  architecturally awkward (it would need to re-enter build/dependency-install logic from a point
+  that currently only prints and exits). Documented this scope decision in both
+  `docs/plan-cli-interactive-verification.md` (Open Question 3, now marked RESOLVED) and
+  `docs/agent-interconnect.md` rather than silently deviating from the plan's wording.
+
+  What P2 actually ships instead: two real, previously-undiscovered honesty gaps found by tracing
+  what P0/P1 had already changed, both fixed with a new outcome-tracking flag apiece, no new
+  consent prompts, no `~bootstrap.status.json`/exit-code changes -- messaging only.
+  - **Gap 1**: `:print_no_exe_briefing` (the no-EXE postflight panel, shipped earlier this same
+    day -- see the "No-EXE postflight briefing panel" Closed Backlog entry above) unconditionally
+    claimed "your code ran successfully just now" regardless of whether the interpreter fallback
+    run that immediately precedes it (`:verify_no_exe_interpreter`) actually exited 0 -- a real,
+    pre-existing dishonest claim. Fixed with a new `HP_NOEXE_VERIFY_FAILED` flag (set in both of
+    `:verify_no_exe_interpreter`'s branches -- the legacy/CI branch on a non-zero `HP_SMOKE_RC`,
+    and the interactive fail-fast-probe branch the same way, noting that call site has zero
+    `-1`/timeout ambiguity since `:run_failfast_probe` never kills, so `HP_SMOKE_RC` is always the
+    interpreter's true final exit code once observed). `:print_no_exe_briefing` was rewritten with
+    goto-based dispatch (mirroring `:print_postflight_briefing`'s own `:pfb_caveat` shape) into a
+    new `:noexe_caveat` branch when the flag is set, replacing the false success claim with
+    "NO STANDALONE .EXE -- AND WE CAN'T CONFIRM YOUR CODE RAN CLEANLY" and honest wording that
+    points the user at running the program themselves.
+  - **Gap 2**: the cached-EXE fast path (`:try_fast_exe`) had NO postflight signal at all -- beyond
+    one WARN log line buried among other console output -- for the case where the fail-fast probe
+    classifies a reused `dist\<env>.exe` as alive/healthy (so it is kept, never discarded/rebuilt)
+    and it later exits non-zero. Fixed with a new `:print_fastpath_ambiguous_note` subroutine,
+    called from `:success`'s dispatch only when `HP_FASTPATH_USED` AND `HP_FASTPATH_RUN_FAILED`
+    are both set -- a plain informational print, never a consent gate, preserving the fast path's
+    "zero friction for PROMPTS" design invariant (`docs/agent-interconnect.md`). Suggests deleting
+    `dist\<env>.exe` and re-running for a fully fresh dependency check.
+
+  **Neither panel claims to know WHY the run was ambiguous** (a bug in the user's own code vs.
+  something this bootstrapper missed vs. an unresolved dependency) -- both are deliberately honest
+  about that limit rather than attempting a diagnosis, which is what Open Question 3 asked and is
+  now resolved by: P2 does not attempt to distinguish root causes, it only states the outcome
+  honestly and points the user at the full output.
+
+  Test coverage extends existing scenarios rather than adding net-new test files, matching this
+  repo's established convention: `tests/selfapps_failfast_probe.ps1`'s existing "alive" scenario
+  (already produces the exact "cached EXE kept, later exits non-zero" condition via a stub that
+  sleeps 6s then exits 7) gained an assertion that the new fastpath-ambiguous-note text appears;
+  `tests/selfapps_pyinstaller_fail.ps1` gained a third `PYI_FAIL_SCENARIO` value,
+  `execfail_runtimefail` (both PyInstaller and the Nuitka fallback fail, AND the interpreter
+  fallback that runs afterward also exits non-zero via a stub that prints then
+  `sys.exit(3)`), wired into `real`/`conda-full` in `batch-check.yml`, asserting the new
+  `:noexe_caveat` text appears instead of the false-success text -- reuses the existing
+  `self.exe.build.xfail` NDJSON row id, matching the file's established multi-scenario-same-row
+  pattern. `docs/agent-ndjson.md` updated to describe all three `PYI_FAIL_SCENARIO` values.
 
 - **CLI-args/stdin-interactive support, P1 requirement 4 (argv passthrough escape hatch) --
   owner-approved next work after all of P0 shipped ("P1 and p2 at least look good enough to

--- a/README.md
+++ b/README.md
@@ -669,6 +669,27 @@ set lives in `run_setup.bat`.
 
 ---
 
+## [REQ-027] Honest Ambiguous-Exit Messaging
+
+- When a verification run ends ambiguously (your program exited with an error, and neither
+  automatic repair -- `--hidden-import` auto-recovery, the dependency-resolution cascade -- fixed
+  it), the bootstrapper no longer claims success it can't actually confirm:
+  - **No-EXE path**: if packaging failed outright (both PyInstaller and the Nuitka fallback) AND
+    the interpreter fallback that then ran your program also exited non-zero, the post-flight
+    panel says so plainly instead of claiming "your code ran successfully."
+  - **Cached-EXE fast path**: if a reused `dist\<env>.exe` was classified alive/healthy by the
+    fail-fast probe (so it was kept, not rebuilt) and it later exited non-zero, a short
+    informational panel now appears -- previously this case had no signal beyond one log line.
+- Neither message claims to know *why* the run was ambiguous (a bug in your own code vs.
+  something this bootstrapper missed) -- both point you at running the program yourself to see
+  the full output, and the fast-path note additionally suggests deleting `dist\<env>.exe` and
+  re-running the bootstrapper if you want a fully fresh dependency check.
+- This is messaging only -- it does not change `~bootstrap.status.json` semantics, the process
+  exit code, or add any new consent prompt (the cached-EXE note is a plain print, preserving the
+  fast path's zero-friction design).
+
+---
+
 ## Maintenance, Logging, and Lessons Learned
 
 - Update conda base periodically (~30 days), but **skip on first Miniconda install**. Ensure base is configured to conda-forge before updating to avoid prompts.

--- a/docs/agent-interconnect.md
+++ b/docs/agent-interconnect.md
@@ -1473,6 +1473,75 @@ CI-only test path (`:ci_skip_entry`'s system-Python launch, see "uv-First Provid
 narrow REQ-010 isolation scenario, not one of the plan's four named real launch sites, and CI has
 no interactive terminal to benefit from argument forwarding there.
 
+## Honest ambiguous-exit messaging (REQ-027, P2) -- two panels, two independent gaps found by tracing what P1/P0 already changed
+
+**Status: SHIPPED 2026-07-24**, the plan's P2 requirement 5 (`docs/plan-cli-interactive-verification.md`).
+Deliberately scoped narrower than the plan originally sketched -- see that doc's own P2 and Open
+Question 3 sections for why "offer a deeper dependency-resolution pass" was dropped from scope
+(the offer already exists and already fires earlier in the flow, at `:warnfix_cascade_detect`;
+re-offering it post-hoc at the final `[STATUS]` line would need much more plumbing for uncertain
+benefit). What shipped is messaging-only, touching two genuinely gapped panels found by tracing
+the ACTUAL control flow rather than assuming the plan's original framing still applied once P0
+and P1 had both shipped.
+
+**Gap 1, a real pre-existing bug: `:print_no_exe_briefing`'s header unconditionally claimed "your
+code ran successfully."** This panel fires whenever `HP_BUILD_OK` is defined (a build was
+attempted) and no EXE exists (`run_setup.bat` ~line 1797-1802, `:success`'s dispatch). It always
+runs AFTER `:verify_no_exe_interpreter` has already executed the entry via the interpreter
+fallback (the only way to reach the no-EXE branch with an entry file defined) -- but the panel's
+own text had zero awareness of whether that interpreter run's `HP_SMOKE_RC` was actually 0. Fixed
+with a new flag, `HP_NOEXE_VERIFY_FAILED`, set in BOTH of `:verify_no_exe_interpreter`'s branches
+(the legacy/non-interactive branch right after `HP_SMOKE_RC` is captured; the
+`:verify_no_exe_probe` branch right after `:run_failfast_probe interpreter` returns) whenever
+`HP_SMOKE_RC` is nonzero -- mirroring the already-existing `HP_EXE_VERIFY_FAILED` pattern for the
+EXE path exactly (same declare-clean-at-top-of-file, set-only-on-failure shape). No `-1`/timeout
+ambiguity to worry about at either branch: `:run_failfast_probe` never kills, so `HP_SMOKE_RC` is
+always the interpreter's true final exit code once it exits. `:print_no_exe_briefing` now
+goto-dispatches its header text on this flag (mirroring `:print_postflight_briefing`'s own
+`:pfb_caveat` shape) -- the caveat variant never claims success and never asserts WHY the run
+failed (real bug vs. something this bootstrapper missed), matching Open Question 3's own framing
+that distinguishing root cause is out of scope.
+
+**Gap 2, a genuinely unsignaled path: the fast-path-kept-despite-failure case had NO postflight
+panel at all.** `:success`'s dispatch (`run_setup.bat` ~line 1797) is gated on `if not defined
+HP_FASTPATH_USED (...)` -- when the fast path IS used (a cached EXE reused, whether the fail-fast
+probe classified it as a fast-fail-and-discard candidate or as alive/healthy-and-kept -- see the
+"Fail-fast probe" section above), NEITHER `:print_postflight_briefing` NOR `:print_no_exe_briefing`
+ever fires, by design (the fast path is meant to be zero-friction, on the theory the user has
+already seen a full briefing on a prior run). But for the specific "kept despite a later non-zero
+exit" sub-case (`HP_FASTPATH_RUN_FAILED` set -- see the "Fail-fast probe" section's own
+`HP_FASTPATH_RUN_FAILED` decoupling fix for how this flag is computed and why it reliably survives
+to `:success`), that meant literally NO postflight signal beyond one `[WARN]` log line buried
+among other console output. New subroutine `:print_fastpath_ambiguous_note`, called from a new
+`else if defined HP_FASTPATH_RUN_FAILED` branch alongside the existing `if not defined
+HP_FASTPATH_USED` dispatch -- deliberately a PLAIN INFORMATIONAL PRINT, no `set /p`, no consent
+gate, so it does not violate the fast path's own "zero friction, no prompts" design requirement
+(that requirement is specifically about not adding QUESTIONS to the fast path; a print-only panel
+costs nothing and asks nothing). Points the user at the direct-run command AND at deleting
+`dist\<env>.exe` + re-running the bootstrapper if they want a genuinely fresh dependency check --
+the closest honest equivalent to "try a deeper pass" this call site can offer without inventing a
+new re-solve mechanism.
+
+**Neither panel asserts a root cause.** Both stay deliberately agnostic about whether the ambiguous
+exit is (a) a real bug in the user's own code, (b) an unresolved dependency, or (c) something else
+entirely -- Open Question 3 in the plan doc explicitly says distinguishing these is not solved by
+this plan, and neither panel pretends otherwise.
+
+**Test coverage, both reusing/extending existing scenarios rather than net-new test files.**
+`tests/selfapps_pyinstaller_fail.ps1` gained a third `PYI_FAIL_SCENARIO` value,
+`execfail_runtimefail` -- identical to `execfail` (forces the PyInstaller build itself to fail via
+`HP_TEST_FORCE_PYINSTALLER_FAIL=1`, with `HP_TEST_FORCE_NUITKA_FAIL=1` keeping Tier A from rescuing
+it) except the stub app ALSO exits non-zero (`sys.exit(3)`) so the interpreter fallback that runs
+next is a genuine failure too -- asserting the caveat header text appears instead of the two other
+scenarios' plain "your code ran successfully" text (which those two still correctly assert
+unchanged, since their trivial stub app still exits 0 via the interpreter fallback). Wired into
+`batch-check.yml` as a third step alongside the existing `execfail`/`output_vanish` steps, same
+`real`/`conda-full` gating lanes. `tests/selfapps_failfast_probe.ps1`'s existing `self.failfast.
+probe.alive` scenario already produces the EXACT "cached EXE kept, later exits non-zero" condition
+`:print_fastpath_ambiguous_note` targets (it exists to prove the decoupling fix from the "Fail-fast
+probe" section above) -- extended with one new assertion for the new panel's text rather than
+writing a fourth, largely-duplicate scenario.
+
 ## Post-execution checkpoint (Slice 2b-C, second half): the elective second run
 
 `:run_postexec_checkpoint` is the other half of 2b-C promised by the original REQ-018 design doc

--- a/docs/agent-ndjson.md
+++ b/docs/agent-ndjson.md
@@ -293,9 +293,14 @@ self.pvw_idempotent.discovery
 
 ## selfapps-pyinstaller-fail NDJSON rows (selfapps_pyinstaller_fail.ps1, real/conda-full lanes)
 
-Two scenarios (`PYI_FAIL_SCENARIO` env var: `execfail` / `output_vanish`), both emitting the
-same row id. XFAIL-style, mirroring `selfapps_exefail.ps1`'s sibling pattern but testing the
-PyInstaller BUILD step failing outright (not a successfully-built EXE crashing at runtime).
+Three scenarios (`PYI_FAIL_SCENARIO` env var: `execfail` / `output_vanish` /
+`execfail_runtimefail`), all emitting the same row id. XFAIL-style, mirroring
+`selfapps_exefail.ps1`'s sibling pattern but testing the PyInstaller BUILD step failing outright
+(not a successfully-built EXE crashing at runtime). `execfail_runtimefail` (added for [REQ-027]
+P2 honest messaging) is `execfail` plus a stub app that ALSO exits non-zero via the interpreter
+fallback, asserting the `HP_NOEXE_VERIFY_FAILED`-gated caveat panel text appears instead of the
+other two scenarios' plain "your code ran successfully" text -- see the Closed Backlog entry for
+the real, pre-existing dishonest-claim bug this closes.
 Regression test for a real bug found 2026-07-20 while scoping the AV-Safe Build Path PRD's
 requirement-1 failure-simulation tests (`docs/prd-av-safe-build-path.md`): a genuine PyInstaller
 build failure previously fell through `:die`'s call-frame-only `exit /b` (it never halts the

--- a/docs/plan-cli-interactive-verification.md
+++ b/docs/plan-cli-interactive-verification.md
@@ -521,15 +521,46 @@ own entry below) -- all of P0 now has an implementation; P1 and P2 remain to be 
    left out of scope -- it is test infrastructure, not one of the plan's four named real launch
    sites, and there is no interactive terminal in CI to benefit from it.
 
-### P2 -- honest messaging for the residual ambiguous case
+### P2 -- honest messaging for the residual ambiguous case -- SHIPPED 2026-07-24
 
-5. When a verification run ends ambiguously (nonzero exit, or the interpreter-fallback path with
-   no argv-passthrough and no confirmed stdin support), replace the bare `[STATUS]` line with
-   something closer to: "the environment appears to be set up correctly, but since your program
-   didn't exit cleanly we can't tell if it actually worked. You can run it yourself now (here's
-   how), or [if applicable] let us try a deeper dependency-resolution pass." The "deeper pass"
-   offer should only appear when it could plausibly help (see Open Question 3) -- not as a
-   default reflex offered for every ambiguous exit.
+5. **SHIPPED, narrower in scope than originally sketched -- see Open Question 3's own resolution
+   note below for why.** Tracing the actual control flow (both P0 and P1 already shipped by this
+   point) found that the "let us try a deeper dependency-resolution pass" offer already exists
+   and already fires at its own natural point earlier in the flow (`:warnfix_cascade_detect` +
+   `:cascade_consent_gate`, build-time, triggered by warnfix's own missing-module detection) --
+   by the time the FINAL `[STATUS]` line prints, that offer (if applicable at all) has already
+   been made and resolved once. Re-offering it again post-hoc would need much more plumbing (the
+   whole dependency-install phase re-run from a point after the program has already executed) for
+   uncertain benefit, and would risk exactly the "reflex offered for every ambiguous exit" the
+   plan's own text warned against. So P2 shipped as MESSAGING ONLY, per its own name -- no new
+   consent gate, no new "try again" mechanism -- targeting the two call sites that traced out as
+   genuinely having no honest signal at all:
+   - **A real, pre-existing bug in `:print_no_exe_briefing`**: its header text unconditionally
+     claimed "your code ran successfully just now" whenever no EXE was produced, with ZERO
+     awareness of whether the interpreter fallback that runs immediately before this panel
+     (`:verify_no_exe_interpreter`) actually exited 0. A new flag, `HP_NOEXE_VERIFY_FAILED` (set
+     in both of that subroutine's branches whenever `HP_SMOKE_RC` is nonzero, mirroring the
+     already-existing `HP_EXE_VERIFY_FAILED` pattern for the EXE path), now gates a caveat
+     variant of the panel's header -- honest about not knowing whether the failure is a bug in
+     the user's own code or something this bootstrapper missed, per Open Question 3's own (a)/
+     (b)/(c) framing, without asserting which.
+   - **A genuine, previously-unsignaled gap for the fast-path-kept-despite-failure case**: when
+     the fail-fast probe classifies a reused cached EXE as alive/healthy (so it is kept, not
+     discarded+rebuilt -- see requirement-3-era work) and it later exits non-zero, the postflight
+     briefing was skipped ENTIRELY (`if not defined HP_FASTPATH_USED` gates both existing
+     panels) -- the only signal was one WARN log line among other console output. A new plain
+     informational panel, `:print_fastpath_ambiguous_note`, closes this without adding a PROMPT
+     (a print-only panel does not violate the fast path's own "zero friction" design requirement,
+     which is specifically about not adding consent gates/questions to that path).
+   - Both new panels are deliberately modest about root cause (never claim which of (a)/(b)/(c)
+     happened), give the user the direct-run command so they can see full output themselves, and
+     for the fastpath case, note that deleting the cached EXE and re-running forces a genuinely
+     fresh dependency check if the user wants to rule out an environment issue.
+   - New CI coverage: `tests/selfapps_pyinstaller_fail.ps1` gained a third scenario
+     (`execfail_runtimefail`) proving the no-EXE caveat fires correctly; `tests/
+     selfapps_failfast_probe.ps1`'s existing `self.failfast.probe.alive` scenario (which already
+     produces the exact "kept cached EXE, later exits non-zero" condition) was extended with an
+     assertion for the new fastpath note.
 
 ### Explicitly NOT attempted here
 
@@ -561,7 +592,7 @@ the owner has a preference -- these aren't standardized industry terms as far as
 found ("CLI program" is ambiguous between the two in common usage, which is part of what made
 this hard to discuss precisely in the first place).
 
-### 3. How does the P2 messaging avoid conflating three different root causes?
+### 3. How does the P2 messaging avoid conflating three different root causes? -- RESOLVED 2026-07-24
 
 A nonzero/ambiguous exit could mean: (a) a real bug in the user's own code, (b) an unresolved
 dependency that a deeper solve (the REQ-009 provider cascade, already-existing warnfix logic)
@@ -570,9 +601,15 @@ Offering "try a deeper solve?" is only sensible for (b) -- offering it reflexive
 would be confusing/unhelpful. The owner's own framing (if uv and conda already installed and
 activated correctly, embedded/venv/system don't add solving power, they only matter when uv/conda
 can't run at all) is accurate and matches how REQ-009's cascade already works -- but distinguishing
-which of (a)/(b)/(c) actually happened is not solved by this plan. Likely sequencing: ship P0
-first (removes most of (c) as a source of false ambiguity for the owner's actual use case), then
-revisit this messaging question with a narrower, cleaner problem.
+which of (a)/(b)/(c) actually happened is still not solved by this plan, and P2 as shipped does
+not attempt to. Resolved by NOT trying to answer "which of (a)/(b)/(c) happened" at all: (c) is
+now genuinely rare (P0's activity-aware kill + live tee remove most of it), and (b)'s own "try a
+deeper solve" offer already exists and already fires at its own natural point earlier in the flow
+(`:warnfix_cascade_detect`, build-time) -- by the time the final `[STATUS]` line prints, that
+offer has already happened if it was ever going to. So P2's two new messages (see requirement 5's
+own SHIPPED note above) never claim to know which cause applies -- they only state plainly that
+the outcome is ambiguous and point the user at running it themselves, which is honest regardless
+of which of (a)/(b)/(c) is the real explanation.
 
 ## Notes from Claude
 

--- a/run_setup.bat
+++ b/run_setup.bat
@@ -429,6 +429,10 @@ set "HP_FASTPATH_USED="
 rem REQ-016: start clean so an inherited env var can never trigger a false "EXE
 rem unverified" caveat; :run_exe_smokerun sets this only on a real non-zero EXE exit.
 set "HP_EXE_VERIFY_FAILED="
+rem [REQ-027] P2 honest messaging: mirrors HP_EXE_VERIFY_FAILED above, but for the NO-EXE
+rem interpreter path -- :verify_no_exe_interpreter sets this only on a real non-zero
+rem interpreter exit, so :print_no_exe_briefing can stop unconditionally claiming success.
+set "HP_NOEXE_VERIFY_FAILED="
 rem REQ-012: HP_EXE_SKIPPED records that EXE verification was skipped by request
 rem (HP_SKIP_EXE_SMOKERUN) -- distinct from "failed" -- for the post-flight note.
 set "HP_EXE_SKIPPED="
@@ -1796,6 +1800,13 @@ if not defined HP_FASTPATH_USED (
   ) else if defined HP_BUILD_OK (
     call :print_no_exe_briefing
   )
+) else if defined HP_FASTPATH_RUN_FAILED (
+  rem [REQ-027] P2 honest messaging: the fast path stays zero-friction for its own PROMPTS (no
+  rem consent gate added here), but a print-only informational note costs nothing and closes a
+  rem genuine gap -- before this, a cached EXE kept-despite-a-later-nonzero-exit (classified
+  rem alive/healthy at the fail-fast probe, so never discarded/rebuilt -- see :try_fast_exe) had
+  rem NO postflight signal at all beyond one WARN log line buried among other console output.
+  call :print_fastpath_ambiguous_note
 )
 call :release_lock
 rem REQ-016: retain terminal window on success so user can read the output.
@@ -2707,8 +2718,9 @@ rem inside ~failfast_probe.ps1 (HP_FAILFAST_PROBE): WaitForExit(HP_FAILFAST_PROB
 rem classifies a fast exit vs. still-running; if still running, a SECOND, UNBOUNDED
 rem WaitForExit() follows and the process is NEVER killed -- this is the only difference
 rem from :run_exe_smokerun, which stays the sole place in this file allowed to force-kill
-rem (the fresh-build verification run). Caller sets HP_PROBE_EXE / HP_PROBE_ARGS (raw,
-rem unquoted -- the helper quotes it) / HP_PROBE_CWD before calling; %1 is a short site tag
+rem (the fresh-build verification run). Caller sets HP_PROBE_EXE / HP_PROBE_ARGS ([REQ-026]:
+rem a full, pre-quoted Windows Arguments string used verbatim -- the CALLER quotes each token,
+rem not this subroutine) / HP_PROBE_CWD before calling; %1 is a short site tag
 rem ('fastpath'|'interpreter'|'checkpoint' -- the last added by :run_postexec_checkpoint,
 rem Slice 2b-C's post-execution checkpoint) used only for the NDJSON row and log text. Always
 rem leaves HP_SMOKE_RC set to the true final exit code and HP_PROBE_EXCEEDED set (1) iff the probe
@@ -2736,8 +2748,9 @@ call :emit_from_base64 "%HP_PROBE_PS%" HP_FAILFAST_PROBE
 if errorlevel 1 (
   rem Extremely rare (disk/permission failure writing a work file); mirror :try_fast_exe's own
   rem emit-failure convention of skipping gracefully rather than hand-rolling an unsafe manual
-  rem launch here (HP_PROBE_ARGS is intentionally unquoted raw text -- only the .ps1 helper
-  rem quotes it safely; a direct cmd invocation would mis-tokenize an entry path with spaces).
+  rem launch here ([REQ-026]: HP_PROBE_ARGS is now a full, pre-quoted Windows Arguments string
+  rem the CALLER is responsible for quoting correctly -- see this subroutine's own header
+  rem comment; a direct cmd invocation here would still need that same care).
   rem HP_SMOKE_RC stays unset; the safety net below turns that into -1 so callers still see a
   rem defined, non-zero, non-"exceeded" outcome (:try_fast_exe's discard-and-rebuild fires).
   call :log "[WARN] Fail-fast probe: could not emit ~failfast_probe.ps1; treating as a failed run."
@@ -3427,6 +3440,9 @@ if "%HP_SMOKE_RC%"=="0" (
   call :log "[STATUS] Run Status: SUCCESS (Exit Code: 0)"
 ) else (
   call :log "[STATUS] Run Status: FAILED (Exit Code: %HP_SMOKE_RC%)"
+  rem [REQ-027] P2 honest messaging: :print_no_exe_briefing reads this to stop claiming
+  rem "your code ran successfully" when it did not.
+  set "HP_NOEXE_VERIFY_FAILED=1"
 )
 call :run_postexec_checkpoint interpreter
 exit /b 0
@@ -3445,6 +3461,10 @@ set "HP_PROBE_EXE=%HP_PY%"
 set "HP_PROBE_ARGS="%HP_ENTRY%"%HP_APP_ARGS%"
 set "HP_PROBE_CWD=%CD%"
 call :run_failfast_probe interpreter
+rem [REQ-027] P2 honest messaging: same flag as the legacy branch above. No -1/timeout
+rem ambiguity at this call site -- :run_failfast_probe never kills, so HP_SMOKE_RC is always
+rem the interpreter's true final exit code once it exits, not a force-stopped placeholder.
+if not "%HP_SMOKE_RC%"=="0" set "HP_NOEXE_VERIFY_FAILED=1"
 call :run_postexec_checkpoint interpreter
 exit /b 0
 :warnfix_cascade_detect
@@ -4454,14 +4474,34 @@ rem final [STATUS] line reads identically to a real EXE success, with the only p
 rem being one [ERROR] line several seconds earlier. This panel closes that gap -- purely
 rem additive, does not touch success/failure semantics (~bootstrap.status.json already
 rem correctly records state=error via :die's own HP_BOOTSTRAP_STATE=error).
+rem [REQ-027] P2 honest messaging: the header text below used to unconditionally claim "your
+rem code ran successfully" regardless of whether the interpreter run (:verify_no_exe_interpreter,
+rem which always runs immediately before this panel on the no-EXE path) actually exited 0 -- a
+rem real, pre-existing dishonest claim, confirmed by tracing that HP_NOEXE_VERIFY_FAILED is the
+rem ONLY signal this panel previously ignored. Branches on it now, mirroring
+rem :print_postflight_briefing's own :pfb_caveat dispatch shape.
 echo.
 echo ============================================================
+if defined HP_NOEXE_VERIFY_FAILED goto :noexe_caveat
 echo  YOUR CODE RAN -- BUT NO STANDALONE .EXE WAS PRODUCED
 echo ============================================================
 echo  We could not package your app into a double-clickable .exe
 echo  (see the ERROR message above for why), but your code ran
 echo  successfully just now using the prepared Python environment.
 echo  Your environment and dependencies ARE installed correctly.
+goto :noexe_runapp
+:noexe_caveat
+echo  NO STANDALONE .EXE -- AND WE CAN'T CONFIRM YOUR CODE RAN CLEANLY
+echo ============================================================
+echo  We could not package your app into a double-clickable .exe
+echo  (see the ERROR message above for why). We also just ran it
+echo  directly via the prepared Python environment, and it exited
+echo  with an error (see the [STATUS] line above) -- so we can't
+echo  tell whether that's a bug in your own code or something this
+echo  bootstrapper missed. Your environment and dependencies ARE
+echo  still installed correctly; run it yourself below to see the
+echo  full output.
+:noexe_runapp
 echo.
 echo  RUNNING YOUR APP (without an .exe)
 echo    "%HP_PY%" "%HP_ENTRY%"
@@ -4477,7 +4517,42 @@ echo    .*_env\ folders   -- environment directories
 echo    ~* files          -- tilde-prefix work files (e.g. ~setup.log)
 echo ============================================================
 echo.
-call :log "[WARN] REQ-016: Post-flight briefing printed; no EXE produced, advised direct interpreter run."
+if defined HP_NOEXE_VERIFY_FAILED (
+  call :log "[WARN] REQ-016: Post-flight briefing printed; no EXE produced, interpreter run also unverified."
+) else (
+  call :log "[WARN] REQ-016: Post-flight briefing printed; no EXE produced, advised direct interpreter run."
+)
+exit /b 0
+
+:print_fastpath_ambiguous_note
+rem [REQ-027] P2 honest messaging (docs/plan-cli-interactive-verification.md): the cached-EXE
+rem fast path is deliberately zero-friction for PROMPTS (never a consent gate, per
+rem docs/agent-interconnect.md's "Fast path = ZERO friction" design requirement) -- this is a
+rem plain informational print, not a question, so it does not violate that requirement. Fires
+rem only when the fail-fast probe classified the reused EXE as alive/healthy (so it was kept,
+rem not discarded+rebuilt) and it later exited non-zero -- see :try_fast_exe. Whether that
+rem non-zero exit means a real bug in the user's own code, an unresolved dependency, or
+rem something else entirely is NOT something this bootstrapper can determine (Open Question 3,
+rem same plan doc) -- this note is deliberately honest about that limit, not a diagnosis.
+echo.
+echo ============================================================
+echo  SETUP COMPLETE -- BUT WE CAN'T CONFIRM YOUR LAST RUN WORKED
+echo ============================================================
+echo  Your existing standalone application was reused (dist\%ENVNAME%.exe),
+echo  and it exited with an error just now (see the [STATUS] line
+echo  above) -- so we can't tell whether that's a bug in your own
+echo  code, or something else. Your environment and dependencies ARE
+echo  still installed correctly.
+echo.
+echo  RUNNING YOUR APP
+echo    Double-click dist\%ENVNAME%.exe to run it, or run it from a
+echo    Command Prompt to see the full output.
+echo.
+echo  WANT A FRESH BUILD (re-checks all dependencies from scratch)?
+echo    Delete dist\%ENVNAME%.exe and run this bootstrapper again.
+echo ============================================================
+echo.
+call :log "[WARN] REQ-016: Post-flight note printed; cached EXE kept despite a non-zero exit after the fail-fast probe."
 exit /b 0
 
 :check_net_after_dl_fail

--- a/tests/selfapps_failfast_probe.ps1
+++ b/tests/selfapps_failfast_probe.ps1
@@ -221,8 +221,13 @@ sys.exit(0)
     $alNotDiscarded = -not ($alRun2Text -match [regex]::Escape('discarding cached EXE and rebuilding'))
     $alExeStillPresent = $alExeCandidates.Count -gt 0
     $alBootstrapStayedOk = ($alStatusState -eq 'ok')
+    # [REQ-027] P2 honest messaging: before this fix, run 2's cached-EXE-kept-despite-failure
+    # outcome had NO postflight signal beyond the WARN log line already asserted above --
+    # :print_fastpath_ambiguous_note (run_setup.bat) closes that gap with a plain informational
+    # panel (no consent prompt, so it does not touch the fast path's zero-friction guarantee).
+    $alAmbiguousNoteFound = $alRun2Text -match [regex]::Escape('WANT A FRESH BUILD (re-checks all dependencies from scratch)?')
 
-    $alivePass = ($alRun1Exit -eq 0) -and ($alRun2Exit -eq 0) -and $alLaunchedInteractive -and $alAliveMsg -and $alStatusFailed -and $alNotDiscarded -and $alExeStillPresent -and $alBootstrapStayedOk
+    $alivePass = ($alRun1Exit -eq 0) -and ($alRun2Exit -eq 0) -and $alLaunchedInteractive -and $alAliveMsg -and $alStatusFailed -and $alNotDiscarded -and $alExeStillPresent -and $alBootstrapStayedOk -and $alAmbiguousNoteFound
     $aliveDetails = [ordered]@{
         run1Exit             = $alRun1Exit
         run2Exit             = $alRun2Exit
@@ -232,6 +237,7 @@ sys.exit(0)
         notDiscarded         = $alNotDiscarded
         exeStillPresent      = $alExeStillPresent
         bootstrapState       = $alStatusState
+        ambiguousNoteFound   = $alAmbiguousNoteFound
         run2Log              = '~al_run2.log'
     }
 } catch {

--- a/tests/selfapps_pyinstaller_fail.ps1
+++ b/tests/selfapps_pyinstaller_fail.ps1
@@ -12,17 +12,24 @@
 # consented to (HP_BUILD_OK). Fixed by setting HP_BOOTSTRAP_STATE=error at the PyInstaller
 # build call site, mirroring the existing preflight-failure precedent in :run_entry_smoke.
 #
-# Two scenarios via PYI_FAIL_SCENARIO env var (research Finding 2,
+# Three scenarios via PYI_FAIL_SCENARIO env var (research Finding 2,
 # docs/prd-av-safe-build-path.md): "execfail" forces the build command itself to fail
 # (HP_TEST_FORCE_PYINSTALLER_FAIL=1); "output_vanish" lets a real build succeed, then deletes
 # dist\<env>.exe immediately after (HP_TEST_FORCE_OUTPUT_VANISH=1) to simulate AV-style
-# post-creation removal as a distinct trigger condition from the build command failing outright.
+# post-creation removal as a distinct trigger condition from the build command failing outright;
+# "execfail_runtimefail" (added for [REQ-027] P2 honest messaging) is "execfail" PLUS a stub app
+# that ALSO exits non-zero when run via the interpreter fallback, exercising the compound
+# failure the other two scenarios' clean-exiting stub app never reaches.
 #
-# Asserts (both scenarios): the final ~bootstrap.status.json reads state=error (not silently
+# Asserts (all scenarios): the final ~bootstrap.status.json reads state=error (not silently
 # overwritten back to ok), the correct [ERROR] message appears in the log, and (docs/
-# open-questions.md item 1) the dedicated :print_no_exe_briefing panel is shown -- since the
-# stub app runs cleanly via the interpreter fallback despite total packaging failure, the final
-# console [STATUS] line alone would otherwise read identically to a real success. Does NOT
+# open-questions.md item 1) the dedicated :print_no_exe_briefing panel is shown. For "execfail"/
+# "output_vanish", the stub app runs cleanly via the interpreter fallback despite total packaging
+# failure, so the final console [STATUS] line alone would otherwise read identically to a real
+# success -- the plain (non-caveat) panel text is asserted. For "execfail_runtimefail", the
+# interpreter fallback ALSO exits non-zero -- [REQ-027]'s HP_NOEXE_VERIFY_FAILED-gated caveat
+# panel text is asserted instead, confirming the panel no longer claims "your code ran
+# successfully" when it did not (a real, pre-existing dishonest claim this closes). Does NOT
 # assert a non-zero process exit code -- :success's own `exit /b 0` runs unconditionally
 # regardless of HP_BOOTSTRAP_STATE, matching this repo's established "graceful stop" contract
 # for this class of failure (see selfapps_preflight.ps1's sibling test, which likewise never
@@ -89,9 +96,17 @@ if (Test-Path $workDir) { Remove-Item -Recurse -Force $workDir }
 New-Item -ItemType Directory -Force -Path $workDir | Out-Null
 Copy-Item -Path $batchPath -Destination $workDir -Force
 
-Set-Content -Path (Join-Path $workDir 'app.py') -Value @'
+if ($scenario -eq 'execfail_runtimefail') {
+    Set-Content -Path (Join-Path $workDir 'app.py') -Value @'
+import sys
+print("i-tried-but-failed")
+sys.exit(3)
+'@ -Encoding ASCII
+} else {
+    Set-Content -Path (Join-Path $workDir 'app.py') -Value @'
 print("should-not-matter")
 '@ -Encoding ASCII
+}
 
 $bootstrapLog = "~pyi_fail_${scenario}_bootstrap.log"
 
@@ -101,7 +116,7 @@ $prevForceVanish = if (Test-Path Env:HP_TEST_FORCE_OUTPUT_VANISH) { $env:HP_TEST
 $prevForceNuitkaFail = if (Test-Path Env:HP_TEST_FORCE_NUITKA_FAIL) { $env:HP_TEST_FORCE_NUITKA_FAIL } else { $null }
 $env:HP_SKIP_PIPREQS = '1'
 $env:HP_TEST_FORCE_NUITKA_FAIL = '1'
-if ($scenario -eq 'execfail') {
+if ($scenario -eq 'execfail' -or $scenario -eq 'execfail_runtimefail') {
     $env:HP_TEST_FORCE_PYINSTALLER_FAIL = '1'
 } else {
     $env:HP_TEST_FORCE_OUTPUT_VANISH = '1'
@@ -120,13 +135,20 @@ try {
     $logLines = if (Test-Path $logPath) { Get-Content -LiteralPath $logPath -Encoding ASCII } else { @() }
     $combined = $logLines -join "`n"
 
-    $expectedMsg = if ($scenario -eq 'execfail') { 'PyInstaller execution failed' } else { 'PyInstaller did not produce dist' }
+    $expectedMsg = if ($scenario -eq 'execfail' -or $scenario -eq 'execfail_runtimefail') { 'PyInstaller execution failed' } else { 'PyInstaller did not produce dist' }
     $expectedMsgFound = $combined -match [regex]::Escape($expectedMsg)
     $testHookFired = $combined -match [regex]::Escape('HP_TEST_FORCE')
     # docs/open-questions.md item 1: when packaging fails outright but the interpreter fallback
     # still runs cleanly, :print_no_exe_briefing (run_setup.bat) prints a dedicated panel instead
     # of leaving the bare "[STATUS] Run Status: SUCCESS" line as the only thing the user sees.
-    $noExeBriefingFound = $combined -match [regex]::Escape('YOUR CODE RAN -- BUT NO STANDALONE .EXE WAS PRODUCED')
+    # [REQ-027] P2 honest messaging: "execfail_runtimefail" makes the interpreter fallback ALSO
+    # fail, so the panel must show the HP_NOEXE_VERIFY_FAILED-gated caveat text instead of the
+    # plain "your code ran successfully" text the other two scenarios still correctly expect.
+    $noExeBriefingFound = if ($scenario -eq 'execfail_runtimefail') {
+        $combined -match [regex]::Escape("NO STANDALONE .EXE -- AND WE CAN'T CONFIRM YOUR CODE RAN CLEANLY")
+    } else {
+        $combined -match [regex]::Escape('YOUR CODE RAN -- BUT NO STANDALONE .EXE WAS PRODUCED')
+    }
 
     $statusPath = Join-Path $workDir '~bootstrap.status.json'
     $statusText = if (Test-Path -LiteralPath $statusPath) { Get-Content -LiteralPath $statusPath -Raw } else { $null }


### PR DESCRIPTION
## Summary

- Closes the final slice (P2) of `docs/plan-cli-interactive-verification.md` — P0 and P1 shipped in prior PRs (#372–#376), P2 completes the plan.
- Fixes a real dishonesty bug: `:print_no_exe_briefing` unconditionally claimed "your code ran successfully" even when the interpreter fallback that runs right before it exited non-zero. Now branches on a new `HP_NOEXE_VERIFY_FAILED` flag into an honest "we can't confirm your code ran cleanly" panel.
- Fixes a real gap: the cached-EXE fast path had zero postflight signal (beyond one buried log line) when a reused EXE, classified alive/healthy by the fail-fast probe, later exited non-zero. New `:print_fastpath_ambiguous_note` prints a plain informational panel for that case — no new consent prompt, preserving the fast path's zero-friction design.
- Messaging only: no change to `~bootstrap.status.json` semantics, process exit codes, or any consent gate.
- Scope was deliberately narrowed from the plan's literal wording (no new "try a deeper dependency-resolution pass?" prompt) since that mechanism already exists earlier in the flow (the REQ-009 provider cascade, `:warnfix_cascade_detect`/`:cascade_consent_gate`) — documented in the plan doc's Open Question 3 (now resolved) and in `docs/agent-interconnect.md`.

## Test plan

- [x] `python -m compileall`, `pyflakes`, `check_delimiters.py`, `yamllint`, `actionlint` all clean
- [x] `tools/check_ndjson_registry.py` — 269/269 IDs match, no doc/code drift
- [x] Full PowerShell AST parse sweep over `tests/*.ps1`, `tools/*.ps1` — clean
- [x] `python -m pytest tests/test_*.py -q` — 386 passed, 2 skipped
- [x] `tests/selfapps_failfast_probe.ps1`'s existing "alive" scenario extended to assert the new fastpath-ambiguous-note text
- [x] `tests/selfapps_pyinstaller_fail.ps1` gained a third scenario (`execfail_runtimefail`: packaging fails AND the interpreter fallback also exits non-zero), wired into `real`/`conda-full`, asserting the new honest no-EXE panel text
- [ ] Real Windows CI confirmation (this repo's `.bat`/`.ps1` runtime behavior cannot be exercised in this sandbox)

Co-Authored-By: Claude <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_015xbWLPbiaKVsobB9FZy8kS)_