### PR TITLE
docs: drop AV-Safe Build Path Tier B from backlog; deepen demo doc

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -496,53 +496,6 @@ a fact confirmed with no action needed, or a recurring/periodic check belongs in
    creation), and the current fixed order is not wrong, just not optimal in either direction.
    Revisit if the network-correlated-embed-failure pattern shows up for real in CI or user
    reports, rather than speculatively building it now.
-6. **AV-Safe Build Path (PyInstaller quarantine fallback via Nuitka)** -- full PRD at
-   `docs/prd-av-safe-build-path.md`. A large, well-specified, preemptive feature (no real user
-   report yet, a documented industry-wide problem) covering a two-tier Nuitka fallback when
-   PyInstaller's build gets AV-quarantined, including a narrow, well-justified Python-3.12 pin
-   scoped to that one fallback tier. The PRD's own "Notes from Claude" section has the original
-   "way later" priority reasoning and a deliberately blunt writeup of why the PRD's narrow,
-   well-justified Tier B version pin should **never** be generalized into a bootstrapper-wide
-   "stay a version or two behind latest" default -- this repo's total absence of telemetry or an
-   auto-update mechanism means any such pin would be permanently frozen into every
-   already-distributed copy of `run_setup.bat`, with no way to walk it back later even after the
-   reason for it stops being true. Read that section before extending Tier B's pinning pattern
-   anywhere else in this codebase.
-
-   **Implementation started 2026-07-20 (owner green light, after a refinement pass on the
-   just-shipped autopep723 work held up cleanly -- see the Closed Backlog entry directly above
-   this one).** Phase 1 requirement 1 (failure-simulation tests, test-first per the PRD's own
-   sequencing note) is SHIPPED -- see the separate Closed Backlog entry for the real,
-   independent correctness bug found and fixed while scoping it. **Requirements 2-4 (dispatch +
-   Tier A: real Nuitka fallback build in the existing environment, no reprovisioning) are ALSO
-   now SHIPPED** -- see the dedicated Closed Backlog entry. **Requirement 9 (P1, the elective
-   "want an optimized build too?" post-success upsell) is ALSO now SHIPPED** -- see its own
-   dedicated Closed Backlog entry.
-
-   **Requirement 5 (Tier B, reprovisioned pinned-3.12 environment via the existing provider
-   chain) is explicitly DEFERRED, owner's direct instruction (2026-07-21): "Until I run the
-   bootstrapper myself and have real problems, I don't want to do the reprovision rollback."**
-   This is not "not started yet" in the usual backlog sense -- it is a deliberate decision not
-   to build it speculatively before a real, owner-observed failure justifies the added
-   complexity (a second provider-chain traversal, a pinned-version environment, the
-   stale-PATH/VIRTUAL_ENV hazard research Finding 6 already flagged). Requirements 6 (loop
-   avoidance) and 8 (connectivity check before Tier B) both depend on Tier B existing and are
-   deferred with it. Do not start Tier B without a fresh, explicit go-ahead -- this differs from
-   how items 2-4 and 9 were greenlit (a broad "go as far as you can" authorization for the PRD
-   generally); Tier B specifically was carved back out after that authorization, so it needs its
-   own separate green light, not inference from the general one.
-
-   **Downtime re-check, 2026-07-20 (research only, no code written):**
-   verified against Nuitka's live changelog/issue tracker that Finding 1's core blocker (MinGW64
-   doesn't support Python 3.13+) is still unresolved as of Nuitka 4.1.2 -- no change to the
-   PRD's design. One narrower update folded into the PRD in place: a real Nuitka 4.0.4 bug fix
-   ("compiling with newer Python versions did not fall back to Zig when MSVC/MinGW64 was
-   unusable") means Tier A's own compiler-discovery chain may now land on Zig automatically more
-   often than Finding 1's original "not mature enough" framing assumed, and the specific crash
-   report Finding 1 cited turned out to be macOS/M3-scoped, not Windows. See the PRD's own inline
-   "Re-checked 2026-07-20" note under Finding 1 for the full detail -- flagged for confirmation
-   whenever Tier A is actually implemented, not verified end-to-end here (no Windows machine
-   available for this research pass).
 7. **CI job steps in `batch-check.yml` don't use `if: always()`, so one failing self-test step
    silently cascade-skips every subsequent step in the same job -- observed directly, not
    theorized.** While landing item 6's requirement-1 tests (PR #368), a bug in the new
@@ -710,8 +663,9 @@ rather than relying on manual memory.
   computed once at pin-time and independently verified, never trusted from a third-party
   checksum file fetched over the same network path as the download itself).
 - **Next-pin probe**: this table's own quarterly refresh (checking python.org for a new minor)
-  already covers this on the "does a new version exist" axis. If REQ-AV's Tier B (see the PRD
-  link in Active Backlog) ever ships its own Python-3.12 pin for Nuitka/MinGW64 compatibility,
+  already covers this on the "does a new version exist" axis. If REQ-AV's Tier B (dropped from the
+  backlog entirely -- see the Known Findings entry below for why and what restarts it; PRD at
+  `docs/prd-av-safe-build-path.md`) ever ships its own Python-3.12 pin for Nuitka/MinGW64 compatibility,
   add a matching probe here: periodically check whether Nuitka's MinGW64 backend has resumed
   Python 3.13+ support upstream, since that specific fact (not a general "try a newer version
   and see") is what the 3.12 pin depends on -- see that PRD's "Notes from Claude" section for why
@@ -755,6 +709,36 @@ for each tracked pin" -- worth doing, not urgent, and deliberately not built spe
 of a second or third pin actually needing it.
 
 ## Known Findings (diagnosed, no action warranted)
+
+- **AV-Safe Build Path Tier B (reprovisioned pinned-3.12 environment) dropped from the backlog
+  entirely, 2026-07-24 owner instruction -- not deferred-with-intent-to-revisit, genuinely not
+  planned unless one of two specific triggers occurs.** Full PRD at
+  `docs/prd-av-safe-build-path.md`; Tier A (real Nuitka fallback build in the existing
+  environment) and requirement 9 (the elective "optimized build?" upsell) are both SHIPPED --
+  see their own dedicated Closed Backlog entries -- and remain the complete, working AV-quarantine
+  mitigation this repo ships today. Tier B was the PRD's second tier: a reprovisioned environment
+  pinned to Python 3.12 specifically to route around Nuitka's MinGW64 backend not supporting
+  Python 3.13+ (Finding 1 in the PRD, last re-confirmed unresolved as of Nuitka 4.1.2 in the
+  2026-07-20 downtime re-check). Building it means a second provider-chain traversal, a
+  pinned-version environment, and the stale-PATH/`VIRTUAL_ENV` hazard research Finding 6 already
+  flagged -- real complexity with no user-observed need yet (the PRD itself notes it as
+  preemptive, "no real user report yet, a documented industry-wide problem").
+  **Two, and only two, conditions restart this work**: (a) the owner personally hits a real
+  PyInstaller AV-quarantine failure that Tier A does not already resolve, giving the reprovision
+  complexity a concrete justification instead of a speculative one; or (b) Nuitka's own upstream
+  MinGW64 backend gains Python 3.13+ support, which would remove the entire reason Tier B needs a
+  narrow version pin in the first place -- at that point Tier B's whole design would need
+  re-evaluating (it might not need a pin at all anymore), not just a version bump. Condition (b)
+  is exactly what the "Next-pin probe concept" section above already tracks quarterly for any
+  future pin justified by one specific, checkable fact -- re-check that same fact each scan
+  (Nuitka's MinGW64 Python-version support), not a generic "try a newer Nuitka" probe. If either
+  condition fires, read the PRD's own "Notes from Claude" section before restarting Tier B -- it
+  has the original reasoning plus a deliberately blunt writeup of why Tier B's narrow, well-
+  justified 3.12 pin should **never** be generalized into a bootstrapper-wide "stay a version or
+  two behind latest" default (this repo has no telemetry or auto-update mechanism, so any such
+  pin freezes permanently into every already-distributed copy of `run_setup.bat`). Requirements 6
+  (loop avoidance) and 8 (connectivity check before Tier B) depend on Tier B existing and are
+  dropped with it, for the same reason.
 
 - **The official `irm https://astral.sh/uv/install.ps1 | iex` installer script was researched as
   a possible replacement for the current uv acquisition method -- rejected, current approach is

--- a/docs/demo-bootstrapper-output.md
+++ b/docs/demo-bootstrapper-output.md
@@ -14,11 +14,12 @@ job log (cited with run ID, job ID, lane, and test file) or, where noted, taken 
 `run_setup.bat`'s current source because no CI run has exercised that exact wording yet -- always
 labeled explicitly which case applies, never presented as a real capture when it isn't.
 
-**Scope so far:** covers the AV-Safe Build Path work (Tier A Nuitka fallback, its interaction
-with hidden-import auto-recovery, and the requirement-9 optimized-build offer) -- the most recent,
-most user-facing-behavior-changing area at the time this doc started. Extend to other areas
-(REQ-009 provider cascade, warnfix, the REQ-018 post-execution checkpoint on its own, etc.) as
-they're reviewed.
+**Scope:** two parts, grouped by feature area and roughly in the order each was reviewed. Part I
+covers the AV-Safe Build Path work (Tier A Nuitka fallback, its interaction with hidden-import
+auto-recovery, and the requirement-9 optimized-build offer). Part II covers the CLI-interactivity
+plan (`docs/plan-cli-interactive-verification.md`): live-tee verification, argv passthrough
+(REQ-026), and honest ambiguous-exit messaging (REQ-027). Extend with a new Part as new feature
+areas get reviewed, rather than growing either existing Part indefinitely.
 
 **Console vs. `~setup.log`:** the bootstrapper writes to two different places that are easy to
 conflate:
@@ -30,20 +31,45 @@ conflate:
   CONSOLE view, not `~setup.log`. Quotes below are from the console-equivalent capture unless
   stated otherwise.
 
+## Table of contents
+
+- [Part I: AV-Safe Build Path (Nuitka fallback)](#part-i-av-safe-build-path-nuitka-fallback)
+  - [Scenario 1: PyInstaller build fails, Tier A (Nuitka) fallback succeeds](#scenario-1-pyinstaller-build-fails-tier-a-nuitka-fallback-succeeds)
+  - [Scenario 2: PyInstaller build fails, Tier A fallback ALSO fails (tier exhaustion)](#scenario-2-pyinstaller-build-fails-tier-a-fallback-also-fails-tier-exhaustion)
+    - [2a. `execfail`](#2a-execfail----the-pyinstaller-build-command-itself-fails)
+    - [2b. `output_vanish`](#2b-output_vanish----pyinstaller-succeeds-then-the-exe-disappears-immediately)
+  - [Scenario 3: Tier A + hidden-import auto-recovery skip guard](#scenario-3-tier-a-hidden-import-auto-recovery-skip-guard)
+  - [Scenario 4: Requirement 9 -- elective "want an optimized build too?" offer](#scenario-4-requirement-9----elective-want-an-optimized-build-too-offer)
+    - [4a. `accept`](#4a-accept----a-real-optimized-build-succeeds-and-is-swapped-in)
+    - [4b. `forcefail`](#4b-forcefail----accepted-but-the-build-fails-original-exe-is-left-untouched)
+    - [4c. `swapfail`](#4c-swapfail----verified-build-but-the-final-swap-step-fails-original-exe-is-left-untouched)
+    - [4d. `decline`](#4d-decline----defaultci-path-prompt-shown-but-nothing-built)
+    - [Reactive-only failure hint](#reactive-only-failure-hint-both-tier-a-and-requirement-9s-real-build-failure-paths)
+- [Part II: CLI interactivity, argv passthrough & honest messaging](#part-ii-cli-interactivity-argv-passthrough-honest-messaging)
+  - [Scenario 5: Interactive verification -- live-tee, activity-aware kill, and the quit-prompt hint](#scenario-5-interactive-verification----live-tee-activity-aware-kill-and-the-quit-prompt-hint)
+  - [Scenario 6: Argv passthrough (REQ-026) -- launch arguments through the bootstrapper](#scenario-6-argv-passthrough-req-026----launch-arguments-through-the-bootstrapper)
+  - [Scenario 7: Honest ambiguous-exit messaging (REQ-027)](#scenario-7-honest-ambiguous-exit-messaging-req-027)
+    - [7a. No-EXE path, interpreter also failed](#7a-no-exe-path-interpreter-also-failed)
+    - [7b. Cached-EXE fast path, kept despite a non-zero exit](#7b-cached-exe-fast-path-kept-despite-a-non-zero-exit)
+
 ---
 
-## Scenario 1: PyInstaller build fails, Tier A (Nuitka) fallback succeeds
+## Part I: AV-Safe Build Path (Nuitka fallback)
+
+### Scenario 1: PyInstaller build fails, Tier A (Nuitka) fallback succeeds
 
 **What's tested:** `self.exe.build.tiera` (`tests/selfapps_nuitka_tiera.ps1`, uv lane,
 non-gating). `HP_TEST_FORCE_PYINSTALLER_FAIL=1` forces the primary build to fail deterministically;
 the Nuitka fallback (`:try_nuitka_tier_a`) then runs for real -- a genuine compile, not simulated.
 
 **What appears on screen**, from the moment PyInstaller's build is attempted through to the final
-summary. Sourced from real CI (run `29788624195`, job `88506013149`), with the "(PyInstaller)"
-verification line, the drive-message reassurance line, and the "Verifying the built standalone
-EXE" line (now conditional -- see `docs/plan-cli-interactive-verification.md` requirement 3 and
-`docs/agent-interconnect.md`'s "Activity-aware EXE-smoke kill") updated to reflect wording fixes
-made after that run -- not yet re-confirmed against a fresh CI capture:
+summary. Sourced from real CI (run `29788624195`, job `88506013149`), with the "(fallback build
+system)" verification line and the drive-message reassurance line as originally captured, but the
+"Verifying the built standalone EXE" line and the "Does your program need launch arguments"
+paragraph both updated in place to the CURRENT shipped wording (`docs/plan-cli-interactive-
+verification.md` requirement 3's activity-aware kill, and REQ-026's argv passthrough -- both
+landed after this specific run) -- **not yet re-confirmed against a fresh CI capture that includes
+either addition**:
 
 ```
 [INFO] Building standalone executable -- this may take a minute or two...
@@ -57,7 +83,7 @@ The system cannot find the drive specified.
 [INFO] PyInstaller build artifacts cleaned up.
 [INFO] EXE smokerun: testing dist\<env>.exe
 [INFO] Running entry script smoke test via packaged EXE.
-[WARN] Verifying the built standalone EXE (fallback build system) now: if it stays completely silent for about 30 seconds it will be force-stopped, but any output (including a prompt waiting on your input) keeps it running as long as needed. Either way, do not start real work in it yet or any unsaved work will be lost.
+[WARN] Verifying the built standalone EXE (fallback build system) now: if it stays completely silent for about 30 seconds it will be force-stopped, but any output (including a prompt waiting on your input) keeps it running as long as needed. If your program is interactive, try answering its prompts through to its own quit/exit option now so we can confirm it exits cleanly. Either way, do not start real work in it yet or any unsaved work will be lost.
 [INFO] EXE smokerun: exited 0 (ok)
 [INFO] Entry smoke exit=0
 [STATUS] Run Status: SUCCESS (Exit Code: 0)
@@ -91,6 +117,15 @@ The system cannot find the drive specified.
    once instead of live when run as the .exe -- that is a stdout
    buffering difference between the .exe and the script, not an error.
 
+   Does your program need launch arguments (e.g. --input file.csv)? Run
+   this bootstrapper again with them added after the entry file, e.g.
+     run_setup.bat "<entry.py>" --input file.csv
+   and they will be forwarded to your program during THIS setup run
+   (up to 8 extra arguments). This does not change how a plain
+   double-click of dist\<env>.exe launches it afterward -- for that,
+   make a Windows shortcut to the .exe and add the arguments to its
+   Target field, or launch it yourself from a Command Prompt.
+
  KEEP these files with your project:
    requirements.txt  -- packages your app depends on
    runtime.txt       -- Python version pin
@@ -108,19 +143,21 @@ instead of a hardcoded "(PyInstaller)" when the EXE being verified was actually 
 "PyInstaller build cache" line is left as-is -- Nuitka never creates a `build\<env>\` folder of
 its own (its `--remove-output` flag cleans up its own intermediates), so that line stays literally
 true regardless of which tool actually built the current EXE: if a `build\` folder exists, it's
-PyInstaller's.
+PyInstaller's. See Scenario 6 for the argv-passthrough paragraph's own dedicated writeup.
 
 ---
 
-## Scenario 2: PyInstaller build fails, Tier A fallback ALSO fails (tier exhaustion)
+### Scenario 2: PyInstaller build fails, Tier A fallback ALSO fails (tier exhaustion)
 
 **What's tested:** `self.exe.build.xfail` (`tests/selfapps_pyinstaller_fail.ps1`, real/conda-full
-lanes, gating). Two sub-scenarios share one NDJSON row id: `execfail` (the PyInstaller build
-command itself fails) and `output_vanish` (PyInstaller succeeds, then the output EXE vanishes
-immediately -- simulating AV-style post-creation removal). Both additionally force
+lanes, gating). Three sub-scenarios share one NDJSON row id: `execfail` (the PyInstaller build
+command itself fails), `output_vanish` (PyInstaller succeeds, then the output EXE vanishes
+immediately -- simulating AV-style post-creation removal), and `execfail_runtimefail` (packaging
+fails AND the interpreter fallback that runs next ALSO exits non-zero -- see Scenario 7a for that
+one's console text, since it's really a REQ-027 demo). The first two additionally force
 `HP_TEST_FORCE_NUITKA_FAIL=1` so the fallback also fails, proving genuine tier exhaustion.
 
-### 2a. `execfail` -- the PyInstaller build command itself fails
+#### 2a. `execfail` -- the PyInstaller build command itself fails
 
 Real CI capture, run `29788624195`, job `88506013028` ("real" lane):
 
@@ -140,20 +177,17 @@ Real CI capture, run `29788624195`, job `88506013028` ("real" lane):
 [INFO] REQ-018: post-execution checkpoint (interpreter): declined (run footprint stays at one execution).
 ```
 
-When BOTH the PyInstaller build and the Nuitka fallback fail outright, the bootstrapper does not
-stop -- it falls through to running the entry script directly via the interpreter, and since that
-trivial script runs cleanly, the final line is `[STATUS] Run Status: SUCCESS (Exit Code: 0)` --
-identical wording to a genuine clean-EXE success, with no on-screen summary reminding the user
-that no `.exe` was produced. This is intentional, documented design (see CLAUDE.md's Known
-Finding on user-code exit-code semantics); whether the final wording should change is tracked as
-an open question -- see `docs/open-questions.md` item 1.
+When BOTH the PyInstaller build and the Nuitka fallback fail outright but the interpreter
+fallback's own run exits 0 (this trivial stub script does), the final line is
+`[STATUS] Run Status: SUCCESS (Exit Code: 0)` and the postflight panel is the plain
+"YOUR CODE RAN -- BUT NO STANDALONE .EXE WAS PRODUCED" variant -- see Scenario 7a for the
+DIFFERENT (honest, "we can't confirm") panel this same tier-exhaustion path now shows when the
+interpreter run ALSO fails, which is the REQ-027 fix that closed the gap this section used to flag
+as an open question.
 
-### 2b. `output_vanish` -- PyInstaller succeeds, then the EXE disappears immediately
+#### 2b. `output_vanish` -- PyInstaller succeeds, then the EXE disappears immediately
 
-Real CI capture, same run/job as 2a, with the warnfix message updated to reflect a wording fix
-made after this run (removes a stale "in the list above" reference, since the raw warn-file dump
-that phrase pointed at only ever went to `~setup.log`, never the console) -- not yet re-confirmed
-against a fresh CI capture:
+Real CI capture, same run/job as 2a:
 
 ```
 [INFO] Building standalone executable -- this may take a minute or two...
@@ -176,7 +210,7 @@ against a fresh CI capture:
 
 ---
 
-## Scenario 3: Tier A + hidden-import auto-recovery skip guard
+### Scenario 3: Tier A + hidden-import auto-recovery skip guard
 
 **What's tested:** `self.exe.tiera.hidden_skip` (`tests/selfapps_nuitka_tiera_hidden_skip.ps1`, uv
 lane, non-gating). Forces Tier A to trigger and succeed for real, then has the stub app fabricate
@@ -209,7 +243,7 @@ attempted a PyInstaller rebuild against a Nuitka-built EXE.
 
 ---
 
-## Scenario 4: Requirement 9 -- elective "want an optimized build too?" offer
+### Scenario 4: Requirement 9 -- elective "want an optimized build too?" offer
 
 **What's tested:** `self.optbuild.offer` (`tests/selfapps_optimized_build.ps1`, uv lane,
 non-gating), four scenarios sharing one row id.
@@ -223,9 +257,12 @@ passing:
 {"desc":"AV-Safe Build Path requirement 9 (decline): default/CI path shows the prompt but never attempts a build","lane":"uv","details":{"statusState":"ok","noBuildAttempt":true,"tmpExeGone":true,"scenario":"decline","log":"~optbuild_decline_bootstrap.log","bootstrapExit":0,"exeExists":true,"declinedLogged":true,"promptShown":true},"req":"REQ-AV","id":"self.optbuild.offer","pass":true}
 ```
 
-### 4a. `accept` -- a real optimized build succeeds and is swapped in
+#### 4a. `accept` -- a real optimized build succeeds and is swapped in
 
-Real, verbatim console dump (`~selftest_optbuild_accept\~optbuild_accept_bootstrap.log`):
+Real, verbatim console dump (`~selftest_optbuild_accept\~optbuild_accept_bootstrap.log`), with the
+"Verifying the built standalone EXE" line updated in place to the CURRENT shipped wording
+(requirement 3's activity-aware kill plus the quit-prompt hint, both landed after this capture) --
+**not yet re-confirmed against a fresh CI capture**:
 
 ```
 [INFO] Building standalone executable -- this may take a minute or two...
@@ -236,7 +273,7 @@ The system cannot find the drive specified.
 [INFO] PyInstaller build artifacts cleaned up.
 [INFO] EXE smokerun: testing dist\<env>.exe
 [INFO] Running entry script smoke test via packaged EXE.
-[WARN] Verifying the built standalone EXE (PyInstaller) now: if it stays completely silent for about 30 seconds it will be force-stopped, but any output (including a prompt waiting on your input) keeps it running as long as needed. Either way, do not start real work in it yet or any unsaved work will be lost.
+[WARN] Verifying the built standalone EXE (PyInstaller) now: if it stays completely silent for about 30 seconds it will be force-stopped, but any output (including a prompt waiting on your input) keeps it running as long as needed. If your program is interactive, try answering its prompts through to its own quit/exit option now so we can confirm it exits cleanly. Either way, do not start real work in it yet or any unsaved work will be lost.
 [INFO] EXE smokerun: exited 0 (ok)
 [INFO] Entry smoke exit=0
 [STATUS] Run Status: SUCCESS (Exit Code: 0)
@@ -254,10 +291,7 @@ The system cannot find the drive specified.
 
 Note the "warnfix: Platform-specific modules..." line above still shows the OLD wording (this
 capture predates the messaging fix described in Scenario 2b) -- the NEW wording is the one shown
-there. The "Verifying the built standalone EXE (PyInstaller)" line has ALSO been updated in place
-to the new conditional wording (requirement 3, `docs/plan-cli-interactive-verification.md`) --
-this capture predates that fix too, so it no longer matches verbatim what a fresh run would show
-for either line; re-pull this capture once a fresh CI run exercises this path again.
+there.
 
 **The interactive `Build the optimized version now? [Y/N]` prompt line is echoed unconditionally
 by design** (same pattern as `:run_postexec_checkpoint`), but does not appear literally in any
@@ -265,7 +299,7 @@ CI capture -- CI answers via the `HP_TEST_OPTBUILD_ANSWER` env-var override, not
 `set /p` path, so only the resolution lines (`accepted`/`declined`) show up in these logs. This is
 expected (CI is non-interactive by design), not a gap.
 
-### 4b. `forcefail` -- accepted, but the build fails; original EXE is left untouched
+#### 4b. `forcefail` -- accepted, but the build fails; original EXE is left untouched
 
 Real, verbatim console dump (`~selftest_optbuild_forcefail\~optbuild_forcefail_bootstrap.log`):
 
@@ -285,7 +319,7 @@ narrower silence than the wording used on a REAL build-failure branch (which exp
 and a genuine build failure currently give the user different amounts of reassurance for what is,
 from their perspective, the same outcome.
 
-### 4c. `swapfail` -- verified build, but the final swap step fails; original EXE is left untouched
+#### 4c. `swapfail` -- verified build, but the final swap step fails; original EXE is left untouched
 
 Regression test for a real bug: the swap-verification check used to test the DESTINATION file
 (which already exists before the move, success or failure alike) instead of the SOURCE (which
@@ -300,7 +334,7 @@ since this scenario has passed on every run so far):
 [WARN] Optimized build verified successfully but could not be swapped into place; your app is still ready to use as-is.
 ```
 
-### 4d. `decline` -- default/CI path, prompt shown but nothing built
+#### 4d. `decline` -- default/CI path, prompt shown but nothing built
 
 Real, verbatim console dump (`~selftest_optbuild_decline\~optbuild_decline_bootstrap.log`):
 
@@ -311,7 +345,7 @@ Real, verbatim console dump (`~selftest_optbuild_decline\~optbuild_decline_boots
 [INFO] Optimized build: declined.
 ```
 
-### Reactive-only failure hint (both Tier A and requirement 9's real-build-failure paths)
+#### Reactive-only failure hint (both Tier A and requirement 9's real-build-failure paths)
 
 Fires only on a GENUINE Nuitka compiler failure (not the `forcefail` test hook, which bypasses it
 entirely). No CI run to date has exercised a real Nuitka compiler failure, so this is sourced from
@@ -321,3 +355,198 @@ entirely). No CI run to date has exercised a real Nuitka compiler failure, so th
 [WARN] Optimized build did not complete; your app is still ready to use as-is.
 [WARN] Hint: if you have Visual Studio 2022 (or newer) with the 'Desktop development with C++' workload installed, this should use it automatically -- no extra setup needed. If not, installing the free Visual Studio Build Tools with that workload can help.
 ```
+
+---
+
+## Part II: CLI interactivity, argv passthrough & honest messaging
+
+Covers `docs/plan-cli-interactive-verification.md` (P0/P1/P2, all shipped): the live-tee
+verification redesign that lets an interactive `input()`-driven program's prompts actually reach
+the console, the activity-aware 30-second kill, argv passthrough (REQ-026), and the honest
+ambiguous-exit messaging panels (REQ-027).
+
+### Scenario 5: Interactive verification -- live-tee, activity-aware kill, and the quit-prompt hint
+
+**What changed, in one sentence:** before this plan, `:run_exe_smokerun`'s verification launch
+force-killed at a hard 30 seconds regardless of output, and captured stdout/stderr only to a file
+(never live to the console) -- so a program correctly waiting on its first `input()` prompt looked
+identical to a genuinely hung one, and the user watching the window saw nothing until the process
+either finished or got killed.
+
+**What's tested (the plumbing):** `self.interactive.stdin.roundtrip`
+(`tests/selfapps_interactive_stdin.ps1`, uv lane, non-gating) builds a real PyInstaller EXE from a
+multi-round `input()`-driven stub app and pipes a scripted answer sequence into `cmd.exe`'s own
+stdin, exercising the full `cmd.exe -> :run_exe_smokerun -> ~exe_smokerun.ps1 -> the built EXE`
+chain and asserting each answer lands in the right round via ordering checks on the captured log
+-- it proves the plumbing doesn't drop or reorder stdin/stdout, not a live human's own typing
+timing (which can't be automated).
+
+**The WARN line a user sees right before the verification launch**, current shipped wording
+(source: `run_setup.bat`, `:warn_user_code_launch` -- not a console capture, since CI answers
+scripted stdin rather than a human watching the window; Scenario 1 and Scenario 4a above both show
+this exact line in situ):
+
+```
+[WARN] Verifying the built standalone EXE (PyInstaller) now: if it stays completely silent for about 30 seconds it will be force-stopped, but any output (including a prompt waiting on your input) keeps it running as long as needed. If your program is interactive, try answering its prompts through to its own quit/exit option now so we can confirm it exits cleanly. Either way, do not start real work in it yet or any unsaved work will be lost.
+```
+
+Three things this one line is doing:
+1. **States the actual kill rule truthfully**: the 30-second cap is a classification checkpoint,
+   not an unconditional deadline -- `Kill()` only fires if the process has stayed COMPLETELY
+   silent that whole time. Any output (including a bare prompt with no trailing newline, the exact
+   shape of Python's own `input("...")`) switches to an unbounded wait.
+2. **Actively guides the user toward a clean result**: driving an interactive program to its own
+   quit/exit option during this pass turns an otherwise-ambiguous exit into a genuine, confirmed
+   `[STATUS] Run Status: SUCCESS` -- this directly reduces how often a real user ever sees either
+   of Scenario 7's ambiguous-exit panels.
+3. **Still warns it's a throwaway pass, not the user's real, saveable session** -- this verification
+   EXE is never reused; only the file it's already tested is kept for later double-clicks.
+
+The `hidden_import` recovery loop's own separate, narrower verification check (see
+`docs/agent-interconnect.md`'s "Activity-aware EXE-smoke kill" section) deliberately keeps the
+OLDER, unconditional 30-second wording -- it's a bounded repair-verification check on an
+already-built EXE, not the user's primary run, so it never got the interactive-friendly rewrite.
+
+### Scenario 6: Argv passthrough (REQ-026) -- launch arguments through the bootstrapper
+
+Extra arguments after the entry file on `run_setup.bat`'s own command line (up to 8) are forwarded
+verbatim to the target program at every real launch site -- the cached-EXE fast path, the fresh EXE
+verification, the no-EXE interpreter run, and the post-execution checkpoint's elective second run.
+This is a documented, opt-in escape hatch (no detection or heuristics involved) for a program that
+needs `--flag value`-style launch arguments to run correctly, on top of this bootstrapper's usual
+zero-argument double-click flow.
+
+**The postflight guidance a user sees after a successful EXE build** (Scenario 1's full panel
+above shows this in context):
+
+```
+   Does your program need launch arguments (e.g. --input file.csv)? Run
+   this bootstrapper again with them added after the entry file, e.g.
+     run_setup.bat "<entry.py>" --input file.csv
+   and they will be forwarded to your program during THIS setup run
+   (up to 8 extra arguments). This does not change how a plain
+   double-click of dist\<env>.exe launches it afterward -- for that,
+   make a Windows shortcut to the .exe and add the arguments to its
+   Target field, or launch it yourself from a Command Prompt.
+```
+
+**The equivalent guidance on the no-EXE path** (direct-interpreter-invocation form, part of
+Scenario 7a's panel below):
+
+```
+   Need launch arguments? Add them directly after that command, e.g.
+     "<python>" "<entry.py>" --input file.csv
+```
+
+Both are additive to the launch commands already shown in each panel, not a separate prompt --
+matching this bootstrapper's general rule that env-var/CLI flags only ever add an opt-in path or
+suppress an optional step, never gate a behavior the Prime Directive needs (see CLAUDE.md's
+`[REQ-019]`).
+
+### Scenario 7: Honest ambiguous-exit messaging (REQ-027)
+
+Both panels below fire only when a verification run ends AMBIGUOUSLY -- the program exited with an
+error, and no automatic repair (`--hidden-import` auto-recovery, the REQ-009 dependency-resolution
+cascade) fixed it. Neither panel claims to know WHY: a bug in the program's own code, something
+this bootstrapper missed, or an unresolved dependency are all indistinguishable from here, and both
+panels say so plainly rather than guessing. This is messaging only -- `~bootstrap.status.json`
+semantics, the process exit code, and consent-gate behavior are all unchanged.
+
+Both are new enough (shipped, then refined once more for wording, entirely within this same
+session) that no CI run has yet produced a console capture including the current wording -- both
+quotes below are sourced directly from `run_setup.bat`, not a job log.
+
+#### 7a. No-EXE path, interpreter also failed
+
+Fires when BOTH PyInstaller and the Nuitka fallback fail to package the app outright, AND the
+interpreter fallback that runs next (the only way left to run the program at all) also exits
+non-zero -- the scenario Scenario 2a's own `execfail` sub-case would hit if its trivial stub script
+didn't happen to exit cleanly. Source: `:print_no_exe_briefing`'s `:noexe_caveat` branch,
+`run_setup.bat`:
+
+```
+============================================================
+ NO STANDALONE .EXE -- AND WE CAN'T CONFIRM YOUR CODE RAN CLEANLY
+============================================================
+ We could not package your app into a double-clickable .exe
+ (see the ERROR message above for why). We also just ran it
+ directly via the prepared Python environment, and it exited
+ with an error (see the [STATUS] line above) -- so we can't
+ tell whether that's a bug in the Python code we tried to run
+ or something this bootstrapper missed. Your environment and
+ dependencies ARE still installed correctly; run it yourself
+ below to see the full output.
+
+ RUNNING YOUR APP (without an .exe) -- the most direct option
+   "<python>" "<entry.py>"
+   Need launch arguments? Add them directly after that command, e.g.
+     "<python>" "<entry.py>" --input file.csv
+
+ Want to try different arguments through the bootstrapper itself
+ instead? Your already-installed environment is reused either
+ way; it will just attempt the .exe build again too:
+   run_setup.bat "<entry.py>" arg1 arg2
+
+ KEEP these files with your project:
+   requirements.txt  -- packages your app depends on
+   runtime.txt       -- Python version pin
+
+ SAFE TO DELETE to reclaim disk space:
+   .*_env\ folders   -- environment directories
+   ~* files          -- tilde-prefix work files (e.g. ~setup.log)
+============================================================
+```
+
+The direct-run command stays the visually primary option (matches this panel's own established
+preference for running the program directly over going back through the bootstrapper); the
+bootstrapper-rerun mention is deliberately secondary and uses the real entry filename (`%HP_ENTRY%`
+is reliably set by this point in the pipeline -- unlike Scenario 7b below).
+
+When the interpreter run instead exits CLEANLY (the common case, and what Scenario 2a's own capture
+shows), this panel's header and opening paragraph read differently -- plain "YOUR CODE RAN -- BUT
+NO STANDALONE .EXE WAS PRODUCED", with no claim of an unconfirmed run -- but the rest of the panel
+(launch commands, KEEP/SAFE TO DELETE lists) is identical either way.
+
+#### 7b. Cached-EXE fast path, kept despite a non-zero exit
+
+Fires when the fail-fast probe classifies a REUSED `dist\<env>.exe` (the top-of-file fast path,
+before any provider/entry-file logic runs) as alive/healthy -- so it's kept, never
+discarded-and-rebuilt -- and it later exits non-zero. Before this fix, this exact case had no
+postflight signal at all beyond one `[WARN]` log line buried among other console output. Source:
+`:print_fastpath_ambiguous_note`, `run_setup.bat`:
+
+```
+============================================================
+ SETUP COMPLETE -- BUT WE CAN'T CONFIRM YOUR LAST RUN WORKED
+============================================================
+ Your existing standalone application was reused (dist\<env>.exe),
+ and it exited with an error just now (see the [STATUS] line
+ above) -- so we can't tell whether that's a bug in the Python
+ code we tried to run, or something else. Your environment and
+ dependencies ARE still installed correctly.
+
+ RUNNING YOUR APP
+   Double-click dist\<env>.exe to run it, or run it from a
+   Command Prompt to see the full output.
+
+ WANT TO TRY AGAIN? You do not have to start over from scratch --
+   just run this bootstrapper again the same way you did before;
+   your already-installed environment and built .exe are reused.
+
+ WANT A FRESH BUILD instead (re-checks all dependencies from scratch)?
+   Delete dist\<env>.exe and run this bootstrapper again.
+============================================================
+```
+
+This panel is a PLAIN INFORMATIONAL PRINT, never a consent gate -- the cached-EXE fast path is
+deliberately zero-friction for prompts (see `docs/agent-interconnect.md`'s "Fast path = ZERO
+friction" design requirement), and this doesn't violate that since it never asks a question.
+
+**No entry filename appears anywhere in this panel, unlike 7a's rerun mention -- deliberately.**
+`HP_ENTRY` is not set yet at the point the top-of-file fast path runs (it fires before
+`:determine_entry` ever executes, since the cached EXE is self-contained and doesn't need the
+original source filename to relaunch), so naming one here would show blank or stale text. The two
+rerun options are worded to distinguish a genuinely different tradeoff instead: rerunning WITHOUT
+deleting the EXE reuses it (via the same fast path that got the user here) with no promise about
+whether it's actually faster overall, while deleting it first forces a full, slower, from-scratch
+dependency check.


### PR DESCRIPTION
## Summary

- **Tier B dropped from the backlog.** `CLAUDE.md`'s Active Backlog item 6 (AV-Safe Build Path Tier B -- reprovisioned pinned-3.12 environment for Nuitka/MinGW64) moved to Known Findings. This isn't "still deferred" -- it's genuinely not planned unless one of two specific triggers occurs: (a) a real, owner-observed AV-quarantine failure that Tier A doesn't already resolve, or (b) Nuitka's own upstream MinGW64 backend gains Python 3.13+ support, which would change Tier B's whole design (it might not need a pin at all), not just its version number. Tier A and requirement 9 (both already shipped) are unaffected -- they remain the complete AV-quarantine mitigation this repo ships today. Fixed the one forward cross-reference (the "Next-pin probe" section) that pointed at Tier B's old Active Backlog location.
- **Demo doc deepened.** `docs/demo-bootstrapper-output.md` gained a table of contents (all 18 anchors verified against GitHub's actual heading-slug algorithm) and was reorganized into two parts -- Part I (AV-Safe Build Path) and the new Part II (CLI interactivity, argv passthrough, honest messaging). While reviewing it against current `run_setup.bat` source, found and filled two real content gaps: the postflight panel's REQ-026 argv-passthrough paragraph and the requirement-3 quit-prompt WARN addition had both shipped since this doc's existing captures and were completely missing from it. Added three new scenarios: interactive verification/live-tee (5), argv passthrough (6), and both REQ-027 honest ambiguous-exit panels (7) -- the latter two are quoted directly from current source and clearly labeled as not-yet-CI-captured, per this doc's existing sourcing convention.

Docs-only change; no `run_setup.bat` logic touched. Full local sanity sweep clean throughout (compileall, pyflakes, delimiters, NDJSON registry, PS parse, pytest 386 passed/2 skipped -- none of these actually exercise the changed files, included per this repo's standard mandatory sweep).

Co-Authored-By: Claude <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_015xbWLPbiaKVsobB9FZy8kS)_