### PR TITLE
ci: fix conda_avail circular gate silently skipping conda-full self-tests

### DIFF
--- a/.github/workflows/batch-check.yml
+++ b/.github/workflows/batch-check.yml
@@ -270,20 +270,27 @@ jobs:
             'pipreqs summary not generated.' | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
           }
 
-      - name: Check Miniconda availability (for downstream !cancelled() gating)
-        # derived requirement (item 7 scoping-pass follow-on): Miniconda installs to a SHARED,
-        # machine-wide path (%PUBLIC%\Documents\Miniconda3), not per-test-directory -- see the
-        # :tci_both_failed CLAUDE.md entry. This is a single, cheap Test-Path (no execution of
-        # run_setup.bat, no network) that downstream !cancelled()-converted steps consult before
-        # attempting their own conda-dependent selfapps script, so a genuine "Miniconda itself
-        # failed to install" failure produces one clean skip per step instead of dozens of
-        # steps EACH redundantly retrying a real (up to 60-90 min per HP_INSTALLER_TIMEOUT)
-        # Miniconda install. !cancelled() so it still runs even when Bootstrap environment
-        # itself failed, but is skipped (like every other step here) if the run is cancelled.
-        # Checks both condabin\conda.bat and the Scripts\conda.bat fallback -- matches
-        # run_setup.bat's own :select_conda_bat (CONDA_MAIN/CONDA_ALT) and the "Validate restored
-        # conda binary" step above, so an install that only landed via the fallback path (a real,
-        # accepted-elsewhere possibility) isn't misreported as unavailable here.
+      - name: Check Miniconda availability (diagnostic only -- no longer gates downstream steps)
+        # derived requirement (found 2026-07-27, real-CI-confirmed): this check's own premise was
+        # wrong for THIS repo's own CI shape. It was designed on the assumption that the earlier
+        # "Bootstrap environment (run_setup.bat)" step (matrix.mode == conda-full, HP_FORCE_CONDA_
+        # ONLY=1) would itself perform the first real Miniconda install, so gating downstream
+        # conda-dependent steps on "is conda already on disk" would only ever skip in the rare
+        # case that install genuinely failed. In reality that step runs against THIS repo's own
+        # root (no loose .py files -- it's testing the empty-repo/no_python_files graceful-exit
+        # path, not a real app), so it NEVER installs Miniconda -- and because every downstream
+        # selfapps step capable of performing the FIRST real install was ALSO gated on this same
+        # check, the conda-full lane could never bootstrap conda for the first time again: a
+        # circular self-skip. Confirmed via the GitHub Actions API against two real runs (efd7a5c
+        # and fd7a046, PR #390) -- ~27 real/conda-full-only self-tests silently "skipped" every
+        # single run, at the exact same timestamp, with the job still reporting overall SUCCESS
+        # (skipped steps don't fail a job), so it merged without the coverage loss ever surfacing.
+        # Downstream !cancelled()-conditions were reverted to their pre-item-7 unconditional form
+        # (matrix.mode == 'conda-full', no conda_avail dependency) -- see CLAUDE.md Active Backlog
+        # for the follow-up: either wire this check in at a point where a real install has
+        # actually had a chance to happen, or remove it if the redundant-retry risk it was meant
+        # to prevent doesn't materialize in practice. The step itself is left in place (harmless,
+        # informational Write-Host only) since nothing currently consumes its output.
         if: ${{ !cancelled() }}
         id: conda_avail
         shell: pwsh
@@ -295,14 +302,14 @@ jobs:
           Write-Host "Miniconda available at shared path: $avail"
 
       - name: "Self-test: empty repo behavior"
-        if: ${{ !cancelled() && env.HP_CACHE_CORRUPTED != '1' && (matrix.mode != 'conda-full' || steps.conda_avail.outputs.available == 'true') }}
+        if: ${{ !cancelled() && env.HP_CACHE_CORRUPTED != '1' }}
         shell: pwsh
         run: |
           & .\tests\selftests.ps1
           Get-Content -LiteralPath tests\~selftest_empty\~empty_bootstrap.log -Tail 60 -ErrorAction SilentlyContinue
 
       - name: "Self-test: single .py entry (CI-only)"
-        if: ${{ !cancelled() && env.HP_CACHE_CORRUPTED != '1' && (matrix.mode != 'conda-full' || steps.conda_avail.outputs.available == 'true') }}
+        if: ${{ !cancelled() && env.HP_CACHE_CORRUPTED != '1' }}
         env:
           HP_CI_SKIP_ENV: '1'
         shell: pwsh
@@ -310,7 +317,7 @@ jobs:
           & tests\selfapps_single.ps1
 
       - name: "Self-test: entry selection (CI-only)"
-        if: ${{ !cancelled() && env.HP_CACHE_CORRUPTED != '1' && (matrix.mode != 'conda-full' || steps.conda_avail.outputs.available == 'true') }}
+        if: ${{ !cancelled() && env.HP_CACHE_CORRUPTED != '1' }}
         env:
           HP_CI_SKIP_ENV: '1'
         shell: pwsh
@@ -318,7 +325,7 @@ jobs:
           & tests\selfapps_entry.ps1
 
       - name: "Self-test: isolation and directory integrity (CI-only)"
-        if: ${{ !cancelled() && env.HP_CACHE_CORRUPTED != '1' && (matrix.mode != 'conda-full' || steps.conda_avail.outputs.available == 'true') }}
+        if: ${{ !cancelled() && env.HP_CACHE_CORRUPTED != '1' }}
         env:
           HP_CI_SKIP_ENV: '1'
         shell: pwsh
@@ -326,7 +333,7 @@ jobs:
           & tests\selfapps_isolation.ps1
 
       - name: "Self-test: env-name sanitization (leading hyphen)"
-        if: ${{ !cancelled() && env.HP_CACHE_CORRUPTED != '1' && (matrix.mode != 'conda-full' || steps.conda_avail.outputs.available == 'true') }}
+        if: ${{ !cancelled() && env.HP_CACHE_CORRUPTED != '1' }}
         shell: pwsh
         run: |
           & tests\selfapps_envname.ps1
@@ -341,7 +348,7 @@ jobs:
           & tests\selfapps_size.ps1
 
       - name: "Self-test: real env smoke (CI-only)"
-        if: ${{ !cancelled() && env.HP_CACHE_CORRUPTED != '1' && (matrix.mode != 'conda-full' || steps.conda_avail.outputs.available == 'true') }}
+        if: ${{ !cancelled() && env.HP_CACHE_CORRUPTED != '1' }}
         shell: pwsh
         run: |
           & tests\selfapps_envsmoke.ps1
@@ -368,19 +375,19 @@ jobs:
           & tests\selfapps_dl_fallback.ps1
 
       - name: "Self-test: requirements specifier coverage"
-        if: ${{ !cancelled() && env.HP_CACHE_CORRUPTED != '1' && (matrix.mode != 'conda-full' || steps.conda_avail.outputs.available == 'true') }}
+        if: ${{ !cancelled() && env.HP_CACHE_CORRUPTED != '1' }}
         shell: pwsh
         run: |
           & tests\selfapps_reqspec.ps1
 
       - name: "Self-test: dep-check skip scenario (real/conda-full only)"
-        if: ${{ !cancelled() && (matrix.mode == 'real' || (matrix.mode == 'conda-full' && steps.conda_avail.outputs.available == 'true')) }}
+        if: ${{ !cancelled() && (matrix.mode == 'real' || matrix.mode == 'conda-full') }}
         shell: pwsh
         run: |
           & tests\selfapps_depcheck.ps1
 
       - name: "Self-test: warnfix PASS scenario (real/conda-full only)"
-        if: ${{ !cancelled() && (matrix.mode == 'real' || (matrix.mode == 'conda-full' && steps.conda_avail.outputs.available == 'true')) }}
+        if: ${{ !cancelled() && (matrix.mode == 'real' || matrix.mode == 'conda-full') }}
         env:
           WARNFIX_SCENARIO: pass
         shell: pwsh
@@ -388,7 +395,7 @@ jobs:
           & tests\selfapps_warnfix.ps1
 
       - name: "Self-test: warnfix XFAIL scenario (real/conda-full only)"
-        if: ${{ !cancelled() && (matrix.mode == 'real' || (matrix.mode == 'conda-full' && steps.conda_avail.outputs.available == 'true')) }}
+        if: ${{ !cancelled() && (matrix.mode == 'real' || matrix.mode == 'conda-full') }}
         env:
           WARNFIX_SCENARIO: xfail
         shell: pwsh
@@ -396,7 +403,7 @@ jobs:
           & tests\selfapps_warnfix.ps1
 
       - name: "Self-test: warnfix REAL scenario - heuristic prevents warnfix (real/conda-full only)"
-        if: ${{ !cancelled() && (matrix.mode == 'real' || (matrix.mode == 'conda-full' && steps.conda_avail.outputs.available == 'true')) }}
+        if: ${{ !cancelled() && (matrix.mode == 'real' || matrix.mode == 'conda-full') }}
         env:
           WARNFIX_SCENARIO: real
         shell: pwsh
@@ -404,7 +411,7 @@ jobs:
           & tests\selfapps_warnfix.ps1
 
       - name: "Self-test: warnfix REAL_WARNFIX scenario - warnfix fixes non-heuristic dep (real/conda-full only)"
-        if: ${{ !cancelled() && (matrix.mode == 'real' || (matrix.mode == 'conda-full' && steps.conda_avail.outputs.available == 'true')) }}
+        if: ${{ !cancelled() && (matrix.mode == 'real' || matrix.mode == 'conda-full') }}
         env:
           WARNFIX_SCENARIO: real_warnfix
         shell: pwsh
@@ -412,7 +419,7 @@ jobs:
           & tests\selfapps_warnfix.ps1
 
       - name: "Self-test: warnfix REAL_WARNFIX_DELAYED scenario - warnfix processes delayed imports (real/conda-full only)"
-        if: ${{ !cancelled() && (matrix.mode == 'real' || (matrix.mode == 'conda-full' && steps.conda_avail.outputs.available == 'true')) }}
+        if: ${{ !cancelled() && (matrix.mode == 'real' || matrix.mode == 'conda-full') }}
         env:
           WARNFIX_SCENARIO: real_warnfix_delayed
         shell: pwsh
@@ -547,13 +554,13 @@ jobs:
           & tests\selfapps_pvw_idempotent.ps1
 
       - name: "Self-test: pre-build collect-submodules double-gate (real/conda-full only)"
-        if: ${{ !cancelled() && (matrix.mode == 'real' || (matrix.mode == 'conda-full' && steps.conda_avail.outputs.available == 'true')) }}
+        if: ${{ !cancelled() && (matrix.mode == 'real' || matrix.mode == 'conda-full') }}
         shell: pwsh
         run: |
           & tests\selfapps_collect.ps1
 
       - name: "Self-test: strict --hidden-import auto-recovery (real/conda-full only)"
-        if: ${{ !cancelled() && (matrix.mode == 'real' || (matrix.mode == 'conda-full' && steps.conda_avail.outputs.available == 'true')) }}
+        if: ${{ !cancelled() && (matrix.mode == 'real' || matrix.mode == 'conda-full') }}
         shell: pwsh
         run: |
           & tests\selfapps_hidden_import.ps1
@@ -562,7 +569,7 @@ jobs:
       # auto-recovery loop to its 3-attempt cap without ever succeeding (its sibling above only
       # covers the one-shot-recoverable success path).
       - name: "Self-test: strict --hidden-import auto-recovery exhaustion (real/conda-full only)"
-        if: ${{ !cancelled() && (matrix.mode == 'real' || (matrix.mode == 'conda-full' && steps.conda_avail.outputs.available == 'true')) }}
+        if: ${{ !cancelled() && (matrix.mode == 'real' || matrix.mode == 'conda-full') }}
         shell: pwsh
         run: |
           & tests\selfapps_hidden_import_exhaust.ps1
@@ -673,13 +680,13 @@ jobs:
           & tests\selfapps_interactive_stdin.ps1
 
       - name: "Self-test: EXE smokerun XFAIL bad import (real/conda-full only)"
-        if: ${{ !cancelled() && (matrix.mode == 'real' || (matrix.mode == 'conda-full' && steps.conda_avail.outputs.available == 'true')) }}
+        if: ${{ !cancelled() && (matrix.mode == 'real' || matrix.mode == 'conda-full') }}
         shell: pwsh
         run: |
           & tests\selfapps_exefail.ps1
 
       - name: "Self-test: PyInstaller build failure correctly reported, not masked (execfail, real/conda-full only)"
-        if: ${{ !cancelled() && (matrix.mode == 'real' || (matrix.mode == 'conda-full' && steps.conda_avail.outputs.available == 'true')) }}
+        if: ${{ !cancelled() && (matrix.mode == 'real' || matrix.mode == 'conda-full') }}
         shell: pwsh
         env:
           PYI_FAIL_SCENARIO: execfail
@@ -687,7 +694,7 @@ jobs:
           & tests\selfapps_pyinstaller_fail.ps1
 
       - name: "Self-test: PyInstaller build failure correctly reported, not masked (output_vanish, real/conda-full only)"
-        if: ${{ !cancelled() && (matrix.mode == 'real' || (matrix.mode == 'conda-full' && steps.conda_avail.outputs.available == 'true')) }}
+        if: ${{ !cancelled() && (matrix.mode == 'real' || matrix.mode == 'conda-full') }}
         shell: pwsh
         env:
           PYI_FAIL_SCENARIO: output_vanish
@@ -695,7 +702,7 @@ jobs:
           & tests\selfapps_pyinstaller_fail.ps1
 
       - name: "Self-test: no-EXE briefing is honest when the interpreter fallback also fails (execfail_runtimefail, real/conda-full only)"
-        if: ${{ !cancelled() && (matrix.mode == 'real' || (matrix.mode == 'conda-full' && steps.conda_avail.outputs.available == 'true')) }}
+        if: ${{ !cancelled() && (matrix.mode == 'real' || matrix.mode == 'conda-full') }}
         shell: pwsh
         env:
           PYI_FAIL_SCENARIO: execfail_runtimefail
@@ -703,67 +710,67 @@ jobs:
           & tests\selfapps_pyinstaller_fail.ps1
 
       - name: "Self-test: REQ-021 py_compile pre-flight syntax error (real/conda-full only)"
-        if: ${{ !cancelled() && (matrix.mode == 'real' || (matrix.mode == 'conda-full' && steps.conda_avail.outputs.available == 'true')) }}
+        if: ${{ !cancelled() && (matrix.mode == 'real' || matrix.mode == 'conda-full') }}
         shell: pwsh
         run: |
           & tests\selfapps_preflight.ps1
 
       - name: "Self-test: EXE smokerun XFAIL missing data file (real/conda-full only)"
-        if: ${{ !cancelled() && (matrix.mode == 'real' || (matrix.mode == 'conda-full' && steps.conda_avail.outputs.available == 'true')) }}
+        if: ${{ !cancelled() && (matrix.mode == 'real' || matrix.mode == 'conda-full') }}
         shell: pwsh
         run: |
           & tests\selfapps_exedata_fail.ps1
 
       - name: "Self-test: EXE smokerun XFAIL dynamic import not bundled (real/conda-full only)"
-        if: ${{ !cancelled() && (matrix.mode == 'real' || (matrix.mode == 'conda-full' && steps.conda_avail.outputs.available == 'true')) }}
+        if: ${{ !cancelled() && (matrix.mode == 'real' || matrix.mode == 'conda-full') }}
         shell: pwsh
         run: |
           & tests\selfapps_exedyn_fail.ps1
 
       - name: "Self-test: fast-path broken-EXE graceful fallback (real/conda-full only)"
-        if: ${{ !cancelled() && (matrix.mode == 'real' || (matrix.mode == 'conda-full' && steps.conda_avail.outputs.available == 'true')) }}
+        if: ${{ !cancelled() && (matrix.mode == 'real' || matrix.mode == 'conda-full') }}
         shell: pwsh
         run: |
           & tests\selfapps_exefastpath.ps1
 
       - name: "Self-test: fail-fast probe -- fast-failure discard and alive-past-probe no-discard (real/conda-full only)"
-        if: ${{ !cancelled() && (matrix.mode == 'real' || (matrix.mode == 'conda-full' && steps.conda_avail.outputs.available == 'true')) }}
+        if: ${{ !cancelled() && (matrix.mode == 'real' || matrix.mode == 'conda-full') }}
         shell: pwsh
         run: |
           & tests\selfapps_failfast_probe.ps1
 
       - name: "Self-test: post-execution checkpoint -- accept and decline (real/conda-full only)"
-        if: ${{ !cancelled() && (matrix.mode == 'real' || (matrix.mode == 'conda-full' && steps.conda_avail.outputs.available == 'true')) }}
+        if: ${{ !cancelled() && (matrix.mode == 'real' || matrix.mode == 'conda-full') }}
         shell: pwsh
         run: |
           & tests\selfapps_postexec_checkpoint.ps1
 
       - name: "Self-test: super-user skip hooks (conda-full only)"
-        if: ${{ !cancelled() && matrix.mode == 'conda-full' && steps.conda_avail.outputs.available == 'true' }}
+        if: ${{ !cancelled() && matrix.mode == 'conda-full' }}
         shell: pwsh
         run: |
           & tests\selfapps_skiphooks.ps1
 
       - name: "Self-test: REQ-002 timed entry picker (conda-full only)"
-        if: ${{ !cancelled() && matrix.mode == 'conda-full' && steps.conda_avail.outputs.available == 'true' }}
+        if: ${{ !cancelled() && matrix.mode == 'conda-full' }}
         shell: pwsh
         run: |
           & tests\selfapps_entry_picker.ps1
 
       - name: "Self-test: REQ-009 cascade consent timed prompt (conda-full only)"
-        if: ${{ !cancelled() && matrix.mode == 'conda-full' && steps.conda_avail.outputs.available == 'true' }}
+        if: ${{ !cancelled() && matrix.mode == 'conda-full' }}
         shell: pwsh
         run: |
           & tests\selfapps_cascade_timed.ps1
 
       - name: "Test pandas/openpyxl heuristic (conda-full only)"
-        if: ${{ !cancelled() && matrix.mode == 'conda-full' && steps.conda_avail.outputs.available == 'true' }}
+        if: ${{ !cancelled() && matrix.mode == 'conda-full' }}
         shell: pwsh
         run: |
           & tests\selfapps_pandas_excel.ps1
 
       - name: "Test pip gap-fill safety net (conda-full only)"
-        if: ${{ !cancelled() && matrix.mode == 'conda-full' && steps.conda_avail.outputs.available == 'true' }}
+        if: ${{ !cancelled() && matrix.mode == 'conda-full' }}
         shell: pwsh
         run: |
           & tests\selfapps_pipgap.ps1
@@ -897,31 +904,31 @@ jobs:
           if (-not $pass) { Write-Host $outStr; exit 1 }
 
       - name: "Self-test: runtime.txt write-back (real/conda-full only)"
-        if: ${{ !cancelled() && (matrix.mode == 'real' || (matrix.mode == 'conda-full' && steps.conda_avail.outputs.available == 'true')) }}
+        if: ${{ !cancelled() && (matrix.mode == 'real' || matrix.mode == 'conda-full') }}
         shell: pwsh
         run: |
           & tests\selfapps_runtime_writeback.ps1
 
       - name: "Self-test: pyvisa NI-VISA detection (real/conda-full only)"
-        if: ${{ !cancelled() && (matrix.mode == 'real' || (matrix.mode == 'conda-full' && steps.conda_avail.outputs.available == 'true')) }}
+        if: ${{ !cancelled() && (matrix.mode == 'real' || matrix.mode == 'conda-full') }}
         shell: pwsh
         run: |
           & tests\selfapps_pyvisa.ps1
 
       - name: "Self-test: pyproject.toml Python version precedence (real/conda-full only)"
-        if: ${{ !cancelled() && (matrix.mode == 'real' || (matrix.mode == 'conda-full' && steps.conda_avail.outputs.available == 'true')) }}
+        if: ${{ !cancelled() && (matrix.mode == 'real' || matrix.mode == 'conda-full') }}
         shell: pwsh
         run: |
           & tests\selfapps_pyproject_precedence.ps1
 
       - name: "Self-test: UX hardening (git config merge)"
-        if: ${{ !cancelled() && env.HP_CACHE_CORRUPTED != '1' && (matrix.mode != 'conda-full' || steps.conda_avail.outputs.available == 'true') }}
+        if: ${{ !cancelled() && env.HP_CACHE_CORRUPTED != '1' }}
         shell: pwsh
         run: |
           & tests\selfapps_ux_hardening.ps1
 
       - name: "Self-test: REQ-007 system-Python build consent gate (non-conda-full)"
-        if: ${{ !cancelled() && env.HP_CACHE_CORRUPTED != '1' && (matrix.mode != 'conda-full' || steps.conda_avail.outputs.available == 'true') }}
+        if: ${{ !cancelled() && env.HP_CACHE_CORRUPTED != '1' }}
         shell: pwsh
         run: |
           & tests\selfapps_sysbuild.ps1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -714,6 +714,52 @@ lines, which naturally show GitHub Actions' inherent doubled checkout path
 (`.../Python_vs_Windows/Python_vs_Windows/...`) -- a runner convention, not a bug. Not chased
 further.)*
 
+15. **`conda_avail`'s own gating premise was wrong for this repo's actual CI shape, and it merged
+    (PR #390) before this was caught -- found 2026-07-27 via a direct owner question ("are we
+    sure we aren't shorting conda-full?") that prompted re-checking real step-level conclusions
+    instead of trusting the job's overall green status.** Item 7's `conda_avail` check (`id:
+    conda_avail`, a `Test-Path` against the shared `%PUBLIC%\Documents\Miniconda3\condabin\
+    conda.bat`/`Scripts\conda.bat`) was designed on the assumption that the earlier "Bootstrap
+    environment (run_setup.bat)" step performs the first real Miniconda install for the
+    `conda-full` lane, so gating ~27 downstream `real/conda-full`-restricted self-test steps on
+    "is conda already on disk" would only ever skip in the rare case that install genuinely
+    failed. **That assumption is false**: the "Bootstrap environment" step runs against THIS
+    repo's own root (no loose `.py` files there -- it's exercising the empty-repo/
+    `no_python_files` graceful-exit path, not a real target app), so it never installs Miniconda
+    at all. Worse, every downstream selfapps step capable of performing the FIRST real install
+    was ALSO gated behind this same `conda_avail` check -- a circular self-skip with no way to
+    ever break out of it. Confirmed directly via the GitHub Actions API against two real runs
+    (`efd7a5c` and `fd7a046`, both PR #390): all ~27 `real/conda-full`-only steps showed
+    `"conclusion":"skipped"` at the identical timestamp on the `conda-full` lane in BOTH runs
+    (dep-check, all 5 warnfix scenarios, pre-build collect-submodules, both hidden-import
+    auto-recovery scenarios, all EXE-smokerun/PyInstaller-failure xfails, py_compile preflight,
+    fast-path graceful fallback, fail-fast probe, post-execution checkpoint, super-user skip
+    hooks, REQ-002 timed picker, REQ-009 cascade timed prompt, pandas/openpyxl, pip gap-fill,
+    runtime.txt write-back, pyvisa detection, pyproject precedence, UX hardening). The job still
+    reported overall SUCCESS both times (a skipped step doesn't fail a job), so this silent,
+    100%-reproducible coverage loss on a GATING lane produced no automated signal at all and
+    merged via auto-merge before it was noticed -- exactly the failure mode the owner's question
+    was worried about, and the CI-time-is-free/watch-for-skips instinct behind it was correct.
+    **Fix, pushed as a follow-up commit on a fresh branch (the merged PR's branch can't be reused
+    per this repo's own stacking rule)**: reverted all 36 `conda_avail`-dependent `if:` clauses
+    to their pre-item-7 unconditional form (`matrix.mode == 'conda-full'`, no `conda_avail`
+    dependency), while KEEPING the `!cancelled()` half of each condition (the part of item 7 that
+    is actually correct and validated -- it still prevents one failing step from cascade-skipping
+    every subsequent step in the job). The `conda_avail` step itself is left in place, unused,
+    with a comment explaining why and pointing here -- removing it outright was judged riskier
+    than leaving a harmless, informational `Write-Host` step for a fix meant to land fast.
+    **Deliberately not attempted in this pass: correctly re-wiring `conda_avail` to fire at a
+    point where a real install has actually had a chance to happen.** The redundant-retry risk it
+    was meant to prevent ("dozens of steps each independently retrying a genuinely failed,
+    up-to-90-minute Miniconda install") is real in principle, but finding the right insertion
+    point requires identifying which selfapps step is genuinely first to trigger a real install
+    for a non-empty app under `HP_FORCE_CONDA_ONLY=1` -- multiple candidates already inspected
+    (`selfapps_single.ps1`, `selfapps_entry.ps1`, `selfapps_isolation.ps1`) turned out to run under
+    `HP_CI_SKIP_ENV=1` themselves (system-Python bypass, never touches conda), so this needs a
+    proper trace, not a guess, before being reintroduced. Revisit as its own dedicated, reviewed
+    pass -- the same "disproportionate to fold into an unrelated fix" reasoning item 7's own
+    history already applies elsewhere in this list.
+
 ## Cold Storage (promising ideas, deliberately shelved -- revisit only if a named trigger fires)
 
 **Scope, and how this differs from Active Backlog and Known Findings**: an Active Backlog item is


### PR DESCRIPTION
## Summary

Follow-up to #390 (merged), found via a direct owner question ("are we sure we aren't shorting conda-full?") that prompted checking real step-level CI conclusions instead of trusting the job's overall green status.

- `conda_avail`'s check (introduced in #390) assumed the "Bootstrap environment (run_setup.bat)" step performs the first real Miniconda install for the `conda-full` lane, so gating ~27 downstream `real/conda-full`-restricted self-test steps on "is conda already on disk" would only skip in the rare case that install genuinely failed.
- **That assumption is false.** "Bootstrap environment" runs against this repo's own root (no loose `.py` files there — it exercises the empty-repo/`no_python_files` graceful-exit path, not a real target app), so it never installs Miniconda at all. Every downstream selfapps step capable of performing the *first* real install was ALSO gated behind this same check — a circular self-skip with no way out.
- Confirmed directly via the GitHub Actions API against two real runs on #390 (`efd7a5c`, `fd7a046`): all ~27 `real/conda-full`-only steps showed `"conclusion":"skipped"` at the identical timestamp on `conda-full`, every run. The job still reported overall SUCCESS (a skipped step doesn't fail a job), so this merged without the coverage loss ever surfacing.
- **Fix**: reverted all 36 `conda_avail`-dependent `if:` clauses to their pre-item-7 unconditional form (`matrix.mode == 'conda-full'`, no `conda_avail` dependency), keeping `!cancelled()` (the part of item 7 that is correct and validated). The `conda_avail` step itself is left in place, unused, with a comment explaining why.
- **Wholistic audit performed on request**, not just this one bug: swept every `if:` condition in the whole 4444-line workflow (all 5 jobs) for the same bug class — none found elsewhere; traced the downstream verdict/enforce/aggregate chain to confirm it has no independent bug (it's just architecturally blind to a step that never ran). Compared the current yml against two real historical baselines (`e20d7cd`, 2026-07-08, well before this work — `conda-full` ran 78 min; `fd11ff3`, immediately before item 7 started — `conda-full` ran 94 min) via direct condition-by-condition diff: zero steps removed, 25 new steps added (all documented features shipped in that window), and all 73 changed conditions fall into exactly two known, reviewed categories (`always()`→`!cancelled()`, or gaining a `!cancelled() &&` prefix) — none reference `conda_avail` anymore. Full rationale recorded in CLAUDE.md's new Active Backlog item 15.

## Test plan

- [x] `python -m compileall -q .`
- [x] `python tools/check_delimiters.py run_setup.bat`
- [x] `python -m yamllint .github/workflows/`
- [x] `actionlint -oneline .github/workflows/*.yml`
- [x] `python -m pytest tests/test_*.py -q` (437 passed, 2 skipped)
- [x] Confirmed via GitHub Actions API that the pre-fix state (two runs on #390) shows the bug; confirmed via direct yml diff that the fix restores exact parity with two known-healthy historical baselines
- [ ] Real Windows CI (this PR) — confirm the `conda-full` lane's ~27 previously-skipped self-tests actually run and pass again, and that job duration returns to the ~80-95 min historical range

Claude-Session: https://claude.ai/code/session_015xbWLPbiaKVsobB9FZy8kS

---
_Generated by [Claude Code](https://claude.ai/code/session_015xbWLPbiaKVsobB9FZy8kS)_