### PR TITLE
ci: convert 5 zero-risk gating-lane steps to if:always() (item 7 scoping pass)

### DIFF
--- a/.github/workflows/batch-check.yml
+++ b/.github/workflows/batch-check.yml
@@ -308,7 +308,10 @@ jobs:
           & tests\selfapps_envname.ps1
 
       - name: "Self-test: bootstrapper size tripwire (REQ-017)"
-        if: ${{ env.HP_CACHE_CORRUPTED != '1' }}
+        # derived requirement (item 7 scoping pass): this step never executes run_setup.bat
+        # (a static byte-size check only), so always() carries zero duration-inflation risk --
+        # it is safe to surface even when an earlier step (e.g. Bootstrap environment) failed.
+        if: ${{ always() && env.HP_CACHE_CORRUPTED != '1' }}
         shell: pwsh
         run: |
           & tests\selfapps_size.ps1
@@ -742,13 +745,19 @@ jobs:
           & tests\selfapps_pipgap.ps1
 
       - name: "Self-test: parse_warn TRANSLATIONS table coverage"
-        if: ${{ env.HP_CACHE_CORRUPTED != '1' }}
+        # derived requirement (item 7 scoping pass): this step only decodes the embedded
+        # HP_PARSE_WARN base64 payload out of run_setup.bat as static text -- it never executes
+        # run_setup.bat -- so always() carries zero duration-inflation risk.
+        if: ${{ always() && env.HP_CACHE_CORRUPTED != '1' }}
         shell: pwsh
         run: |
           & tests\selfapps_parse_warn_table.ps1
 
       - name: "Self-test: parse_warn pytest (test_parse_warn.py)"
-        if: ${{ env.HP_CACHE_CORRUPTED != '1' }}
+        # derived requirement (item 7 scoping pass): pure `python -m unittest` against this
+        # repo's own tools/parse_warn.py -- no dependency on run_setup.bat/conda/Miniconda at
+        # all, so always() carries zero duration-inflation risk.
+        if: ${{ always() && env.HP_CACHE_CORRUPTED != '1' }}
         shell: pwsh
         run: |
           $nd   = "tests\~test-results.ndjson"
@@ -777,7 +786,10 @@ jobs:
           if (-not $pass) { Write-Host $outStr; exit 1 }
 
       - name: "Self-test: heuristics unittest (test_heuristics.py)"
-        if: ${{ env.HP_CACHE_CORRUPTED != '1' }}
+        # derived requirement (item 7 scoping pass): pure `python -m unittest` against this
+        # repo's own tools/prep_requirements.py -- no dependency on run_setup.bat/conda/Miniconda
+        # at all, so always() carries zero duration-inflation risk.
+        if: ${{ always() && env.HP_CACHE_CORRUPTED != '1' }}
         shell: pwsh
         run: |
           $nd   = "tests\~test-results.ndjson"
@@ -806,7 +818,10 @@ jobs:
           if (-not $pass) { Write-Host $outStr; exit 1 }
 
       - name: "Self-test: Python unit tests (pytest cross-platform)"
-        if: ${{ env.HP_CACHE_CORRUPTED != '1' }}
+        # derived requirement (item 7 scoping pass): pure `pytest` against this repo's own
+        # tests/test_*.py suite -- no dependency on run_setup.bat/conda/Miniconda at all, so
+        # always() carries zero duration-inflation risk.
+        if: ${{ always() && env.HP_CACHE_CORRUPTED != '1' }}
         shell: pwsh
         run: |
           $nd   = "tests\~test-results.ndjson"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -560,6 +560,57 @@ below instead of here (see that section's own scope note for the distinction fro
      two original reasons for deferral (a wide, ~50-step blast radius; no observed instance of
      this class of gap hiding a real regression yet) both still hold, now with a clearer picture
      of what a future dedicated pass would actually need to verify before shipping.
+
+   **Partially closed, 2026-07-26: the dedicated scoping pass this item asked for, owner-
+   requested directly ("Item 7 scoping pass").** Catalogued all 123 steps in the `selftest` job
+   by exact `if:` condition, not from memory: ~44 (steps ~84-123, plus the two harness-parse
+   steps near the top) already carry `always()`/`failure()` -- the summary/verdict/upload/
+   diagnostics tail of the job is already fully hardened. The real risk band is steps ~17-83
+   (~67 steps, gated on `env.HP_CACHE_CORRUPTED != '1'` or a specific `matrix.mode` match, no
+   `always()`), all downstream of the single "Bootstrap environment (run_setup.bat)" step.
+   - **Traced every one of those ~67 steps to its underlying script and found exactly 5 that are
+     provably zero-risk** -- they never execute `run_setup.bat` as a subprocess at all, so
+     `always()` cannot trigger a redundant real bootstrap for them, only surface a result that
+     was previously silently skipped: `selfapps_size.ps1` (a static byte-size tripwire, REQ-017),
+     `selfapps_parse_warn_table.ps1` (decodes the embedded `HP_PARSE_WARN` base64 payload as
+     static text, never runs the bootstrapper), and the three pure `python -m unittest`/`pytest`
+     steps against this repo's own `tests/test_*.py` suite (`test_parse_warn.py`,
+     `test_heuristics.py`, the cross-platform pytest step). **Shipped in this pass**: all 5
+     converted to `if: always() && <existing lane condition>`, each with an inline comment
+     recording why it's safe (verified via `yamllint`/`actionlint`, both clean). Real, if modest,
+     immediate hardening at zero duration risk -- a bug in `tools/parse_warn.py` or
+     `tools/prep_requirements.py` that coincides with an unrelated bootstrap failure is no longer
+     silently invisible.
+   - **The remaining ~62 steps all genuinely spin up their own scratch-dir `run_setup.bat`
+     invocation** (confirmed via `grep` for each script's actual execution pattern, e.g.
+     `cmd /c .\run_setup.bat`, not just a textual mention) -- this is the real, still-open blast
+     radius the original backlog text worried about, essentially unchanged in size.
+   - **The duration-inflation risk itself is now sharper, not just "lower," thanks to two
+     concrete pieces of new evidence.** First, this repo's own already-documented fact (see the
+     `:tci_both_failed` Closed Backlog entry) that Miniconda installs to a SHARED, machine-wide
+     path (`%PUBLIC%\Documents\Miniconda3`), not a per-test-directory one -- meaning once the main
+     bootstrap step gets far enough to install Miniconda successfully, every downstream
+     conda-dependent selfapps step finds `conda.bat` already present and skips its own install
+     block entirely, at zero extra cost. Second, this session's own owner-authorized CI
+     fault-injection experiment (three throwaway-branch probes, see chat history) produced live
+     confirmation of BOTH ends of this: a probe that broke `run_setup.bat` before Miniconda is
+     ever touched (an unbalanced paren) failed in under a second via cmd.exe's own native parser,
+     and a probe that broke it well after Miniconda/conda would already be installed (a corrupted
+     PyInstaller flag) also failed fast and deterministically, not via a slow network timeout.
+     **Net conclusion: the duration-inflation risk is not "any bootstrap failure," it is
+     specifically scoped to the one case where Miniconda itself fails to install** (a real,
+     if narrower, failure mode this repo has hit before -- see the REQ-013 connectivity-check
+     retry-hardening entry's `conda.anaconda.org` 403 example) -- only THAT case would make every
+     downstream conda-dependent step redundantly retry a slow install in lockstep.
+   - **Concrete follow-on design for the remaining ~62 steps, not implemented in this pass**: a
+     shared, fast pre-check (a single new early step, or a helper both `run_setup.bat` and the
+     selfapps scripts could consult) that tests whether `conda.bat` already exists at the shared
+     Miniconda path; steps converted to `always()` would consult it and skip cleanly with an
+     honest `pass=false`/`skip=true` NDJSON row (never blindly retry) when Miniconda itself is
+     confirmed absent. This targets the ACTUAL risk precisely instead of either doing nothing
+     (today) or a blanket conversion (still not proven safe). Sizing this precisely (touching
+     dozens of scripts, even if each edit is small) is its own dedicated pass -- correctly still
+     deferred, but with a real design now instead of an open question.
 *(Item 5 from the pre-existing "cosmetic log noise/path doubling" debrief note was checked
 briefly per standing instruction not to over-invest: no `--distpath`/`--workpath` override or
 other structural path-doubling exists in the PyInstaller build invocation. Most likely source is


### PR DESCRIPTION
## Summary

- Owner-requested dedicated scoping pass for CLAUDE.md Active Backlog item 7 (gating-lane `if: always()` hardening, previously deferred pending exactly this kind of reviewed pass).
- Catalogued all 123 steps in the `selftest` job: ~44 already carry `always()`/`failure()`; the real risk band is ~67 steps downstream of "Bootstrap environment" with no `always()`, so one early failure silently skips everything after it.
- Traced every one of those ~67 steps to its underlying script and found exactly **5 that never execute `run_setup.bat` as a subprocess at all** — a static byte-size tripwire, a static embedded-payload decode check, and three pure `python -m unittest`/`pytest` invocations against this repo's own helper unit tests. Converting these to `if: always()` carries zero duration-inflation risk since there's nothing to redundantly retry.
- The remaining ~62 steps genuinely spin up their own scratch-dir `run_setup.bat` bootstrap, so the original blast-radius concern still holds there — but this pass sharpens *why*: Miniconda installs to a shared, machine-wide path, so once it succeeds once, downstream steps reuse it for free. The duration-inflation risk is specifically scoped to "Miniconda itself fails to install," not "any bootstrap failure" — confirmed via this session's own owner-authorized CI fault-injection experiment (two synthetic regressions on throwaway branches, both of which failed fast rather than via a slow network timeout).
- A concrete follow-on design (a shared "is conda already available" fast pre-check) is documented in CLAUDE.md for the remaining ~62-step band, deliberately not implemented in this pass.

## Test plan

- [x] `python -m compileall -q .`
- [x] `python tools/check_delimiters.py run_setup.bat`
- [x] `python -m yamllint .github/workflows/`
- [x] `actionlint -oneline .github/workflows/*.yml`
- [x] ASCII sweep over touched files
- [x] PowerShell AST parse sweep over `tests/*.ps1`, `tools/*.ps1`
- [x] `python -m pytest tests/test_*.py -q` (437 passed, 2 skipped)
- [ ] Real Windows CI (this PR) — confirm the 5 converted steps still pass normally on a clean run, and that `yamllint`/`actionlint` results hold in CI too

Claude-Session: https://claude.ai/code/session_015xbWLPbiaKVsobB9FZy8kS

---
_Generated by [Claude Code](https://claude.ai/code/session_015xbWLPbiaKVsobB9FZy8kS)_