### PR TITLE
fix: cascade-vs-postexec offers, timed consent prompt, dependency-incomplete note; dedupe test boilerplate

### DIFF
--- a/.github/workflows/batch-check.yml
+++ b/.github/workflows/batch-check.yml
@@ -723,6 +723,12 @@ jobs:
         run: |
           & tests\selfapps_entry_picker.ps1
 
+      - name: "Self-test: REQ-009 cascade consent timed prompt (conda-full only)"
+        if: ${{ matrix.mode == 'conda-full' }}
+        shell: pwsh
+        run: |
+          & tests\selfapps_cascade_timed.ps1
+
       - name: "Test pandas/openpyxl heuristic (conda-full only)"
         if: ${{ matrix.mode == 'conda-full' }}
         shell: pwsh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -469,27 +469,6 @@ a fact confirmed with no action needed, or a recurring/periodic check belongs in
 "Known Findings", `docs/agent-lessons-learned.md`, or "Periodic Maintenance Checks" below instead
 (see those sections' own scope notes).
 
-1. **conda-full lane duration (~80 min on both the original and retriggered attempt of run
-   29002681009)** is the dominant single contributor to overall CI wall-clock growth (20 min ->
-   1.5 h), separate from the (now-fixed, see Closed Backlog) diagnostics-bloat item. Likely
-   accumulated feature/test-scenario growth (more selftest scripts each doing a real
-   `conda create`), not a regression from any single change. Worth periodic reassessment, no
-   action planned yet. **Fresh data point, 2026-07-25 `/goal`-directed review**: pulled
-   created/updated timestamps for the 18 most recent successful full-workflow runs on this
-   branch via the GitHub API (`workflow_runs` list) -- overall wall-clock (all 8 matrix lanes
-   run in parallel, so this reflects whichever lane is slowest, not conda-full's own duration in
-   isolation) ranged 85-110 minutes, averaging ~92 minutes, consistent with the original ~80 min
-   observation and not showing runaway growth since. Confirms the item's own "worth periodic
-   reassessment, no action planned" framing is still the right call -- still no single-lane
-   breakdown gathered (would need per-job, not per-run, timestamps to isolate conda-full
-   specifically), and still not pursued as a separate investigation given no action is planned
-   either way.
-3. **~85 lines of near-duplicated env-var save/set/restore boilerplate between
-   `self.embed.fallback.decline` and `self.embed.fallback.real`** in
-   `tests/selfapps_ux_hardening.ps1`. Factorable into a shared helper, but each block forces a
-   genuinely different set of env vars (decline: 6 vars; real: 5 different vars), so the helper
-   would need real parameterization -- a small design decision, not a mechanical copy-paste
-   cleanup. Cosmetic; defer unless already touching these test blocks for another reason.
 4. **PYSPEC-aware venv-vs-embed decision function (promising, deliberately not implemented yet --
    don't add the complexity until there's a concrete reason to).** `:try_venv_fallback` currently
    uses whatever ambient Python is on the machine unconditionally, with no check of whether it
@@ -509,6 +488,13 @@ a fact confirmed with no action needed, or a recurring/periodic check belongs in
    creation), and the current fixed order is not wrong, just not optimal in either direction.
    Revisit if the network-correlated-embed-failure pattern shows up for real in CI or user
    reports, rather than speculatively building it now.
+   **Re-examined 2026-07-25 per an owner request to raise confidence-to-implement wherever
+   possible**: this is not actually a confidence question -- the design sketch above is sound and
+   could be implemented with reasonable confidence in its own correctness. What's missing is
+   evidence that it's WORTH the added complexity: the item's own "revisit if" trigger (a real,
+   observed network-correlated-embed-failure pattern) has not occurred, in CI or in any user
+   report, since this was written. Raising implementation confidence doesn't manufacture that
+   evidence -- still correctly deferred, for the reason already on record, not a new one.
 7. **CI job steps in `batch-check.yml` don't use `if: always()`, so one failing self-test step
    silently cascade-skips every subsequent step in the same job -- observed directly, not
    theorized.** While landing item 6's requirement-1 tests (PR #368), a bug in the new
@@ -566,6 +552,39 @@ a fact confirmed with no action needed, or a recurring/periodic check belongs in
    bootstrapper run itself -- a single transient cache-restore failure would silently skip the
    entire cache-lane self-test battery, not just a handful of sibling scenario steps. Fixed the
    same way (added `continue-on-error: true` to both steps); `cache` remains non-gating either way.
+
+   **Re-examined 2026-07-25 per an owner request to raise confidence-to-implement wherever
+   possible, gating-lane half only.** Found real, previously-uninvestigated information in both
+   directions -- net effect: still not implemented, but for a more precise reason than before.
+   - **Lower risk than originally feared, confirmed by actually reading the step definitions
+     rather than assuming**: `steps.X.outputs` cross-references and `GITHUB_ENV` state-passing
+     inside the `selftest` job are minimal and almost entirely early/self-contained (lane-config
+     flags set before the main bootstrap step, plus the already-`always()`-guarded `cache`-lane
+     corruption chain) -- confirming the established "every selfapps_*.ps1 test creates its own
+     `~selftest_X` scratch directory, independent of sibling steps" convention genuinely holds at
+     the CI-step level too, not just within a single test file. This means the originally-feared
+     failure mode (step N's crash corrupting step N+1's inputs, producing confusing, misattributed
+     secondary failures) is less likely than assumed -- most conda-dependent tests already have
+     their own defensive "conda not found" handling (see "Test files that assume conda is present"
+     above), which would produce an accurate, if repetitive, `pass=false` rather than a nonsensical
+     crash.
+   - **A genuinely NEW risk surfaced that the original reasoning never considered**: `if:
+     always()` does not just control whether a step RUNS, it can change HOW LONG a job takes to
+     FAIL. If the root cause is the top-level "Bootstrap environment" step itself (e.g. Miniconda
+     failing to install), a blanket `if: always()` would mean dozens of downstream steps EACH
+     attempt their own real sub-bootstrap (each potentially retrying its own slow Miniconda/
+     conda-forge network operations) before finally completing, rather than failing fast as today.
+     This directly compounds with item 1's own concern (below, now under Periodic Maintenance
+     Checks) about CI wall-clock growth -- turning a fast single-step failure into a much longer
+     one specifically in the failure case, which is exactly when a contributor is waiting on the
+     signal most.
+   - **Net assessment: medium, not high, confidence** -- the coupling risk is lower than
+     originally assumed, but the newly-found duration-inflation risk is real and unquantified
+     (verifying it would need deliberately breaking a real CI run and observing actual timing
+     across ~40 downstream steps, not something to do casually). Still correctly deferred; the
+     two original reasons for deferral (a wide, ~50-step blast radius; no observed instance of
+     this class of gap hiding a real regression yet) both still hold, now with a clearer picture
+     of what a future dedicated pass would actually need to verify before shipping.
 *(Item 5 from the pre-existing "cosmetic log noise/path doubling" debrief note was checked
 briefly per standing instruction not to over-invest: no `--distpath`/`--workpath` override or
 other structural path-doubling exists in the PyInstaller build invocation. Most likely source is
@@ -573,13 +592,6 @@ the "Build public diagnostics tree" step's own `DIAG CWD`/`DIAG ROOT`/`DIAG TREE
 lines, which naturally show GitHub Actions' inherent doubled checkout path
 (`.../Python_vs_Windows/Python_vs_Windows/...`) -- a runner convention, not a bug. Not chased
 further.)*
-9. **Cascade consent (REQ-009/REQ-005.10) is granted BEFORE the current build's own postexec
-   offers fire, so a user can be asked to rerun/optimize a build the bootstrapper already knows
-   is about to be discarded.** This is a genuine open UX/design question, not a one-line fix --
-   posed in full, with the plain-language context, two options, tradeoffs, and a recommendation,
-   in `docs/open-questions.md` item 1. No code change made pending that answer. See
-   `docs/agent-interconnect.md`'s "Post-execution checkpoint" and "AV-Safe Build Path
-   requirement 9" sections for the exact call chain if picking this up.
 ## Periodic Maintenance Checks (recurring, quarterly)
 
 This section is for checks that need to be **repeated on a schedule** because they track
@@ -641,6 +653,37 @@ rather than relying on manual memory.
   `uv-dl-fallback` non-gating indefinitely (their non-gating status is explicitly load-bearing,
   not provisional). `ndjson-registry-check` needs several more real-CI runs at clean PASS before
   even considering gating -- one green run is not a trend.
+
+### CI wall-clock duration (conda-full lane growth)
+
+This tracks a genuine periodic-reassessment concern, not a one-time backlog item -- moved here
+2026-07-25 from Active Backlog (it was originally filed as a backlog item, but "worth periodic
+reassessment, no action planned" is exactly what this section exists for, and letting it grow
+stale as a single never-closed backlog entry was the wrong home for it).
+
+**What this tracks and why it matters**: `conda-full` (the lane that forces every dependency
+install through real conda, no fallbacks -- the slowest of the 8 matrix lanes, since conda's own
+dependency solver is materially slower than pip/uv) is the dominant single contributor to overall
+CI wall-clock time, which grew from ~20 min to ~1.5h historically. Since all 8 matrix lanes run in
+parallel, the WHOLE workflow's wall-clock is bounded by whichever lane is slowest -- almost always
+`conda-full` -- so this lane's own growth directly sets how long every contributor waits for a PR
+to go green. This matters for development velocity (a slower feedback loop costs real time on
+every single PR), not correctness -- nothing about the lane itself is broken.
+
+- **Last scanned**: 2026-07-25. Pulled created/updated timestamps for the 18 most recent
+  successful full-workflow runs on this branch via the GitHub API (`workflow_runs` list) --
+  overall wall-clock ranged 85-110 minutes, averaging ~92 minutes, consistent with the original
+  ~80 min observation and not showing runaway growth since. No single-lane breakdown gathered yet
+  (would need per-job, not per-run, timestamps to isolate `conda-full` specifically from the
+  other 7 lanes running alongside it).
+- **Findings**: likely accumulated feature/test-scenario growth over time (more selftest scripts
+  each doing a real `conda create`/`conda install`), not a regression traceable to any single
+  change -- no evidence of a single fixable root cause has surfaced across multiple scans.
+- **Going forward**: re-check the same 18-run wall-clock sample each scan; flag if the average
+  climbs meaningfully above ~92 minutes (would suggest either unchecked growth or an actual
+  regression, not just noise) rather than plateauing. If a real investigation is ever warranted,
+  it needs per-job (not per-run) timestamps to isolate `conda-full`'s own duration from the other
+  7 lanes -- not yet gathered, since no action has been planned either way.
 
 ### pipreqs ecosystem status
 
@@ -904,6 +947,72 @@ of a second or third pin actually needing it.
   bundles an ~40 MB SQLite package database, a non-starter for a single-file bootstrapper).
 
 ## Closed Backlog
+
+- **Cascade-vs-postexec fix (Active Backlog item 9), 2026-07-25, owner-directed follow-up to a
+  question posed for maintainer decision the same day.** The owner reviewed
+  `docs/open-questions.md` item 1 and directly instructed: implement the "skip both postexec
+  offers once cascade is approved" piece (their own framing: "once they ask for cascade, then
+  immediately cascade and don't do anything else"), and separately, make the cascade consent gate
+  timed like sibling prompts plus add a persistent "dependencies may be incomplete" note for the
+  decline path.
+  - **The literal "don't do anything else" framing was investigated and found unsafe as a literal
+    instruction -- caught before shipping, not after.** A first draft skipped `:run_exe_smokerun`
+    itself (not just the two elective postexec offers) whenever `HP_CASCADE_APPROVED` was set.
+    Tracing the actual control flow found a real regression: `HP_CASCADE_APPROVED` only means the
+    NEXT provider tier will be TRIED -- `:provider_cascade` (reached later, from the top-level main
+    line, only after the whole build+warnfix subroutine returns) can still find every remaining
+    tier unavailable/declined (e.g. the terminal system tier's own REQ-014 consent being declined)
+    and fall back to one of its six "keeping current build" exhaustion messages. Skipping the
+    smoke run unconditionally would have left that KEPT build completely unverified in the
+    exhaustion case -- a real regression from the pre-fix behavior, which always verified at least
+    once even when the verified build later turned out to be replaced. Fixed by keeping the smoke
+    run unconditional and only wrapping the two ELECTIVE follow-ups (`:run_postexec_checkpoint`,
+    `:offer_optimized_build`, both called from `:smokerun_ndjson`) in the `HP_CASCADE_APPROVED`
+    check. See `docs/agent-interconnect.md`'s new "Cascade-vs-postexec fix" subsection (under
+    "Post-execution checkpoint") for the full trace.
+  - **`:cascade_consent_gate` now uses a TIMED `choice /T` prompt** (default 30s,
+    `HP_TEST_FORCE_INTERACTIVE_CASCADE=1` forces the branch under CI and shrinks it to 2s) instead
+    of an unbounded `set /p`, mirroring `:pick_entry_interactive`'s own established pattern -- an
+    unattended interactive user no longer hangs the whole bootstrap forever; on timeout it
+    defaults to decline (N), so the current build is still tried once, unprompted. Rewritten with
+    goto-based dispatch (not nested parens) per "Provider-cascade dispatch is goto-based on
+    purpose" in `docs/agent-lessons-learned.md` -- `choice` followed by an `%ERRORLEVEL%`-reading
+    `set` is exactly the bug class that lesson warns about inside a shared parenthesized block;
+    `if errorlevel N` is used instead to sidestep it entirely.
+  - **New `HP_DEP_MAYBE_INCOMPLETE` note**: set in `:warnfix_cascade_detect` when a cascade
+    candidate was detected but not approved (declined, timed out, or CI auto-declined); reset at
+    the top of every fresh build attempt so a provider needing no warnfix repair doesn't inherit a
+    stale flag from an earlier, cascaded-away provider. Surfaced at two points -- an immediate
+    `[WARN]` at decision time and a second reminder right before the EXE launches
+    (`:warn_user_code_launch`) -- deliberately a note, never a second gate, since the user may know
+    something the automated install missed and want to push through anyway.
+  - **The "extra credit" idea (tell the user their odds of a specific next tier helping) was
+    investigated with a real mechanism-level analysis, not implemented in this pass.** See
+    `docs/open-questions.md`'s remaining open item for the full reasoning: cascading uv->conda has
+    real, mechanism-justified value (a genuinely different package index), but conda->embed and
+    beyond are all pip/PyPI-based and add comparatively little once uv and conda have both already
+    struggled -- a well-supported qualitative claim, but left out of this pass at the owner's own
+    flagged hesitation about complexity/risk, pending their read of the full analysis.
+  - Test coverage: `tests/selfapps_cascade.ps1`'s existing `self.cascade.exec` (uv lane) gained an
+    assertion that all 4 approved-cascade builds correctly skip their postexec offers (exactly 4
+    occurrences, one per real cascade hop). New `tests/selfapps_cascade_timed.ps1` (conda-full
+    lane, `self.cascade.timed`) proves the timed-choice mechanism and both dirty-flag injection
+    points positively, and that the offers-skip message correctly does NOT fire on decline.
+
+- **Env-var save/set/restore boilerplate dedup (Active Backlog item 3), 2026-07-25, owner-approved
+  after confidence was raised to high.** New `Invoke-WithEnvOverrides` helper in
+  `tests/selfapps_ux_hardening.ps1` (test-only, zero `run_setup.bat` risk) replaces the ~85 lines
+  of near-identical save/set/restore code duplicated between `self.embed.fallback.decline` (6 env
+  vars) and `self.embed.fallback.real` (5 different env vars) with a single hashtable-driven
+  helper: `[Environment]::SetEnvironmentVariable($name, $null)` uniformly both unsets a
+  previously-unset var and restores a previously-set one on the way out, removing the need for the
+  original code's special-cased `if ($null -eq $saved) { Remove-Item } else { set }` branches
+  entirely. Confirmed correct via direct local `pwsh` verification before touching the real file:
+  proper unset-on-restore for a var that wasn't set before, proper restore-to-original-value for a
+  var that was, and correct closure-scoping (the body scriptblock can read caller-scope variables
+  like `$embedDeclineDir`, and its return value -- `$LASTEXITCODE` from inside a `try/finally` --
+  propagates back through `& $Body` to the caller's own assignment) -- this is what raised
+  confidence from "reasonable design" to "verified correct" before landing it.
 
 - **`HP_PREP_REQUIREMENTS` canonical-source promotion (Active Backlog item 8), 2026-07-25,
   `/goal`-directed close-out pass.** New `tools/prep_requirements.py`, a byte-for-byte decode of

--- a/docs/agent-interconnect.md
+++ b/docs/agent-interconnect.md
@@ -1702,3 +1702,69 @@ asserting the prompt is shown in both cases and the run footprint is exactly two
 `Entry smoke exit=0` occurrences. `tests/harness.ps1`'s `batch.postexec.checkpoint` statically
 guards the subroutine, the test override, the unconditional prompt echo, both log lines, and that
 all three call sites are still wired (`call :run_postexec_checkpoint` count `-ge 3`).
+
+**Cascade-vs-postexec fix (CLAUDE.md item 9 / docs/open-questions.md item 1) -- the checkpoint and
+requirement 9's optimized-build offer are now both skipped, but ONLY at the `exe` call site, and
+ONLY when the CURRENT provider's own cascade was just approved.** The original open question
+(closed by this fix) was: cascade consent is asked BEFORE the EXE smoke run, so a user who already
+said "yes, try the next provider" would still be shown two more elective prompts (`:run_postexec_
+checkpoint`, `:offer_optimized_build`) about the build they just opted away from, wasting real time
+(the optimized-build offer alone can take a minute or more compiling something about to be
+discarded once the cascade rebuilds under the next tier).
+
+**The smoke run ITSELF is deliberately NOT skipped, even when cascade is approved -- this was the
+first, wrong design attempted, caught before shipping.** `HP_CASCADE_APPROVED` (set inside
+`:warnfix_cascade_detect`, well before `:run_exe_smokerun` is even called) only means the NEXT
+provider tier will be TRIED -- it does not guarantee the cascade actually reaches a new tier.
+`:provider_cascade` (reached later, from the top-level main line, only after `:run_entry_smoke`
+fully returns -- see "Provider cascade execution re-enters env-create" above) can still find every
+remaining tier unavailable or declined (e.g. the terminal system tier's own REQ-014 consent gate
+being declined) and fall back to one of its six "keeping current build" exhaustion messages
+(`run_setup.bat` lines ~1853/1868/1881/1884/1896/1910) -- at which point the CURRENT build (the
+one whose smoke run would have been skipped) is what actually ships. Skipping the smoke run
+entirely would leave that kept-on-exhaustion build completely unverified, a real regression from
+the pre-fix behavior (which always verified at least once, just sometimes for a build that turned
+out to be discarded moments later). Fix: `:run_exe_smokerun` always runs; only the two ELECTIVE
+follow-up calls inside `:smokerun_ndjson` (`:run_postexec_checkpoint exe`, `:offer_optimized_
+build`) are wrapped in `if defined HP_CASCADE_APPROVED (...) else (...)`, so the mandatory
+diagnostic step never disappears but the two optional prompts do, exactly when they'd otherwise be
+asked about a build the user has already opted away from.
+
+**The "declined/timed-out" side got two companion pieces, both requested directly:**
+1. **`:cascade_consent_gate`'s real-interactive-user branch now uses a TIMED `choice /T` prompt
+   (default 30s) instead of an unbounded `set /p`**, mirroring `:pick_entry_interactive`'s own
+   established `choice /T %HP_PICK_T% /D %HP_PICK_DEFAULT%` pattern (the entry picker is the only
+   OTHER consent-style prompt in this file that was already timed -- every sibling gate
+   (`:run_postexec_checkpoint`, `:offer_optimized_build`, `:system_build_consent_gate`,
+   `:conda_binary_corrupt`'s heal prompt, `:check_net_after_dl_fail`, `:system_python_consent_gate`)
+   still uses a bare, unbounded `set /p` and shares this same "hangs forever if nobody's at the
+   keyboard" characteristic -- fixing all of them was judged out of scope for this pass; flagged
+   here so a future pass doesn't have to rediscover the pattern). On timeout with no answer, `/D N`
+   resolves to decline -- an unattended interactive run still tries the current build once,
+   unprompted, rather than hanging the whole bootstrap indefinitely. `HP_TEST_FORCE_INTERACTIVE_
+   CASCADE=1` forces this branch to be reached even under `HP_CI_LANE` (mirrors `HP_TEST_FORCE_
+   PICKER`) and shrinks the timeout to 2s for CI. Rewritten with goto-based dispatch throughout
+   (not nested parens) per "Provider-cascade dispatch is goto-based on purpose" in
+   `docs/agent-lessons-learned.md` -- a `choice` call followed by an `%ERRORLEVEL%`-reading `set`
+   is exactly the bug class that lesson documents when nested inside a shared parenthesized block;
+   `if errorlevel N` (the special comparison form, not `%ERRORLEVEL%` text substitution) is used
+   instead specifically to sidestep it, matching `:pick_entry_interactive`'s own established idiom.
+2. **A new "dependencies may be incomplete" note** (`HP_DEP_MAYBE_INCOMPLETE`), set in
+   `:warnfix_cascade_detect` whenever a cascade candidate was detected but NOT approved (declined,
+   timed out, or auto-declined in CI) -- reset to unset at the top of every FRESH build attempt
+   (alongside `HP_NUITKA_FALLBACK_USED`'s own reset) so a provider that needs no warnfix repair at
+   all doesn't inherit a stale flag from an earlier, cascaded-away provider's failure. Consumed at
+   two points: an immediate `[WARN]` right where the decision was made, and a second reminder line
+   in `:warn_user_code_launch` (right before the EXE actually launches) so the context survives to
+   the moment it's most useful -- a confusing runtime failure right after is not mistaken for a bug
+   in the user's own code. Deliberately a NOTE, never a second gate: the user may know something the
+   automated install missed and want to push through anyway. The "extra credit" idea discussed
+   alongside this (telling the user their odds of a DIFFERENT specific next tier helping) was
+   investigated but not implemented -- see docs/open-questions.md's remaining open item for the
+   supporting analysis and why it was left out of this pass specifically.
+
+Test coverage: `tests/selfapps_cascade.ps1`'s existing `self.cascade.exec` (uv lane, non-gating)
+gained an assertion that all 4 approved-cascade builds (uv, conda, embed, venv) correctly skip
+their postexec offers (`offersSkipped` count, expected exactly 4). New `tests/selfapps_cascade_
+timed.ps1` (conda-full lane) proves the timed-choice mechanism and the dirty-flag note positively;
+see `docs/agent-ndjson.md`'s own section on it for the full assertion list.

--- a/docs/agent-ndjson.md
+++ b/docs/agent-ndjson.md
@@ -45,7 +45,7 @@ self.exe.warnfix.real_warnfix_delayed,
 self.collect.submodules,
 self.exe.hidden_import, self.exe.hidden_import.exhaust,
 self.preflight.syntax,
-self.cascade.detect, self.cascade.consent,
+self.cascade.detect, self.cascade.consent, self.cascade.timed,
 self.cascade.exec (uv lane only -- selfapps_cascade.ps1; non-gating),
 self.conda.bothfail (uv lane only -- selfapps_conda_bothfail.ps1; non-gating),
 self.exe.build.tiera (uv lane only -- selfapps_nuitka_tiera.ps1; non-gating),
@@ -301,6 +301,32 @@ full-tree-artifact-capture pattern as `selfapps_autopep_discovery.ps1` -- no ind
 
 ```
 self.pvw_idempotent.discovery
+```
+
+## selfapps-cascade-timed NDJSON rows (selfapps_cascade_timed.ps1, conda-full lane only)
+
+CLAUDE.md item 9 / docs/open-questions.md item 1 follow-up: `:cascade_consent_gate` previously used
+an unbounded `set /p` for a real interactive user, unlike sibling prompts such as
+`:pick_entry_interactive`'s own `choice /T` timed prompt -- an unattended real user (not physically
+present when the prompt appeared) would hang the whole bootstrap forever. Now uses the same
+`choice /T` pattern (default 30s, mirrors `:pick_entry_interactive`'s HP_PICK_T convention),
+defaulting to N (decline) on timeout so an unattended run still tries the current build once rather
+than hanging. `HP_TEST_FORCE_INTERACTIVE_CASCADE=1` forces the timed-choice branch to be reached
+even under `HP_CI_LANE` (mirrors `HP_TEST_FORCE_PICKER`'s own established pattern for
+`:pick_entry_interactive`, see `tests/selfapps_entry_picker.ps1`) and shrinks the timeout to 2s.
+With no interactive console and no `HP_TEST_CASCADE_ANSWER` override, `choice` degrades to its
+default (N) within ~2s, proving the mechanism reaches the prompt and resolves without hanging.
+
+Also proves the companion "dependencies may be incomplete" note (`HP_DEP_MAYBE_INCOMPLETE`, set
+only when a cascade candidate was detected but NOT approved) fires at both its injection points
+(the decline-time WARN in `:warnfix_cascade_detect` and the pre-launch reminder in
+`:warn_user_code_launch`), and that the postexec-offers-skip message (proven positively by
+`self.cascade.exec`'s approved-cascade path, below) correctly does NOT fire here, since only
+cascade *approval* -- not detection alone -- skips the elective postexec checkpoint/optimized-build
+offers.
+
+```
+self.cascade.timed
 ```
 
 ## selfapps-conda-bothfail NDJSON rows (selfapps_conda_bothfail.ps1, uv lane only, non-gating)

--- a/docs/open-questions.md
+++ b/docs/open-questions.md
@@ -9,119 +9,100 @@ changelog-style sections are for.
 
 ---
 
-## 1. Cascade-to-next-provider prompt fires before the user has seen the current build run -- what should happen to the two follow-up offers?
+## 1. Should the cascade decision remain an interruptive consent prompt at all?
 
-**Status: open, needs a maintainer decision. No code has been changed for this yet.**
+**Status: open, needs a maintainer decision. No code changed for this specific question.**
 
-### Plain-language summary of what's actually happening
+**Context**: the original version of this item (cascade prompt firing before the postexec
+offers, wasting the user's time on a build they'd already opted away from) is now RESOLVED and
+shipped -- see CLAUDE.md's Closed Backlog "Cascade-vs-postexec fix" entry and
+`docs/agent-interconnect.md`'s matching subsection for what changed (option (b) was implemented:
+the two elective postexec offers are now skipped once cascade is approved; the smoke run itself
+is deliberately still always run, since skipping it too would leave a kept-on-exhaustion build
+unverified). This item is the narrower, harder question that surfaced while investigating that
+fix: should the underlying signal (`HP_CASCADE_CANDIDATE`) keep triggering an interruptive
+consent prompt at all, given how mixed its reliability actually is once traced through?
 
-The bootstrapper tries a sequence of ways to get Python and your packages working, in this
-order: **uv** (fastest, tried first) -> **conda** (Miniconda) -> a fresh **embedded Python**
-download -> a plain **venv** -> whatever Python is **already on the machine** (last resort).
-Each of these is called a "provider." Most runs succeed on the first provider (uv) and never
-touch any of this.
+### What "couldn't get everything working" actually means, precisely
 
-After building the `.exe` (via PyInstaller, the packaging tool), the bootstrapper checks
-PyInstaller's own "this module wasn't found" warnings and tries to install anything obviously
-missing, then rebuilds once (this repair step is called "warnfix"). If that repair *still*
-can't resolve everything under the CURRENT provider, the bootstrapper can offer to retry the
-whole dependency-install step again from scratch under the NEXT provider in the list (e.g. "uv
-couldn't get everything working, want to try conda instead?"). That retry offer is called the
-**cascade consent prompt**.
+Two build-time, static signals, BOTH required before a cascade is even offered (`:warnfix_
+cascade_detect` in `run_setup.bat`):
+- **Signal A**: PyInstaller's own warn file (a list of imports its static analyzer couldn't
+  resolve while building the `.exe`) still lists something, even AFTER a repair-install attempt
+  and a rebuild.
+- **Signal B**: at least one specific `pip install <package>` / `conda install <package>` repair
+  command, during that same repair round, itself returned a real, nonzero exit code.
 
-Separately, AFTER the `.exe` has been run once to confirm it works ("post-execution", or
-**postexec**), there are two more OPTIONAL, purely elective prompts a real (non-CI) user can
-see:
-- The **postexec checkpoint**: "want to run your program again right now, just to double
-  check?"
-- The **optimized-build offer** (requirement 9): "want me to also build a second, faster/leaner
-  version of your `.exe` using a different build tool (Nuitka)?" -- this one can take a minute
-  or more.
+This is **never based on running the `.exe`** -- the cascade decision happens entirely before
+the app is ever launched. It's also **narrower than "any warnfix repair failure"**: most apps
+that need any repair at all get fixed cleanly by a single install (case 1 below) -- the
+requirement for BOTH signals together is what makes this genuinely uncommon, not the base rate
+of warnfix repairs needed.
 
-### The actual question
+### Truth table: what each combination means and how confident the signal actually is
 
-Traced directly in the code (`run_setup.bat`, high confidence -- this is a literal read of the
-call order, not an inference): the **cascade consent prompt is asked FIRST**, before the `.exe`
-is even run to verify it. Then, regardless of whether the user said yes or no to the cascade,
-the bootstrapper goes ahead and runs the `.exe` anyway (it always has to, for its own logging),
-and then shows BOTH of the postexec prompts above -- for the SAME build the user may have just
-said "no thanks, try something else" to. Only after all of that does the bootstrapper actually
-act on the cascade answer and retry under the next provider.
+| Signal A (still unresolved) | Signal B (an install genuinely failed) | Cascade offered? | What it usually means | Est. odds the `.exe` still runs fine |
+|---|---|---|---|---|
+| No | No | No | Repair fully worked, or nothing was needed. The common case. | Very high (~95%+) |
+| No | Yes | No | An install command failed, but the rebuild's own scan came back clean anyway -- either that import was a false positive PyInstaller flags but doesn't actually need, or something else in the same round resolved it. Matches the "the failure flag was wrong / it wasn't actually needed" scenario directly. | High (~80-90%) |
+| Yes | No | No | A real gap the design doesn't catch: the repair round's OWN installs can pull in a brand-new import PyInstaller now also flags, which the repair loop never targeted (so nothing "failed" for it) -- the confidence gate doesn't distinguish this from noise. | Medium (~60-70%) |
+| Yes | Yes | **Yes** | The actual trigger: a real install failure AND a persistent static-analysis gap. The strongest available signal, but still not proof the app will crash. | Lower, and audience-dependent (~25-40% -- see below) |
 
-So a real interactive user who hits this can see, in order: "Want to try a different way?" ->
-(says yes) -> "Want to run this one again?" -> "Want to spend a minute building an optimized
-version of this one?" -> *then* it finally moves on to the different way they asked for two
-questions ago. See `docs/agent-interconnect.md`'s "Post-execution checkpoint" and "AV-Safe
-Build Path requirement 9" sections for the exact subroutine-by-subroutine trace
-(`:warnfix_cascade_detect` / `:cascade_consent_gate` -> `:run_exe_smokerun` ->
-`:run_postexec_checkpoint` -> `:offer_optimized_build`, with the cascade retry only happening
-after all of that returns to the main line).
+### Row 4 in more depth (the one that actually reaches the user)
 
-### Why is the cascade question asked before the user has even seen the current build run?
+**Could the `.exe` still succeed even with a genuine (A=yes, B=yes) signal?** Yes, plausibly --
+PyInstaller's warn file is a whole-codebase static scan, not proof a specific code path
+executes. An optional feature behind `try/except ImportError`, a rarely-used branch, or a
+type-checking-only import would all trigger this signal without the main flow ever needing it.
+Against that: this bootstrapper's own stated audience is beginners with straightforward scripts,
+where a top-level, unconditionally-used import is common -- so an outright crash is plausibly
+MORE likely than not, just not overwhelming. These percentages are informed estimates from
+reasoning through the mechanism, not measured production telemetry -- there's no real usage data
+to check them against.
 
-This is not an oversight so much as an unresolved design tension. The cascade question is
-triggered by objective evidence the bootstrapper already has -- warnfix's own repair-install
-attempt genuinely failed to resolve a dependency -- not a guess. In that sense, asking early is
-defensible: the tool already knows this build probably won't work right, so there's an argument
-for offering an alternative before spending more of the user's time on it. The problem isn't
-really the early ask; it's that the bootstrapper doesn't *also* remember that answer when it
-gets to the two follow-up prompts a few seconds later.
+**Could the NEXT provider actually help, given this signal?** It depends entirely on WHICH hop,
+and the bootstrapper has no way to tell which:
+- **uv -> conda**: the one hop with real, mechanism-level justification. conda-forge is a
+  genuinely different package index from PyPI, with different maintainers and (crucially)
+  pre-built binaries for some native-extension packages that are notoriously hard to get right
+  via pip on Windows. A meaningfully better chance here, though 0% if the package is genuinely
+  absent from every index (a translation-table bug, or a nonexistent/private package name).
+- **conda -> embed -> venv -> system**: all of these still install via plain pip against PyPI
+  once bootstrapped -- functionally the SAME resolution mechanism uv already tried, just in a
+  fresh environment. They only help if the root cause was environment-specific (a stale cache, a
+  `PYTHONPATH`/`VIRTUAL_ENV` conflict, a uv-specific bug), not genuine package unavailability --
+  and if uv AND conda have BOTH already reached this exact state, that's some evidence against a
+  simple environment glitch. Meaningfully lower odds of success on these later hops.
 
-### What actually happens if the user proceeds anyway (today's behavior, unfixed)
+This directly supports (with a real mechanism behind it, not just intuition) the "extra credit"
+idea floated alongside the original question: telling the user conda has a decent, justified
+chance while later tiers don't. **Deliberately not implemented in this pass** -- it was flagged
+as possibly too risky to be wrong and too complex to be robust, and this analysis doesn't fully
+resolve that concern: it supports the GENERAL, qualitative claim (a different package index has
+real value; retrying the same one doesn't), but the bootstrapper still has no way to know the
+TRUE root cause for any specific package, so a stronger per-package claim would be overreach.
 
-Nothing breaks, and nothing is lost -- this is a UX/wasted-time issue, not a correctness bug:
-- Declining both follow-up prompts: harmless. Just two extra, confusing y/n prompts to read and
-  click through for a build the user just moved on from. Costs a few seconds of attention.
-- Accepting "run it again?": harmless. Wastes a few seconds re-running a build already known to
-  have an issue; that run's result is tracked separately and never affects the final outcome.
-- Accepting "build an optimized version?": the costliest case. Nuitka (the alternate build tool)
-  can take a minute or more, and the resulting optimized `.exe` almost certainly has the exact
-  same missing-dependency problem, since nothing about the environment has changed yet -- the
-  cascade retry hasn't happened. Worse, even if it somehow succeeds, this optimized build gets
-  silently overwritten once the cascade to the next provider actually runs and rebuilds from
-  scratch -- so accepting it is pure wasted time with zero lasting benefit.
+### The actual open question
 
-In short: proceeding "wrong" here never produces an incorrect final result or a stuck bootstrap
--- it only burns a real, watching user's time and attention on decisions about a build the tool
-has already provisionally written off. This never happens in CI (all these prompts auto-decline
-under `HP_CI_LANE`), and it only happens at all when warnfix's own repair genuinely fails to fix
-everything -- most runs never reach this path.
+Given how mixed row 4's own reliability is (an estimated 60-75% chance of a real problem, not a
+certainty), is an INTERRUPTIVE consent prompt still the right mechanism for this signal? Three
+shapes this could take, roughly in order of how much they change from today:
+1. **Keep it exactly as-is** (current shipped state): a timed, decline-by-default consent
+   prompt, with the "dependencies may be incomplete" note now added for the decline path (see
+   the Closed Backlog entry). Simple, already shipped, but still asks a yes/no question based on
+   a signal that's wrong roughly a quarter to two-fifths of the time.
+2. **Auto-cascade without asking**, at least for the highest-value uv->conda hop specifically,
+   since that hop has real mechanism-level justification and conda is the strongest solver this
+   bootstrapper has. Removes an interruption for a genuinely-likely-to-help case, but takes away
+   the user's chance to say "no, I know this is fine, don't waste time redoing the whole
+   dependency install."
+3. **Downgrade to a passive note only**, never a prompt: build once, tell the user honestly that
+   dependencies may be incomplete and cascading MIGHT help, and let them decide to re-run with an
+   explicit opt-in flag if they want the cascade tried, rather than interrupting the default flow
+   at all.
 
-### Options and tradeoffs
-
-**(a) Reorder: ask the cascade question AFTER the postexec offers**, so the flow becomes "verify
-the current build -> offer to run it again / optimize it -> *then* ask about trying a different
-provider."
-- Feels more natural: try the current thing, see how it does, then decide whether to move on.
-- Bigger, riskier change -- touches the call order across several places in `run_setup.bat`, the
-  exact "frail" mechanism there's already reluctance to touch casually.
-- Doesn't actually remove the wasted-time problem, just relocates it: the postexec offers are
-  still made for a build the tool already suspects is broken. If the user accepts the optimized
-  build and THEN says "yes, try a different provider," that optimized build is still thrown away
-  moments later -- same waste, different order.
-
-**(b) Gate: keep the cascade question first (as today), but skip both postexec offers whenever
-the user already agreed to cascade.**
-- Small, self-contained, low-risk fix -- roughly a one-line guard added to two existing
-  subroutine call sites.
-- Directly removes the actual harm: once the user says "yes, try something else," they are not
-  asked two more questions about the thing they're leaving behind.
-- The `.exe` verification run itself still happens quietly in the background either way (it's
-  needed for the bootstrapper's own logging regardless) -- this only suppresses the two OPTIONAL
-  follow-up prompts, not any required plumbing.
-- Leaves the "cascade asked before the build is verified" ordering as-is -- but per the
-  reasoning above, that ordering is arguably already correct, since it's based on real evidence
-  rather than a guess.
-
-### Recommendation
-
-**Option (b).** It is the smaller, safer, more targeted fix -- it removes the actual wasted-time
-problem (two unnecessary prompts about an abandoned build) without reordering the trickier call
-chain in the part of the file everyone is already cautious about touching. The early cascade ask
-isn't really a flaw to fix; asking based on real, already-gathered evidence rather than making
-the user watch a near-certain failure play out first is reasonable on its own. The fix that's
-actually needed is just making the two later, optional prompts respect an answer the bootstrapper
-already has.
-
-If you'd rather have option (a), or a third approach, say so and it can be implemented instead --
-nothing has been changed in the code for this yet.
+No recommendation is made here on this specific question -- unlike the now-resolved postexec
+question, this one trades off real things (interruption cost vs. informed consent vs. wasted
+compute on a cascade that might not help) without an obviously-safer default the way skipping
+two elective prompts was. Says so explicitly rather than picking one to avoid presenting a
+guess as a recommendation.

--- a/run_setup.bat
+++ b/run_setup.bat
@@ -3242,6 +3242,12 @@ if not defined HP_BUILD_OK (
     rem like a PyInstaller-produced EXE (parse_warn/warnfix below is a no-op for it: no warn
     rem file exists, so that block already degrades gracefully per its own "not found" branch).
     set "HP_NUITKA_FALLBACK_USED="
+    rem REQ-009/REQ-005.10 (cascade-vs-postexec fix): reset the "this provider's dependencies
+    rem look incomplete" flag at the start of every fresh build attempt, not just when warnfix
+    rem happens to run again -- a provider that needs no warnfix repair at all must not inherit
+    rem a stale flag left by an earlier, cascaded-away provider's failure. Set (if warranted) and
+    rem consumed further down; see :warnfix_cascade_detect and :warn_user_code_launch.
+    set "HP_DEP_MAYBE_INCOMPLETE="
     if defined HP_TEST_FORCE_PYINSTALLER_FAIL (
       call :log "[TEST] HP_TEST_FORCE_PYINSTALLER_FAIL: simulating PyInstaller build failure."
       call :try_nuitka_tier_a
@@ -3374,6 +3380,14 @@ if not defined HP_BUILD_OK (
     set "HP_SPEC_PREEXIST="
     if exist "build\%ENVNAME%" rd /s /q "build\%ENVNAME%" >nul 2>&1
     call :log "[INFO] PyInstaller build artifacts cleaned up."
+    rem REQ-009/REQ-005.10 (cascade-vs-postexec fix): the smoke run itself is NOT skipped here,
+    rem even when HP_CASCADE_APPROVED is set -- approval only means the NEXT provider tier will
+    rem be TRIED; :provider_cascade (reached later, from the top-level main line, once this whole
+    rem subroutine returns) can still find every remaining tier unavailable/declined and fall
+    rem back to "keeping current build" -- the build this smoke run is about to verify. Skipping
+    rem it here would leave that kept build completely unverified in the exhaustion case. Only
+    rem the two ELECTIVE follow-up offers (postexec checkpoint, optimized build) are suppressed,
+    rem inside :smokerun_ndjson below -- see that label's own comment for why that scope is safe.
     call :run_exe_smokerun
   )
 )
@@ -3554,6 +3568,14 @@ if defined HP_CASCADE_CANDIDATE call :cascade_consent_gate
 if defined HP_CASCADE_CANDIDATE if not errorlevel 1 set "HP_CASCADE_APPROVED=1"
 if defined HP_CASCADE_APPROVED call :log "[INFO] REQ-009: cascade approved; will re-attempt under the next provider tier."
 if defined HP_CASCADE_CANDIDATE if not defined HP_CASCADE_APPROVED call :log "[INFO] REQ-009: cascade declined; keeping current build."
+rem Not approved (declined, timed out, or auto-declined in CI) but the candidate signal was
+rem real: set a flag that persists for the rest of THIS provider's attempt (reset at the top of
+rem every fresh build attempt -- see HP_NUITKA_FALLBACK_USED's neighbor above) so later
+rem user-facing messages (:warn_user_code_launch) can add context the bootstrapper otherwise has
+rem no other way to surface. The user may know something the automated install missed and want
+rem to push through anyway -- this is a note, never a second gate.
+if defined HP_CASCADE_CANDIDATE if not defined HP_CASCADE_APPROVED set "HP_DEP_MAYBE_INCOMPLETE=1"
+if defined HP_CASCADE_CANDIDATE if not defined HP_CASCADE_APPROVED call :log "[WARN] REQ-009: dependencies for this provider may still be incomplete. If the run below fails or behaves unexpectedly, re-run and accept the cascade prompt to try a different provider, or check/edit requirements.txt yourself if you believe the automatic install missed something it shouldn't have."
 if exist "~missing_after.txt" del "~missing_after.txt" >nul 2>&1
 exit /b 0
 :pep723_writeback
@@ -3689,20 +3711,48 @@ exit /b 0
 :cascade_consent_gate
 rem REQ-009/REQ-005.10: require explicit consent before cascading to the next provider tier.
 rem CI-safe (mirrors :conda_binary_corrupt heal prompt): HP_TEST_CASCADE_ANSWER (Y/N) overrides;
-rem otherwise HP_CI_LANE auto-declines with no prompt (no set /p hang in CI); interactive users
-rem get a Y/N prompt. exit 0 = approved (cascade), exit 1 = declined (keep the current build).
+rem otherwise HP_CI_LANE auto-declines with no prompt (no wait in CI) UNLESS
+rem HP_TEST_FORCE_INTERACTIVE_CASCADE forces the real-user branch for deterministic CI coverage
+rem of the timed prompt itself (mirrors HP_TEST_FORCE_PICKER's use for :pick_entry_interactive).
+rem A real interactive user gets a TIMED choice /T prompt (default: 30s), not an unbounded
+rem set /p -- if nobody answers in time it defaults to N (decline), so an unattended run still
+rem tries the current build once rather than hanging the whole bootstrap forever. Goto-based
+rem dispatch throughout (not nested parens) so `choice` + `if errorlevel` reads are never inside
+rem a block that could freeze an earlier value -- see docs/agent-lessons-learned.md's
+rem "Provider-cascade dispatch is goto-based on purpose". exit 0 = approved, exit 1 = declined.
 echo.
 echo *** Some dependencies could not be installed under the current Python provider. ***
 echo.
-set "HP_CASCADE_RAW="
-if defined HP_TEST_CASCADE_ANSWER (
-  set "HP_CASCADE_RAW=%HP_TEST_CASCADE_ANSWER%"
-) else if defined HP_CI_LANE (
-  set "HP_CASCADE_RAW=n"
-) else (
-  set /p "HP_CASCADE_RAW=  Try the next Python provider to resolve them? [Y/N] "
-)
+set "HP_CASCADE_CHOICE="
+if defined HP_TEST_CASCADE_ANSWER goto :cascade_consent_from_override
+if defined HP_CI_LANE if not defined HP_TEST_FORCE_INTERACTIVE_CASCADE goto :cascade_consent_ci_decline
+goto :cascade_consent_interactive
+
+:cascade_consent_from_override
+set "HP_CASCADE_RAW=%HP_TEST_CASCADE_ANSWER%"
 set "HP_CASCADE_CHOICE=%HP_CASCADE_RAW:~0,1%"
+goto :cascade_consent_resolve
+
+:cascade_consent_ci_decline
+set "HP_CASCADE_CHOICE=N"
+goto :cascade_consent_resolve
+
+:cascade_consent_interactive
+set "HP_CASCADE_T=30"
+if defined HP_TEST_FORCE_INTERACTIVE_CASCADE set "HP_CASCADE_T=2"
+where choice >nul 2>&1
+if errorlevel 1 goto :cascade_consent_no_choice_exe
+choice /C YN /N /T %HP_CASCADE_T% /D N /M "  Try the next Python provider to resolve them? [Y/N, defaults to N after %HP_CASCADE_T%s] "
+if errorlevel 2 goto :cascade_consent_ci_decline
+set "HP_CASCADE_CHOICE=Y"
+goto :cascade_consent_resolve
+
+:cascade_consent_no_choice_exe
+rem no choice.exe on this image (stripped install) -- keep the safe default (decline).
+set "HP_CASCADE_CHOICE=N"
+goto :cascade_consent_resolve
+
+:cascade_consent_resolve
 if /I "%HP_CASCADE_CHOICE%"=="Y" (
   call :log "[INFO] REQ-009: cascade consent: accepted."
   exit /b 0
@@ -3815,6 +3865,11 @@ if "%~1"=="hidden_import" (
     call :log "[WARN] Verifying the built standalone EXE (PyInstaller) now: if it stays completely silent for about 30 seconds it will be force-stopped, but any output (including a prompt waiting on your input) keeps it running as long as needed. If your program is interactive, try answering its prompts through to its own quit/exit option now so we can confirm it exits cleanly. Either way, do not start real work in it yet or any unsaved work will be lost."
   )
 )
+rem REQ-009/REQ-005.10 (cascade-vs-postexec fix): carry the "dependencies may be incomplete"
+rem context (set in :warnfix_cascade_detect when a cascade was offered but not approved) into
+rem this launch warning too, so a confusing runtime failure right after is not mistaken for a
+rem bug in the user's own code.
+if defined HP_DEP_MAYBE_INCOMPLETE call :log "[WARN] Note: dependency installation for this run may be incomplete (see the earlier warning above) -- unexpected behavior below could stem from that rather than a bug in your own code."
 exit /b 0
 :run_exe_smokerun
 if not exist "dist\%ENVNAME%.exe" (
@@ -3914,11 +3969,23 @@ if defined HP_NDJSON (
     "$r=[ordered]@{id='self.exe.smokerun';pass=($c -eq 0);details=[ordered]@{exitCode=$c}}|ConvertTo-Json -Compress -Depth 8;" ^
     "Add-Content -Path '%HP_NDJSON%' -Value $r -Encoding ASCII" >> "%LOG%" 2>&1
 )
-call :run_postexec_checkpoint exe
-rem AV-Safe Build Path requirement 9 (P1): offer an elective optimized build right after the
-rem verification telemetry above, while %HP_EXE_EXIT% still holds this run's real outcome (the
-rem next line clears it). See :offer_optimized_build's own header comment for the full gating.
-call :offer_optimized_build
+rem REQ-009/REQ-005.10 (cascade-vs-postexec fix, CLAUDE.md docs/open-questions.md item 1):
+rem when the user has already agreed to cascade to the next provider tier, this build is about
+rem to be replaced -- do not also ask them to verify-again or optimize a build they just opted
+rem away from. Both offers are purely elective (never required for correctness; the smoke run
+rem above already happened regardless -- see the comment at its call site for why THAT must
+rem never be skipped), so suppressing them here costs nothing if :provider_cascade later finds
+rem every remaining tier unavailable and keeps this build after all -- the user was never asked
+rem to verify/optimize it, but it was still verified once, just without the elective extras.
+if defined HP_CASCADE_APPROVED (
+  call :log "[INFO] REQ-009: cascade approved; skipping the post-verification offers for this build."
+) else (
+  call :run_postexec_checkpoint exe
+  rem AV-Safe Build Path requirement 9 (P1): offer an elective optimized build right after the
+  rem verification telemetry above, while %HP_EXE_EXIT% still holds this run's real outcome (the
+  rem next line clears it). See :offer_optimized_build's own header comment for the full gating.
+  call :offer_optimized_build
+)
 set "HP_EXE_EXIT="
 exit /b 0
 :exe_smokerun_hints

--- a/tests/selfapps_cascade.ps1
+++ b/tests/selfapps_cascade.ps1
@@ -135,6 +135,14 @@ $terminated = $combined -match [regex]::Escape('keeping current build')
 # No tier was used as a cascade source more than once (per-tier guard works -> no loop).
 $noLoop = ($uvToConda -le 1) -and ($condaToEmbed -le 1) -and ($embedToVenv -le 1) -and ($venvToSystem -le 1)
 
+# CLAUDE.md item 9 (docs/open-questions.md item 1, cascade-vs-postexec fix): every one of the 4
+# cascade-approved builds in this test (uv, conda, embed, venv, each answered Y via
+# HP_TEST_CASCADE_ANSWER) must skip its own postexec checkpoint/optimized-build offers, since
+# each is about to be replaced by the next tier. Counted against the single-source $setupText,
+# same reasoning as the phrases above.
+$offersSkipped = ([regex]::Matches($setupText, [regex]::Escape('REQ-009: cascade approved; skipping the post-verification offers'))).Count
+$offersSkippedOk = ($offersSkipped -eq 4)
+
 # Bootstrap status: the run must end gracefully (exitCode 0) despite the unresolvable dep.
 $statusPath = Join-Path $workDir '~bootstrap.status.json'
 $statusExit = $null
@@ -148,15 +156,16 @@ if (Test-Path $statusPath) {
 }
 
 # Primary criteria: the priority uv -> conda cascade executed and selected conda, the run
-# terminated (did not loop), no tier was retried, and the bootstrap ended gracefully (exit 0).
-$execPass = ($uvToConda -eq 1) -and $condaSelected -and $terminated -and $noLoop -and ($statusExit -eq 0)
+# terminated (did not loop), no tier was retried, every approved-cascade build correctly
+# skipped its own postexec offers, and the bootstrap ended gracefully (exit 0).
+$execPass = ($uvToConda -eq 1) -and $condaSelected -and $terminated -and $noLoop -and $offersSkippedOk -and ($statusExit -eq 0)
 
 # Self-diagnosis: run_setup.bat output is redirected to the bootstrap log file, so without this
 # the CI job log shows nothing about what the cascade actually did. Echo the computed evidence
 # and the REQ-009 / provider / warnfix lines so a failure is diagnosable from the step log alone.
 Write-Host "=== self.cascade.exec evidence ==="
-Write-Host ("uvToConda={0} condaToEmbed={1} embedToVenv={2} venvToSystem={3} condaSelected={4} terminated={5} noLoop={6} statusExit={7} statusState={8} runExit={9} execPass={10}" -f `
-    $uvToConda, $condaToEmbed, $embedToVenv, $venvToSystem, $condaSelected, $terminated, $noLoop, $statusExit, $statusState, $runExit, $execPass)
+Write-Host ("uvToConda={0} condaToEmbed={1} embedToVenv={2} venvToSystem={3} condaSelected={4} terminated={5} noLoop={6} offersSkipped={7} statusExit={8} statusState={9} runExit={10} execPass={11}" -f `
+    $uvToConda, $condaToEmbed, $embedToVenv, $venvToSystem, $condaSelected, $terminated, $noLoop, $offersSkipped, $statusExit, $statusState, $runExit, $execPass)
 Write-Host "=== REQ-009 / provider / warnfix lines (setup log) ==="
 ($setupText -split "`n") | Where-Object { $_ -match 'REQ-009|Selected Python provider|REPAIR|HP_ENV_MODE|warnfix|cascade|Trying the next Python provider|Installing Miniconda' } | Select-Object -First 80 | ForEach-Object { Write-Host $_ }
 Write-Host "=== bootstrap stdout log tail (50) ==="
@@ -176,6 +185,7 @@ Write-NdjsonRow ([ordered]@{
         condaSelected = $condaSelected
         terminated    = $terminated
         noLoop        = $noLoop
+        offersSkipped = $offersSkipped
         statusExit    = $statusExit
         statusState   = $statusState
         runExit       = $runExit

--- a/tests/selfapps_cascade_timed.ps1
+++ b/tests/selfapps_cascade_timed.ps1
@@ -1,0 +1,152 @@
+# ASCII only
+# selfapps_cascade_timed.ps1 - REQ-009/REQ-005.10: cascade consent gate's TIMED prompt.
+#
+# CLAUDE.md item 9 / docs/open-questions.md item 1 follow-up: before this fix, an interactive
+# user who was not physically present when the cascade consent prompt appeared would hang the
+# whole bootstrap forever (a bare `set /p` has no timeout). :cascade_consent_gate now uses a
+# `choice /T` timed prompt (default: 30s, mirrors :pick_entry_interactive's own established
+# pattern) that defaults to N (decline) if nobody answers -- so an unattended run still tries
+# the current build once, unprompted, instead of hanging.
+#
+# HP_TEST_FORCE_INTERACTIVE_CASCADE=1 forces the timed-choice branch to be reached even under
+# HP_CI_LANE (which would otherwise auto-decline with no prompt at all) and shrinks the timeout
+# to 2s, mirroring HP_TEST_FORCE_PICKER's own established pattern for :pick_entry_interactive
+# (see tests/selfapps_entry_picker.ps1). With no interactive console and no HP_TEST_CASCADE_ANSWER
+# override, `choice` degrades to its default (N) within ~2s -- proving the timed mechanism itself
+# works (reaches the prompt, does not hang, resolves to decline) without needing a real human.
+#
+# Also verifies the companion "dependencies may be incomplete" note (HP_DEP_MAYBE_INCOMPLETE)
+# fires on decline and appears before the EXE launch, and that the postexec-offers-skip message
+# (added for the SAME item, tested positively in self.cascade.exec's approved-cascade path) does
+# NOT fire here, since cascade was declined, not approved -- the offers should still be shown.
+#
+# The app imports a nonexistent module so warnfix's repair genuinely fails and a cascade
+# candidate is detected, exactly like selfapps_cascade.ps1's own app -- but this test never lets
+# the cascade proceed, so it never reaches conda/embed/venv/system and stays fast.
+#
+# Emits: self.cascade.timed
+#
+# Lane: conda-full only (one real bootstrap; HP_FORCE_CONDA_ONLY keeps the provider deterministic
+# and this test needs only ONE warnfix/cascade-candidate cycle, not a full multi-tier walk).
+param()
+$ErrorActionPreference = 'Continue'
+$here = $PSScriptRoot
+$repo = Split-Path -Path $here -Parent
+$nd   = Join-Path $here '~test-results.ndjson'
+$ciNd = Join-Path $repo 'ci_test_results.ndjson'
+if (-not (Test-Path $nd))   { New-Item -ItemType File -Path $nd   -Force | Out-Null }
+if (-not (Test-Path $ciNd)) { New-Item -ItemType File -Path $ciNd -Force | Out-Null }
+
+function Write-NdjsonRow {
+    param([hashtable]$Row)
+    $lane = [Environment]::GetEnvironmentVariable('HP_CI_LANE')
+    if ($lane -and -not $Row.ContainsKey('lane')) { $Row['lane'] = $lane }
+    $json = $Row | ConvertTo-Json -Compress -Depth 8
+    Add-Content -LiteralPath $nd   -Value $json -Encoding Ascii
+    Add-Content -LiteralPath $ciNd -Value $json -Encoding Ascii
+}
+
+if (-not $IsWindows) {
+    Write-NdjsonRow ([ordered]@{
+        id      = 'self.cascade.timed'
+        req     = 'REQ-009'
+        pass    = $true
+        desc    = 'Cascade consent timed prompt (skipped on non-Windows)'
+        details = [ordered]@{ skip = $true; reason = 'non-windows-host' }
+    })
+    exit 0
+}
+
+$batchPath = Join-Path $repo 'run_setup.bat'
+if (-not (Test-Path $batchPath)) {
+    Write-NdjsonRow ([ordered]@{
+        id      = 'self.cascade.timed'
+        req     = 'REQ-009'
+        pass    = $false
+        desc    = 'run_setup.bat not found'
+        details = [ordered]@{ error = 'run_setup.bat not found at ' + $batchPath }
+    })
+    exit 1
+}
+
+$workDir = Join-Path $here '~selftest_cascade_timed'
+if (Test-Path $workDir) { Remove-Item -Recurse -Force $workDir }
+New-Item -ItemType Directory -Force -Path $workDir | Out-Null
+Copy-Item -Path $batchPath -Destination $workDir -Force
+
+$appCode = @'
+import fake_pkg_cascade_timed_xyz
+print('cascade-timed-app-ran')
+'@
+Set-Content -Path (Join-Path $workDir 'app.py') -Value $appCode -Encoding ASCII
+
+$prevSkipPip  = if (Test-Path Env:HP_SKIP_PIPREQS)                  { $env:HP_SKIP_PIPREQS }                  else { $null }
+$prevDisableH = if (Test-Path Env:HP_DISABLE_HEURISTICS)            { $env:HP_DISABLE_HEURISTICS }            else { $null }
+$prevForce    = if (Test-Path Env:HP_TEST_FORCE_INTERACTIVE_CASCADE){ $env:HP_TEST_FORCE_INTERACTIVE_CASCADE }else { $null }
+$env:HP_SKIP_PIPREQS       = '1'
+$env:HP_DISABLE_HEURISTICS = '1'
+$env:HP_TEST_FORCE_INTERACTIVE_CASCADE = '1'
+
+$bootstrapLog = '~cascade_timed_bootstrap.log'
+$runExit = -1
+Push-Location -LiteralPath $workDir
+try {
+    cmd /c "call run_setup.bat > $bootstrapLog 2>&1"
+    $runExit = $LASTEXITCODE
+} finally {
+    Pop-Location
+    if ($null -eq $prevSkipPip)  { Remove-Item Env:HP_SKIP_PIPREQS -ErrorAction SilentlyContinue }                  else { $env:HP_SKIP_PIPREQS = $prevSkipPip }
+    if ($null -eq $prevDisableH) { Remove-Item Env:HP_DISABLE_HEURISTICS -ErrorAction SilentlyContinue }            else { $env:HP_DISABLE_HEURISTICS = $prevDisableH }
+    if ($null -eq $prevForce)    { Remove-Item Env:HP_TEST_FORCE_INTERACTIVE_CASCADE -ErrorAction SilentlyContinue }else { $env:HP_TEST_FORCE_INTERACTIVE_CASCADE = $prevForce }
+}
+
+$logPath   = Join-Path $workDir $bootstrapLog
+$setupLog  = Join-Path $workDir '~setup.log'
+$logLines  = if (Test-Path $logPath)  { Get-Content -LiteralPath $logPath  -Encoding ASCII } else { @() }
+$setupText = if (Test-Path $setupLog) { Get-Content -LiteralPath $setupLog -Raw -Encoding ASCII } else { '' }
+$combined  = ($logLines -join "`n") + "`n" + $setupText
+
+# The timed prompt itself was actually shown (not silently skipped like the plain HP_CI_LANE
+# auto-decline path would) -- proves HP_TEST_FORCE_INTERACTIVE_CASCADE reached the interactive
+# branch, not the CI auto-decline shortcut.
+$promptShown = $combined -match [regex]::Escape('Try the next Python provider to resolve them?')
+# It resolved to decline (the /D N default, since nothing answered it within 2s) -- not a hang
+# (proven by runExit being a real exit code at all) and not an accidental accept.
+$consentDeclined = $combined -match [regex]::Escape('[INFO] REQ-009: cascade consent: declined.')
+$consentAccepted = $combined -match [regex]::Escape('[INFO] REQ-009: cascade consent: accepted.')
+# The dirty-flag note fired at both its injection points: the decline-time WARN and the
+# pre-launch reminder in :warn_user_code_launch.
+$declineNoteFired = $combined -match [regex]::Escape('[WARN] REQ-009: dependencies for this provider may still be incomplete.')
+$launchNoteFired  = $combined -match [regex]::Escape('[WARN] Note: dependency installation for this run may be incomplete')
+# Since cascade was DECLINED (not approved), the postexec-offers-skip message must NOT fire --
+# only cascade approval skips those offers (self.cascade.exec proves the positive case).
+$offersSkipWronglyFired = $combined -match [regex]::Escape('REQ-009: cascade approved; skipping the post-verification offers')
+# The run still completed gracefully (declining is not a bootstrapper failure).
+$statusPath = Join-Path $workDir '~bootstrap.status.json'
+$statusState = $null
+if (Test-Path -LiteralPath $statusPath) {
+    try { $statusState = (Get-Content -LiteralPath $statusPath -Raw | ConvertFrom-Json).state } catch { }
+}
+
+$pass = $promptShown -and $consentDeclined -and (-not $consentAccepted) -and $declineNoteFired -and $launchNoteFired -and (-not $offersSkipWronglyFired) -and ($statusState -eq 'ok')
+
+Write-NdjsonRow ([ordered]@{
+    id      = 'self.cascade.timed'
+    req     = 'REQ-009'
+    pass    = $pass
+    desc    = 'Cascade consent gate uses a TIMED choice prompt (not an unbounded set /p); with no answer it defaults to decline within 2s, and the dependency-incomplete note reaches the user'
+    details = [ordered]@{
+        promptShown             = $promptShown
+        consentDeclined         = $consentDeclined
+        consentAccepted         = $consentAccepted
+        declineNoteFired        = $declineNoteFired
+        launchNoteFired         = $launchNoteFired
+        offersSkipWronglyFired  = $offersSkipWronglyFired
+        statusState             = $statusState
+        runExit                 = $runExit
+        log                     = $bootstrapLog
+    }
+})
+
+if (-not $pass) { exit 1 }
+exit 0

--- a/tests/selfapps_ux_hardening.ps1
+++ b/tests/selfapps_ux_hardening.ps1
@@ -18,6 +18,33 @@ function Write-NdjsonRow {
     Add-Content -LiteralPath $ciNd -Value $json -Encoding Ascii
 }
 
+# CLAUDE.md Active Backlog item 3: shared save/set/restore helper for the two REQ-009 Tier 5
+# scenarios below (self.embed.fallback.decline / .real), each of which forces a genuinely
+# different set of env vars (decline: 6; real: 5 different ones) -- so this takes a hashtable
+# rather than a fixed var list. [Environment]::SetEnvironmentVariable($name, $null) both restores
+# an unset var to unset AND sets a var to a value uniformly, so no separate "was it null before"
+# branch is needed on restore (verified locally via pwsh before relying on it here). Runs the body
+# via the call operator inside try/finally so overrides are restored even if the body throws, and
+# returns whatever the body scriptblock returns so callers can still capture e.g. an exit code.
+function Invoke-WithEnvOverrides {
+    param(
+        [Parameter(Mandatory)][hashtable]$Overrides,
+        [Parameter(Mandatory)][scriptblock]$Body
+    )
+    $saved = @{}
+    foreach ($name in $Overrides.Keys) {
+        $saved[$name] = [Environment]::GetEnvironmentVariable($name)
+        [Environment]::SetEnvironmentVariable($name, [string]$Overrides[$name])
+    }
+    try {
+        & $Body
+    } finally {
+        foreach ($name in $saved.Keys) {
+            [Environment]::SetEnvironmentVariable($name, $saved[$name])
+        }
+    }
+}
+
 # Non-Windows skip
 if (-not $IsWindows) {
     $platform = [System.Environment]::OSVersion.Platform.ToString()
@@ -833,32 +860,23 @@ if ($env:HP_FORCE_CONDA_ONLY -eq '1') {
         details = [ordered]@{ skip = $true; reason = 'HP_FORCE_CONDA_ONLY-prohibits-non-conda-fallbacks' }
     })
 } else {
-    $savedCondaFail7 = $env:HP_TEST_FORCE_CONDA_FAIL
-    $savedVenvFail7  = $env:HP_TEST_FORCE_VENV_FAIL
-    $savedSyscon7    = $env:HP_TEST_SYSCON_ANSWER
-    $savedOffline7   = $env:HP_OFFLINE_MODE
-    $savedLane7      = $env:HP_CI_LANE
-    $savedEmbedFail7 = $env:HP_TEST_FORCE_EMBED_FAIL
-    $env:HP_TEST_FORCE_CONDA_FAIL = '1'
-    $env:HP_TEST_FORCE_VENV_FAIL  = '1'
-    $env:HP_TEST_SYSCON_ANSWER    = 'N'
-    $env:HP_OFFLINE_MODE          = '1'
-    $env:HP_CI_LANE               = 'test'
-    $env:HP_TEST_FORCE_EMBED_FAIL = '1'
     $embedDeclineLog = Join-Path $embedDeclineDir '~embed_decline.log'
-    Push-Location -LiteralPath $embedDeclineDir
-    try {
-        cmd /c "run_setup.bat > ~embed_decline.log 2>&1"
-        $embedDeclineExit = $LASTEXITCODE
-    } finally {
-        Pop-Location
+    $embedDeclineExit = Invoke-WithEnvOverrides -Overrides @{
+        HP_TEST_FORCE_CONDA_FAIL = '1'
+        HP_TEST_FORCE_VENV_FAIL  = '1'
+        HP_TEST_SYSCON_ANSWER    = 'N'
+        HP_OFFLINE_MODE          = '1'
+        HP_CI_LANE               = 'test'
+        HP_TEST_FORCE_EMBED_FAIL = '1'
+    } -Body {
+        Push-Location -LiteralPath $embedDeclineDir
+        try {
+            cmd /c "run_setup.bat > ~embed_decline.log 2>&1"
+            $LASTEXITCODE
+        } finally {
+            Pop-Location
+        }
     }
-    $env:HP_TEST_FORCE_CONDA_FAIL = $savedCondaFail7
-    $env:HP_TEST_FORCE_VENV_FAIL  = $savedVenvFail7
-    if ($null -eq $savedSyscon7) { Remove-Item Env:HP_TEST_SYSCON_ANSWER -ErrorAction SilentlyContinue } else { $env:HP_TEST_SYSCON_ANSWER = $savedSyscon7 }
-    $env:HP_OFFLINE_MODE          = $savedOffline7
-    $env:HP_CI_LANE               = $savedLane7
-    if ($null -eq $savedEmbedFail7) { Remove-Item Env:HP_TEST_FORCE_EMBED_FAIL -ErrorAction SilentlyContinue } else { $env:HP_TEST_FORCE_EMBED_FAIL = $savedEmbedFail7 }
 
     $embedDeclineText = ''
     if (Test-Path -LiteralPath $embedDeclineLog) {
@@ -934,29 +952,22 @@ if ($env:HP_FORCE_CONDA_ONLY -eq '1') {
         details = [ordered]@{ skip = $true; reason = 'HP_FORCE_CONDA_ONLY-prohibits-non-conda-fallbacks' }
     })
 } else {
-    $savedCondaFail8 = $env:HP_TEST_FORCE_CONDA_FAIL
-    $savedOffline8   = $env:HP_OFFLINE_MODE
-    $savedSkipPR8    = $env:HP_SKIP_PIPREQS
-    $savedLane8      = $env:HP_CI_LANE
-    $savedEmbedReal8 = $env:HP_TEST_FORCE_EMBED_REAL
-    $env:HP_TEST_FORCE_CONDA_FAIL = '1'
-    $env:HP_OFFLINE_MODE          = '1'
-    $env:HP_SKIP_PIPREQS          = '1'
-    $env:HP_CI_LANE               = 'test'
-    $env:HP_TEST_FORCE_EMBED_REAL = '1'
     $embedRealLog = Join-Path $embedRealDir '~embed_real.log'
-    Push-Location -LiteralPath $embedRealDir
-    try {
-        cmd /c "run_setup.bat > ~embed_real.log 2>&1"
-        $embedRealExit = $LASTEXITCODE
-    } finally {
-        Pop-Location
+    $embedRealExit = Invoke-WithEnvOverrides -Overrides @{
+        HP_TEST_FORCE_CONDA_FAIL = '1'
+        HP_OFFLINE_MODE          = '1'
+        HP_SKIP_PIPREQS          = '1'
+        HP_CI_LANE               = 'test'
+        HP_TEST_FORCE_EMBED_REAL = '1'
+    } -Body {
+        Push-Location -LiteralPath $embedRealDir
+        try {
+            cmd /c "run_setup.bat > ~embed_real.log 2>&1"
+            $LASTEXITCODE
+        } finally {
+            Pop-Location
+        }
     }
-    $env:HP_TEST_FORCE_CONDA_FAIL = $savedCondaFail8
-    $env:HP_OFFLINE_MODE          = $savedOffline8
-    $env:HP_SKIP_PIPREQS          = $savedSkipPR8
-    $env:HP_CI_LANE               = $savedLane8
-    if ($null -eq $savedEmbedReal8) { Remove-Item Env:HP_TEST_FORCE_EMBED_REAL -ErrorAction SilentlyContinue } else { $env:HP_TEST_FORCE_EMBED_REAL = $savedEmbedReal8 }
 
     $embedRealSetupLog = Join-Path $embedRealDir '~setup.log'
     $embedRealSetupText = ''


### PR DESCRIPTION
## Summary

Owner-directed follow-up to `docs/open-questions.md` item 1 (the cascade-consent-vs-postexec-offers question), plus a small approved test refactor and two documentation reassessments.

- **Cascade-vs-postexec fix**: once a user approves cascading to the next Python provider tier, the bootstrapper no longer asks two more elective questions (postexec checkpoint, optimized-build offer) about the build they just opted away from. The EXE smoke run itself stays unconditional — an earlier draft skipped it too, but tracing `:provider_cascade`'s own exhaustion paths ("keeping current build" when every remaining tier is unavailable/declined) showed that would leave a kept-on-exhaustion build completely unverified, a real regression. Only the two purely elective offers are suppressed.
- **Timed cascade consent prompt**: `:cascade_consent_gate` now uses a `choice /T` timed prompt (default 30s) instead of an unbounded `set /p`, mirroring `:pick_entry_interactive`'s established pattern — an unattended interactive user no longer hangs the whole bootstrap forever; it defaults to decline and tries the current build once.
- **New "dependencies may be incomplete" note** (`HP_DEP_MAYBE_INCOMPLETE`): surfaced when a cascade candidate was detected but not approved, at both decision time and right before the EXE launches, so a confusing runtime failure isn't mistaken for a bug in the user's own code.
- **`docs/open-questions.md` item 1 rewritten**: the original prompt-ordering question is resolved and closed; a narrower remaining question (should the cascade signal be an interruptive prompt at all, given its own mixed reliability) is posed with a full truth-table analysis.
- **Test-only refactor**: `Invoke-WithEnvOverrides` helper in `tests/selfapps_ux_hardening.ps1` dedupes ~85 lines of near-identical env-var save/set/restore boilerplate (CLAUDE.md Active Backlog item 3, zero `run_setup.bat` risk).
- **CLAUDE.md housekeeping**: item 9 moved to Closed Backlog; item 1 (CI wall-clock duration) moved to Periodic Maintenance Checks as a genuine recurring check, not a one-time backlog item; items 4 and 7 got confidence-vs-evidence reassessment notes (both remain correctly deferred, for more precise reasons now).

## Test plan
- [x] `python tools/check_delimiters.py run_setup.bat` — clean
- [x] `python -m yamllint .github/workflows/` / `actionlint` — clean
- [x] Full `tools/run_sanity_sweep.sh` — all checks pass (compileall, pyflakes, delimiters, yamllint, actionlint, ASCII sweep, PowerShell AST parse sweep, full pytest suite: 437 passed, 2 skipped)
- [x] New `tests/selfapps_cascade_timed.ps1` (conda-full lane) added, proving the timed-choice mechanism and both note injection points positively
- [x] `tests/selfapps_cascade.ps1`'s existing `self.cascade.exec` extended with an assertion that all 4 approved-cascade builds skip their postexec offers
- [ ] Real Windows CI (`real`/`conda-full` lanes) — this feature cannot be exercised end-to-end locally; watching CI for confirmation

Co-Authored-By: Claude Sonnet 5

https://claude.ai/code/session_015xbWLPbiaKVsobB9FZy8kS

---
_Generated by [Claude Code](https://claude.ai/code/session_015xbWLPbiaKVsobB9FZy8kS)_