### PR TITLE
fix: PS selfapps scripts silently exit 0 despite failing rows (8 instances)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -892,7 +892,7 @@ Items completed and shipped:
   be"), 2026-07-24.** Two parallel research-only agents (`run_setup.bat` itself; CI workflow +
   test infrastructure) swept the codebase for new bugs beyond what earlier passes had already
   found. Every finding was independently re-verified by direct code tracing before being acted on.
-  - **7 `selfapps_*.ps1` files never propagated their computed `$pass` to a process exit code --
+  - **8 `selfapps_*.ps1` files never propagated their computed `$pass` to a process exit code --
     a NEW instance of the exact bug class already found and fixed twice before (3 files, then
     separately `tests/selftest.ps1`, per the earlier Closed Backlog entries).** A fresh sweep found
     `selfapps_contract_uv.ps1`, `selfapps_entry.ps1`, `selfapps_envsmoke.ps1`,
@@ -908,14 +908,30 @@ Items completed and shipped:
     still report green. **`selfapps_pandas_excel.ps1` had the more severe variant already seen
     once before in `reqspec.ps1`'s own conda-not-found branch**: its `HP_FORCE_CONDA_ONLY -eq '1'`
     branch (the conda-full gating lane, where conda genuinely missing IS a real failure) writes
-    six `pass=$false` NDJSON rows and then unconditionally `exit 0`s. Fixed via the SAME
-    central-choke-point pattern already proven correct for `tests/selftest.ps1`: each file's
-    `Write-NdjsonRow` function now sets a script-scoped `$script:AnyRowFailed` flag whenever a
-    row's `pass` is `$false`, and every exit site (both the final one and, for `pandas_excel.ps1`,
-    the one genuinely-unsafe mid-file one) checks it -- chosen over hand-deriving each file's own
+    six `pass=$false` NDJSON rows and then unconditionally `exit 0`s -- and `reqspec.ps1`'s own
+    structurally identical conda-not-found branch (line 347-353, same `HP_FORCE_CONDA_ONLY -eq '1'`
+    condition, same pattern of real `pass=$false` rows via `Write-ReqspecRows`) turned out to have
+    the SAME gap, caught in a follow-up self-check rather than the original sweep, and fixed the
+    same way. **A follow-up, targeted grep pass (files with zero `exit 1` occurrences anywhere,
+    run after the first 7 were fixed) found an 8th instance the two research agents both missed:
+    `selfapps_single.ps1`** (REQ-002, `entry.single.direct`/`helper.invoke`/`pipreqs.run`/
+    `entry.expected` rows) -- unconditional `exit 0` at end of file with zero `exit 1` anywhere,
+    despite four call sites that can write `pass=$false`. Lower real-world severity than the other
+    7 (this file's own header docstring notes it's gated on `pyFiles==1`, which the bootstrapper
+    repo's own multi-file CI runs never satisfy -- so this repo's CI has likely never actually
+    exercised the buggy branch -- but the file is an explicit template "In consumer repos it checks
+    the entry selection breadcrumbs when exactly one Python file is present," where the gap is
+    real). Fixed via the identical central-choke-point pattern: each file's `Write-NdjsonRow`
+    function now sets a script-scoped `$script:AnyRowFailed` flag whenever a row's `pass` is
+    `$false`, and every exit site (final, plus the genuinely-unsafe mid-file ones in
+    `pandas_excel.ps1` and `reqspec.ps1`) checks it -- chosen over hand-deriving each file's own
     "real" aggregate pass condition, since `reqspec.ps1`'s own ingest rows use locally-scoped pass
     variables that are NOT folded into its `$overallPass`, making a per-file manual aggregation
-    riskier to get right than the already-proven central-tracking mechanism.
+    riskier to get right than the already-proven central-tracking mechanism. This pass's own
+    lesson: a grep for "zero `exit 1` occurrences despite `pass=$false` literals present" is a
+    cheap, mechanical way to re-run this exact check in the future without needing a fresh agent
+    sweep -- worth remembering as the go-to verification method if this bug class is ever
+    suspected to have a 9th instance.
   - **`tests/harness.ps1`'s `$allowedStates` for the `bootstrap.state` check was missing
     `'embed_env'`** -- the state value `:try_embed_fallback` (REQ-009 Tier 5) sets on a successful
     embed-tier fallback, confirmed present in `run_setup.bat` alongside the already-allowlisted

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -887,6 +887,71 @@ of a second or third pin actually needing it.
 
 Items completed and shipped:
 
+- **Multi-agent parallel bug-hunt pass, requested directly by the owner ("general research
+  refinement and code review... shoring up and checking if things are really the way they need to
+  be"), 2026-07-24.** Two parallel research-only agents (`run_setup.bat` itself; CI workflow +
+  test infrastructure) swept the codebase for new bugs beyond what earlier passes had already
+  found. Every finding was independently re-verified by direct code tracing before being acted on.
+  - **7 `selfapps_*.ps1` files never propagated their computed `$pass` to a process exit code --
+    a NEW instance of the exact bug class already found and fixed twice before (3 files, then
+    separately `tests/selftest.ps1`, per the earlier Closed Backlog entries).** A fresh sweep found
+    `selfapps_contract_uv.ps1`, `selfapps_entry.ps1`, `selfapps_envsmoke.ps1`,
+    `selfapps_pandas_excel.ps1`, `selfapps_pipgap.ps1`, `selfapps_reqspec.ps1`, and
+    `selfapps_runtime_writeback.ps1` all missing `if (-not $pass) { exit 1 }; exit 0` at the end --
+    confirmed via `grep` that none contained any final exit statement (a few had only mid-file
+    `exit 0` skip-guards for non-Windows hosts or missing conda, all writing `pass=$true` rows
+    only, genuinely safe as unconditional exits). Four of these files (`entry`, `envsmoke`,
+    `reqspec`, `runtime_writeback`) run unconditionally in the GATING `real`/`conda-full` lanes
+    with no `continue-on-error`, meaning a real regression in entry selection, env-smoke
+    verification, requirement-spec translation, or runtime.txt write-back could compute
+    `pass=$false`, write it correctly into the NDJSON row -- and the step, job, and PR check would
+    still report green. **`selfapps_pandas_excel.ps1` had the more severe variant already seen
+    once before in `reqspec.ps1`'s own conda-not-found branch**: its `HP_FORCE_CONDA_ONLY -eq '1'`
+    branch (the conda-full gating lane, where conda genuinely missing IS a real failure) writes
+    six `pass=$false` NDJSON rows and then unconditionally `exit 0`s. Fixed via the SAME
+    central-choke-point pattern already proven correct for `tests/selftest.ps1`: each file's
+    `Write-NdjsonRow` function now sets a script-scoped `$script:AnyRowFailed` flag whenever a
+    row's `pass` is `$false`, and every exit site (both the final one and, for `pandas_excel.ps1`,
+    the one genuinely-unsafe mid-file one) checks it -- chosen over hand-deriving each file's own
+    "real" aggregate pass condition, since `reqspec.ps1`'s own ingest rows use locally-scoped pass
+    variables that are NOT folded into its `$overallPass`, making a per-file manual aggregation
+    riskier to get right than the already-proven central-tracking mechanism.
+  - **`tests/harness.ps1`'s `$allowedStates` for the `bootstrap.state` check was missing
+    `'embed_env'`** -- the state value `:try_embed_fallback` (REQ-009 Tier 5) sets on a successful
+    embed-tier fallback, confirmed present in `run_setup.bat` alongside the already-allowlisted
+    `venv_env`/`degraded_env` sibling states. Since the provider chain is
+    `uv -> conda -> embed -> venv -> system`, a genuine (non-test-forced) double failure of uv and
+    conda in the `real` (gating) lane would legitimately land here -- and would have been reported
+    as a `harness.ps1` failure despite being correct, designed fallback behavior, exactly mirroring
+    the already-allowlisted `venv_env`/`degraded_env` cases. Fixed by adding it to the allowlist.
+  - **The warnfix-triggered PyInstaller rebuild (`run_setup.bat`, inside the `HP_WARNFIX_NEEDED`
+    block) had zero failure handling, unlike its sibling original-build call a few dozen lines
+    earlier.** See `docs/agent-interconnect.md`'s "AV-Safe Build Path Tier A and hidden-import
+    auto-recovery" section for the full trace, failure scenario, and fix (mirrors the original
+    build's `if errorlevel 1 (...) else if not exist ... (...) else (...)` shape and
+    `HP_BOOTSTRAP_STATE=error` handling, deliberately without a `:try_nuitka_tier_a` retry; also
+    clears `HP_NUITKA_FALLBACK_USED` on a genuine PyInstaller rebuild success so
+    `:hidden_import_recover`'s existing Nuitka-skip guard doesn't misfire afterward). No dedicated
+    CI test added -- flagged here as a candidate for a future dedicated test pass (a
+    `HP_TEST_FORCE_WARNFIX_REBUILD_FAIL` hook mirroring the existing
+    `HP_TEST_FORCE_PYINSTALLER_FAIL` pattern) if this path's real-world trigger rate ever
+    justifies the investment; not built speculatively here, consistent with this repo's general
+    bias against untriggered speculative work.
+  - **Investigated and found NOT a new issue, no action**: the `real`-lane review agent's other
+    observations (a loose substring match in `selfapps_pyinstaller_fail.ps1`'s `$testHookFired`
+    clause, two cache-lane steps still missing `continue-on-error`) were both judged low-impact
+    (the loose match is ANDed with 3 other specific assertions so the test as a whole isn't
+    tautological; the cache-lane gap sits right before a step that already has `if: always()`) and
+    left for a future pass rather than expanding this one's scope further. The `run_setup.bat`
+    review agent's broader sweep (parse-time `%VAR%` freezing, fallback-tier state consistency,
+    unquoted risky `:log`/`echo` values, `move`/`rd` swap verification, guaranteed-vs-assumed-set
+    variables, and the newest REQ-026/REQ-027/activity-aware-kill code) found the codebase
+    consistently applying its own already-documented defensive patterns everywhere else traced,
+    including a specific check of whether `HP_NOEXE_VERIFY_FAILED`/`HP_FASTPATH_RUN_FAILED` could
+    go stale across a REQ-009 provider-cascade re-entry (confirmed they cannot, since
+    `HP_CASCADE_APPROVED` is unconditionally cleared at the top of `:provider_cascade` on every
+    re-entry) -- no further findings surfaced there.
+
 - **CLI-args/stdin-interactive support, P2 (honest ambiguous-exit messaging) -- final slice,
   `docs/plan-cli-interactive-verification.md`'s plan is now FULLY SHIPPED (P0, P1, P2 all
   complete).** Scope was narrowed from the plan's literal wording during implementation: the

--- a/docs/agent-interconnect.md
+++ b/docs/agent-interconnect.md
@@ -122,8 +122,35 @@ installed in the exact build interpreter Tier A just used, so the scanner's `fin
 treat it as fixable if the skip guard were missing or broken) -- then asserts the skip log line
 fires and the OLD `[REPAIR][HIDDEN_IMPORT] Adding --hidden-import=` rebuild line does NOT.
 
-**If a future Tier B (requirement 5, reprovisioned pinned-3.12 environment) or any other
-alternate-build-tool path is added, it needs this same guard.** The check belongs on
+**The warnfix-triggered rebuild (a SECOND PyInstaller rebuild call site, inside the
+`HP_WARNFIX_NEEDED` block) had the mirror-image gap, found via a later bug-hunt review pass: no
+failure handling at all, and no `HP_NUITKA_FALLBACK_USED` clearing on success.** Unlike the
+original build a few dozen lines earlier (which routes every failure through `:try_nuitka_tier_a`
+/ `:die` / `HP_BOOTSTRAP_STATE=error`), the warnfix rebuild's `"%HP_PY%" -m PyInstaller ...`
+call had no `if errorlevel 1` check at all -- the very next line unconditionally logged
+`[REPAIR] rebuild complete after warnfix.` regardless of whether it actually did, and nothing
+re-checked `dist\%ENVNAME%.exe`. A genuine rebuild failure here (e.g. the exact AV-lock class the
+whole PRD exists to route around) fell through to `:run_exe_smokerun`'s silent no-op-when-missing
+skip, then a clean interpreter-fallback run, ending in a false `state=ok`. Fixed with the same
+`if errorlevel 1 (...) else if not exist "dist\%ENVNAME%.exe" (...) else (...)` shape, nested
+if/else (no goto, matching the "safe inside a parenthesized block" pattern the original build's
+own comment documents) -- **deliberately NOT retried via `:try_nuitka_tier_a`** unlike the
+original build: this rebuild only exists to bundle an already-installed warnfix module into an
+EXE that was already confirmed working before this attempt, so the conservative, honest response
+to a failure is to report it via `HP_BOOTSTRAP_STATE=error`, not to speculatively invoke a second
+build tool inside an already-nested failure path. On a SUCCESSFUL rebuild, the fix also clears
+`HP_NUITKA_FALLBACK_USED` -- this rebuild always uses PyInstaller, so if the EXE it just replaced
+was previously Nuitka-built (a stale PyInstaller `build\%ENVNAME%\warn-%ENVNAME%.txt` can survive
+a Tier-A-rescued build and still trigger this warnfix block), the flag must reflect that the file
+at `dist\%ENVNAME%.exe` is now genuinely PyInstaller-built, or `:hidden_import_recover`'s own
+guard above would wrongly keep skipping repair on it. No dedicated CI test added for this specific
+fix (a review-pass correctness fix reusing an already-thoroughly-tested failure-handling shape,
+not a new feature) -- flagged in CLAUDE.md as a candidate for a future dedicated test pass if this
+path's real-world trigger rate ever justifies it.
+
+**If a future Tier B (requirement 5, reprovisioned pinned-3.12 environment, dropped from the
+backlog -- see CLAUDE.md's Known Findings) or any other alternate-build-tool path is added, it
+needs this same guard.** The check belongs on
 `HP_NUITKA_FALLBACK_USED` specifically (or an equivalent "the EXE currently at `dist\<env>.exe`
 was NOT built by PyInstaller" signal) -- any future subroutine that can produce `dist\<env>.exe`
 via something other than PyInstaller should set an analogous marker and this guard should be

--- a/run_setup.bat
+++ b/run_setup.bat
@@ -3308,7 +3308,34 @@ if not defined HP_BUILD_OK (
       if exist "~warnfix_repair_failed.flag" call :log "[WARN] One or more repair attempts failed"
       call :log "[INFO] Rebuilding standalone executable after warnfix -- this may take a minute or two..."
       "%HP_PY%" -m PyInstaller -y --onefile --clean --log-level WARN %HP_PYI_EXPAT% %HP_PYI_COLLECT% --name "%ENVNAME%" "%HP_ENTRY%" >> "%LOG%" 2>&1
-      call :log "[REPAIR] rebuild complete after warnfix."
+      rem derived requirement (bug-hunt pass): unlike the ORIGINAL build a few dozen lines
+      rem above (which routes every failure through :try_nuitka_tier_a / :die /
+      rem HP_BOOTSTRAP_STATE=error), this warnfix-triggered rebuild previously had NO failure
+      rem handling at all -- the log line below always said "rebuild complete" and nothing
+      rem re-checked dist\%ENVNAME%.exe, so a genuine rebuild failure (e.g. the exact AV-lock
+      rem class the whole AV-Safe Build Path PRD exists to route around) fell through to
+      rem :run_exe_smokerun's silent no-op-when-missing skip, then a clean interpreter-fallback
+      rem run, ending in a false ~bootstrap.status.json state=ok. Deliberately NOT retried via
+      rem :try_nuitka_tier_a here (unlike the original build) -- this rebuild only exists to
+      rem bundle a module warnfix already installed into an EXE that was already confirmed
+      rem working before this rebuild attempt; the conservative, honest response to a failure
+      rem is to report it, not to speculatively rebuild via a second tool inside an already
+      rem-nested failure path.
+      if errorlevel 1 (
+        call :log "[ERROR] PyInstaller execution failed during warnfix rebuild; the previous build may no longer be valid."
+        set "HP_BOOTSTRAP_STATE=error"
+      ) else if not exist "dist\%ENVNAME%.exe" (
+        call :log "[ERROR] PyInstaller did not produce dist\%ENVNAME%.exe during warnfix rebuild."
+        set "HP_BOOTSTRAP_STATE=error"
+      ) else (
+        call :log "[REPAIR] rebuild complete after warnfix."
+        rem The warnfix rebuild always uses PyInstaller -- if the EXE it just replaced was
+        rem previously Nuitka-built (Tier A), it no longer is; clear the flag so
+        rem :hidden_import_recover's Nuitka-skip guard doesn't wrongly skip repair on what is
+        rem now genuinely a PyInstaller-built EXE (see docs/agent-interconnect.md "Tier A and
+        rem hidden-import auto-recovery").
+        set "HP_NUITKA_FALLBACK_USED="
+      )
       rem REQ-005.11: warnfix-trigger PEP 723 write-back. Must run here, not later --
       rem ~missing_modules.txt and ~warnfix_repair_failed.flag are both still on disk at
       rem this point and are deleted shortly after (see below).

--- a/run_setup.bat
+++ b/run_setup.bat
@@ -3319,8 +3319,8 @@ if not defined HP_BUILD_OK (
       rem :try_nuitka_tier_a here (unlike the original build) -- this rebuild only exists to
       rem bundle a module warnfix already installed into an EXE that was already confirmed
       rem working before this rebuild attempt; the conservative, honest response to a failure
-      rem is to report it, not to speculatively rebuild via a second tool inside an already
-      rem-nested failure path.
+      rem is to report it, not to speculatively rebuild via a second tool inside an
+      rem already-nested failure path.
       if errorlevel 1 (
         call :log "[ERROR] PyInstaller execution failed during warnfix rebuild; the previous build may no longer be valid."
         set "HP_BOOTSTRAP_STATE=error"

--- a/tests/harness.ps1
+++ b/tests/harness.ps1
@@ -108,9 +108,9 @@ if (Get-Command Get-FileHash -ErrorAction SilentlyContinue) {
   Write-Host ("SHA256 (fallback): {0}" -f $sha)
 }
 Write-Result "file.hash" "SHA256 of run_setup.bat" $true @{ sha256 = $sha }
-$allowedStates = @('ok','no_python_files','venv_env','degraded_env','cache_corrupted')
+$allowedStates = @('ok','no_python_files','venv_env','degraded_env','embed_env','cache_corrupted')
 $stateOk = $allowedStates -contains $BootstrapStatus.state
-Write-Result "bootstrap.state" "Bootstrap status state is ok/no_python_files/venv_env/degraded_env" $stateOk @{ state=$BootstrapStatus.state; exitCode=$BootstrapStatus.exitCode; pyFiles=$BootstrapStatus.pyFiles; allowed=$allowedStates }
+Write-Result "bootstrap.state" "Bootstrap status state is ok/no_python_files/venv_env/degraded_env/embed_env" $stateOk @{ state=$BootstrapStatus.state; exitCode=$BootstrapStatus.exitCode; pyFiles=$BootstrapStatus.pyFiles; allowed=$allowedStates }
 Write-Result "bootstrap.exit" "Bootstrap exitCode is 0" ($BootstrapStatus.exitCode -eq 0) @{ exitCode=$BootstrapStatus.exitCode }
 $payloads = @{}
 foreach ($line in $Lines) {

--- a/tests/selfapps_contract_uv.ps1
+++ b/tests/selfapps_contract_uv.ps1
@@ -6,8 +6,10 @@ $ciNd = Join-Path $repo 'ci_test_results.ndjson'
 if (-not (Test-Path $nd)) { New-Item -ItemType File -Path $nd -Force | Out-Null }
 if (-not (Test-Path $ciNd)) { New-Item -ItemType File -Path $ciNd -Force | Out-Null }
 
+$script:AnyRowFailed = $false
 function Write-NdjsonRow {
     param([hashtable]$Row)
+    if ($Row.ContainsKey('pass') -and -not $Row['pass']) { $script:AnyRowFailed = $true }
     $json = $Row | ConvertTo-Json -Compress -Depth 8
     Add-Content -LiteralPath $nd   -Value $json -Encoding Ascii
     Add-Content -LiteralPath $ciNd -Value $json -Encoding Ascii
@@ -319,3 +321,6 @@ if ($lane -eq 'contract-uv-fail') {
         lane    = $lane
     })
 }
+
+if ($script:AnyRowFailed) { exit 1 }
+exit 0

--- a/tests/selfapps_entry.ps1
+++ b/tests/selfapps_entry.ps1
@@ -21,9 +21,11 @@ if (-not (Test-Path -LiteralPath $ciNd)) {
 }
 
 
+$script:AnyRowFailed = $false
 function Write-NdjsonRow {
     param([hashtable]$Row)
 
+    if ($Row.ContainsKey('pass') -and -not $Row['pass']) { $script:AnyRowFailed = $true }
     $json = $Row | ConvertTo-Json -Compress -Depth 8
     Add-Content -LiteralPath $nd -Value $json -Encoding Ascii
     Add-Content -LiteralPath $ciNd -Value $json -Encoding Ascii
@@ -359,3 +361,6 @@ Write-NdjsonRow ([ordered]@{
     desc    = 'Entry scenarios emitted breadcrumbs and passed'
     details = @{ issues = $issues }
 })
+
+if ($script:AnyRowFailed) { exit 1 }
+exit 0

--- a/tests/selfapps_envsmoke.ps1
+++ b/tests/selfapps_envsmoke.ps1
@@ -6,9 +6,11 @@ $ciNd = Join-Path $repo 'ci_test_results.ndjson'
 if (-not (Test-Path $nd)) { New-Item -ItemType File -Path $nd -Force | Out-Null }
 if (-not (Test-Path $ciNd)) { New-Item -ItemType File -Path $ciNd -Force | Out-Null }
 
+$script:AnyRowFailed = $false
 function Write-NdjsonRow {
     param([hashtable]$Row)
 
+    if ($Row.ContainsKey('pass') -and -not $Row['pass']) { $script:AnyRowFailed = $true }
     $json = $Row | ConvertTo-Json -Compress -Depth 8
     Add-Content -LiteralPath $nd -Value $json -Encoding Ascii
     Add-Content -LiteralPath $ciNd -Value $json -Encoding Ascii
@@ -787,3 +789,6 @@ Write-NdjsonRow ([ordered]@{
         interpreterPath=$spaceInterpreterPath
     }
 })
+
+if ($script:AnyRowFailed) { exit 1 }
+exit 0

--- a/tests/selfapps_pandas_excel.ps1
+++ b/tests/selfapps_pandas_excel.ps1
@@ -6,9 +6,11 @@ $ciNd = Join-Path $repo 'ci_test_results.ndjson'
 if (-not (Test-Path -LiteralPath $nd)) { New-Item -ItemType File -Path $nd -Force | Out-Null }
 if (-not (Test-Path -LiteralPath $ciNd)) { New-Item -ItemType File -Path $ciNd -Force | Out-Null }
 
+$script:AnyRowFailed = $false
 function Write-NdjsonRow {
     param([hashtable]$Row)
 
+    if ($Row.ContainsKey('pass') -and -not $Row['pass']) { $script:AnyRowFailed = $true }
     $lane = [Environment]::GetEnvironmentVariable('HP_CI_LANE')
     if ($lane -and -not $Row.ContainsKey('lane')) { $Row['lane'] = $lane }
     $json = $Row | ConvertTo-Json -Compress -Depth 8
@@ -154,6 +156,7 @@ if (-not $condaBat) {
         Write-NdjsonRow ([ordered]@{ id = 'self.pandas.openpyxl.install'; req = 'REQ-005'; pass = $false; desc = 'pandas and openpyxl both present in conda env after install'; details = ([ordered]@{ skip = $false; reason = 'conda-not-found'; condaBatCandidates = $condaInfo.candidates; publicRoot = $condaInfo.publicRoot }) })
         Write-NdjsonRow ([ordered]@{ id = 'self.pandas.openpyxl.import';  req = 'REQ-005'; pass = $false; desc = 'import pandas; import openpyxl succeeds in conda env'; details = ([ordered]@{ skip = $false; reason = 'conda-not-found'; condaBatCandidates = $condaInfo.candidates; publicRoot = $condaInfo.publicRoot }) })
     }
+    if ($script:AnyRowFailed) { exit 1 }
     exit 0
 }
 
@@ -266,3 +269,6 @@ $importPass   = ($importDetails.exitCode -eq 0)
 
 Write-NdjsonRow ([ordered]@{ id = 'self.pandas.openpyxl.install'; req = 'REQ-005'; pass = $envListPass; desc = 'pandas and openpyxl both present in conda env after install'; details = $envListDetails })
 Write-NdjsonRow ([ordered]@{ id = 'self.pandas.openpyxl.import';  req = 'REQ-005'; pass = $importPass;  desc = 'import pandas; import openpyxl succeeds in conda env'; details = $importDetails })
+
+if ($script:AnyRowFailed) { exit 1 }
+exit 0

--- a/tests/selfapps_pipgap.ps1
+++ b/tests/selfapps_pipgap.ps1
@@ -19,8 +19,10 @@ $ciNd = Join-Path -Path $repoRoot -ChildPath 'ci_test_results.ndjson'
 if (-not (Test-Path -LiteralPath $nd))   { New-Item -ItemType File -Path $nd   -Force | Out-Null }
 if (-not (Test-Path -LiteralPath $ciNd)) { New-Item -ItemType File -Path $ciNd -Force | Out-Null }
 
+$script:AnyRowFailed = $false
 function Write-NdjsonRow {
     param([hashtable]$Row)
+    if ($Row.ContainsKey('pass') -and -not $Row['pass']) { $script:AnyRowFailed = $true }
     $lane = [Environment]::GetEnvironmentVariable('HP_CI_LANE')
     if ($lane -and -not $Row.ContainsKey('lane')) { $Row['lane'] = $lane }
     $json = $Row | ConvertTo-Json -Compress -Depth 8
@@ -121,3 +123,6 @@ Write-NdjsonRow ([ordered]@{
 if (-not $condaMissPass) { Write-Host '[pipgap] conda did not miss opencv-python as expected' }
 if (-not $pipFillPass)   { Write-Host '[pipgap] pip gap-fill did not install opencv-python' }
 if (-not $importPass)    { Write-Host '[pipgap] import cv2 sentinel not found in entry smoke output' }
+
+if ($script:AnyRowFailed) { exit 1 }
+exit 0

--- a/tests/selfapps_reqspec.ps1
+++ b/tests/selfapps_reqspec.ps1
@@ -6,9 +6,11 @@ $ciNd = Join-Path $repo 'ci_test_results.ndjson'
 if (-not (Test-Path -LiteralPath $nd)) { New-Item -ItemType File -Path $nd -Force | Out-Null }
 if (-not (Test-Path -LiteralPath $ciNd)) { New-Item -ItemType File -Path $ciNd -Force | Out-Null }
 
+$script:AnyRowFailed = $false
 function Write-NdjsonRow {
     param([hashtable]$Row)
 
+    if ($Row.ContainsKey('pass') -and -not $Row['pass']) { $script:AnyRowFailed = $true }
     $lane = [Environment]::GetEnvironmentVariable('HP_CI_LANE')
     if ($lane -and -not $Row.ContainsKey('lane')) { $Row['lane'] = $lane }
     $json = $Row | ConvertTo-Json -Compress -Depth 8
@@ -349,6 +351,7 @@ if (-not $condaBat) {
         Write-ReqspecRows -Pass $true -Skip $true -Reason 'conda-not-installed-uv-first' -TranslationChecks $translationChecks -DryRunDetails $dryRunDetails -InstallDetails $installDetails -FailcaseDetails ([ordered]@{ exitCode = -1; expectedFailure = $true; constraint = 'six<1.0'; reason = 'conda-not-found'; condaBatCandidates = $condaInfo.candidates; publicRoot = $condaInfo.publicRoot }) -ChannelPinDetails ([ordered]@{ channel = 'conda-forge'; exitCode = -1; defaultsFound = $false; pkgsMainFound = $false; outputMatched = $false; solverOutputSnippet = ''; reason = 'conda-not-found'; condaBatCandidates = $condaInfo.candidates; publicRoot = $condaInfo.publicRoot })
         Write-ReqspecIngestRows -Skip $true -Reason 'conda-not-installed-uv-first' -TranslateDetails ([ordered]@{ source = 'requirements.txt'; translated = $false; reason = 'conda-not-found'; condaBatCandidates = $condaInfo.candidates; publicRoot = $condaInfo.publicRoot }) -DryRunDetails ([ordered]@{ exitCode = -1; source = 'requirements.txt'; reason = 'conda-not-found'; condaBatCandidates = $condaInfo.candidates; publicRoot = $condaInfo.publicRoot }) -ImportDetails ([ordered]@{ package = 'six'; importable = $false; exitCode = -1; reason = 'conda-not-found'; condaBatCandidates = $condaInfo.candidates; publicRoot = $condaInfo.publicRoot })
     }
+    if ($script:AnyRowFailed) { exit 1 }
     exit 0
 }
 
@@ -668,3 +671,6 @@ try {
 
 Write-ReqspecRows -Pass $overallPass -TranslationChecks $translationChecks -DryRunDetails $dryRunDetails -InstallDetails $installDetails -FailcaseDetails $failcaseDetails -ChannelPinDetails $channelPinDetails
 Write-ReqspecIngestRows -TranslateDetails $ingestTranslateDetails -DryRunDetails $ingestDryRunDetails -ImportDetails $ingestImportDetails
+
+if ($script:AnyRowFailed) { exit 1 }
+exit 0

--- a/tests/selfapps_runtime_writeback.ps1
+++ b/tests/selfapps_runtime_writeback.ps1
@@ -12,8 +12,10 @@ $ciNd = Join-Path $repoRoot 'ci_test_results.ndjson'
 if (-not (Test-Path -LiteralPath $nd))   { New-Item -ItemType File -Path $nd   -Force | Out-Null }
 if (-not (Test-Path -LiteralPath $ciNd)) { New-Item -ItemType File -Path $ciNd -Force | Out-Null }
 
+$script:AnyRowFailed = $false
 function Write-NdjsonRow {
     param([hashtable]$Row)
+    if ($Row.ContainsKey('pass') -and -not $Row['pass']) { $script:AnyRowFailed = $true }
     $lane = [Environment]::GetEnvironmentVariable('HP_CI_LANE')
     if ($lane -and -not $Row.ContainsKey('lane')) { $Row['lane'] = $lane }
     $json = $Row | ConvertTo-Json -Compress -Depth 8
@@ -123,3 +125,6 @@ Write-NdjsonRow ([ordered]@{
         secondRunNoWriteback = $secondRunNoWriteback
     }
 })
+
+if ($script:AnyRowFailed) { exit 1 }
+exit 0

--- a/tests/selfapps_single.ps1
+++ b/tests/selfapps_single.ps1
@@ -51,9 +51,11 @@ if ($null -ne $pyFileCount -and $pyFileCount -ne 1) {
     exit 0
 }
 
+$script:AnyRowFailed = $false
 function Write-NdjsonRow {
     param([hashtable]$Row)
 
+    if ($Row.ContainsKey('pass') -and -not $Row['pass']) { $script:AnyRowFailed = $true }
     $json = $Row | ConvertTo-Json -Compress
     Add-Content -LiteralPath $nd -Value $json -Encoding Ascii
     Add-Content -LiteralPath $ciNd -Value $json -Encoding Ascii
@@ -248,4 +250,5 @@ finally {
     }
 }
 
+if ($script:AnyRowFailed) { exit 1 }
 exit 0


### PR DESCRIPTION
## Summary

Slice 1 of a larger batch of independently-verified findings from a deep research/bug-hunt pass (3 parallel background agents covering branch-coverage gaps, Python-helper edge cases, and CLI-feature interaction gotchas). Split into separate small PRs for fault isolation, per standing instructions.

- **8 `selfapps_*.ps1` files silently `exit 0` regardless of computed `$pass`.** `selfapps_contract_uv.ps1`, `selfapps_entry.ps1`, `selfapps_envsmoke.ps1`, `selfapps_pandas_excel.ps1`, `selfapps_pipgap.ps1`, `selfapps_reqspec.ps1`, `selfapps_runtime_writeback.ps1`, and `selfapps_single.ps1` (found via a targeted follow-up grep for "zero `exit 1` occurrences despite `pass=$false` literals present") were all missing the `if (-not $pass) { exit 1 }; exit 0` propagation pattern every sibling test file already has. Four of these run unconditionally in the gating `real`/`conda-full` lanes with no `continue-on-error` — meaning a real regression could compute `pass=$false`, write it correctly into the NDJSON row, and the step/job/PR check would still report green. `selfapps_pandas_excel.ps1` and `selfapps_reqspec.ps1` each had a more severe mid-file variant (a conda-not-found branch that writes several real `pass=$false` rows and then unconditionally `exit 0`s). `selfapps_single.ps1`'s instance was found separately, since its own gating condition (`pyFiles==1`) means this repo's own multi-file CI has likely never exercised the buggy branch — still fixed for correctness/template-repo consumers.
- **Fixed via the established central-choke-point pattern**: each file's row-writer function now sets a script-scoped `$script:AnyRowFailed` flag whenever a row's `pass` is `$false`, and every exit site (final, plus the mid-file unsafe ones) checks it.
- **Bonus, same theme**: the warnfix-triggered PyInstaller rebuild (inside the `HP_WARNFIX_NEEDED` block) had zero failure handling, unlike the original build call a few dozen lines earlier — mirrors the original build's `if errorlevel 1 (...) else if not exist ... (...) else (...)` shape and `HP_BOOTSTRAP_STATE=error` handling.

Full detail (per-file trace, severity notes) is in `CLAUDE.md`'s Closed Backlog under "Multi-agent parallel bug-hunt pass... 2026-07-24."

## Test plan

- [x] `python -m compileall -q .`
- [x] `python -m pyflakes .`
- [x] `python tools/check_delimiters.py run_setup.bat`
- [x] `python -m yamllint .github/workflows/`
- [x] `actionlint -oneline .github/workflows/*.yml`
- [x] ASCII sweep on touched files
- [x] PowerShell AST parse sweep (`tests/*.ps1`, `tools/*.ps1`)
- [x] `python -m pytest tests/test_*.py -q` — 386 passed, 2 skipped
- [ ] Windows CI lanes (real/conda-full gate this PR; behavior can't be exercised locally since `run_setup.bat` is Windows-only)

Co-Authored-By: Claude

---
_Generated by [Claude Code](https://claude.ai/code/session_015xbWLPbiaKVsobB9FZy8kS)_