### PR TITLE
docs: trace conda_avail re-wiring insertion point; decision to defer implementation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -776,6 +776,42 @@ further.)*
   pass -- the same "disproportionate to fold into an unrelated fix" reasoning item 7's own
   history already applies elsewhere in this list.
 
+  **The trace this needed was completed 2026-07-27, same day, per the standing 2-hour watchdog
+  mandate re-checking Active Backlog once nothing else was in-flight.** Read `batch-check.yml`'s
+  full `selftest` job step order from the top and checked each step's own env/script for an
+  `HP_CI_SKIP_ENV` override or a static-only check (never invokes `run_setup.bat` at all):
+  `selfapps_single.ps1`/`selfapps_entry.ps1`/`selfapps_isolation.ps1` all set
+  `HP_CI_SKIP_ENV: '1'` at the STEP level in the YAML itself (confirming the prior note directly,
+  not just citing it); `selfapps_envname.ps1` sets `HP_CI_SKIP_ENV=1` internally in its own script
+  body (a fourth candidate not previously named); `tests\selftests.ps1` (the empty-repo step)
+  replays a captured log rather than re-running the bootstrapper at all (see this file's own
+  "selftest.ps1 vs selftests.ps1" note); `selfapps_size.ps1` is a static byte-size check with no
+  bootstrap invocation. **The genuine first candidate is `selfapps_envsmoke.ps1`** ("Self-test:
+  real env smoke (CI-only)," gated only on `env.HP_CACHE_CORRUPTED != '1'`, no lane restriction
+  and no `HP_CI_SKIP_ENV` override) -- its own script comment says outright "FULL bootstrap here:
+  do NOT set HP_CI_SKIP_ENV," and it does `cmd /c .\run_setup.bat` against a real scratch app
+  directory, genuinely exercising conda-mode install under `HP_FORCE_CONDA_ONLY=1` inherited from
+  the job env. It runs immediately after the (confirmed-safe) size tripwire and immediately
+  before the first `real/conda-full only`-gated self-test block (`selfapps_depcheck.ps1`) --
+  i.e., right where `conda_avail` would need to move to for its premise to actually hold this
+  time, instead of checking too early (the original bug) or too late.
+  **Decision: do not re-implement the gating a third time without explicit owner sign-off,
+  despite having the answer this section asked for.** Two real, independently-discovered bugs
+  have already come out of this exact mechanism in close succession (the original premature-gate
+  bug this whole entry documents, plus a distinct CodeRabbit-caught wording slip on the very PR
+  that reverted it) -- both subtle, both missed on first read, both only caught via careful
+  after-the-fact scrutiny. A third attempt at gating steps in the two GATING lanes
+  (`real`/`conda-full`, explicitly must-not-regress territory) on a new `conda_avail`-at-a-new-
+  position mechanism carries real risk of a third, differently-subtle mistake in the same fragile
+  spot, and the value it buys is a bounded-but-unobserved worst case: no genuine Miniconda
+  install failure (as opposed to a transient blip already covered by REQ-022's own retry
+  hardening) has actually been hit in this repo's real CI history despite extensive documented
+  usage. Per this file's own standing instruction to escalate architecturally-significant,
+  already-burned-twice decisions rather than re-attempt them silently a third time: this is left
+  here, fully traced and ready to implement in a single well-scoped commit (move the existing,
+  currently-unused `conda_avail` step to right after `selfapps_envsmoke.ps1`, re-point the same
+  36 `if:` conditions at it), pending the owner's explicit go-ahead.
+
 ## Cold Storage (promising ideas, deliberately shelved -- revisit only if a named trigger fires)
 
 **Scope, and how this differs from Active Backlog and Known Findings**: an Active Backlog item is


### PR DESCRIPTION
## Summary

Completes the scoping pass CLAUDE.md's own Active Backlog explicitly asked for before any further `conda_avail` work: "this needs a proper trace, not a guess, before being reintroduced."

- Traced `batch-check.yml`'s full `selftest` job step order from the top, checking each step for an `HP_CI_SKIP_ENV` override or a static-only check that never invokes `run_setup.bat`.
- Confirmed `selfapps_single.ps1`/`selfapps_entry.ps1`/`selfapps_isolation.ps1` all set `HP_CI_SKIP_ENV: '1'` at the step level (previously only cited, now directly confirmed); found a fourth candidate not previously named (`selfapps_envname.ps1`, sets it internally); confirmed `selftests.ps1` replays a captured log rather than re-bootstrapping, and `selfapps_size.ps1` is a static byte-size check.
- **Identified the genuine first real-install candidate: `selfapps_envsmoke.ps1`** ("Self-test: real env smoke (CI-only)") -- its own script comment says "FULL bootstrap here: do NOT set HP_CI_SKIP_ENV," it runs unrestricted by lane, and it sits immediately before the first `real/conda-full only` self-test block.
- **Decision: do not implement the re-wiring itself in this pass.** This exact mechanism (`conda_avail`, gating the two must-not-regress lanes) has already produced two real, subtle bugs in quick succession -- the original premature-gating bug (#391) and a distinct wording slip CodeRabbit caught on the PR that reverted it (#392). A third attempt at the same fragile spot, even with the trace now in hand, is treated as architecturally significant enough to need explicit owner sign-off rather than autonomous action, per this repo's own standing escalation policy. The full implementation shape (move the existing unused `conda_avail` step to right after `selfapps_envsmoke.ps1`, re-point the same 36 `if:` conditions) is documented and ready if/when approved.

Doc-only change, zero `run_setup.bat`/workflow-YAML risk.

## Test plan

- [x] `python -m compileall -q .`
- [x] `python tools/check_delimiters.py run_setup.bat`
- [x] `markdownlint-cli2 CLAUDE.md` (clean, only the expected permanent baseline finding)
- [x] `python -m yamllint .github/workflows/`
- [x] `actionlint -oneline .github/workflows/*.yml`
- [x] PowerShell AST parse sweep (tests/*.ps1, tools/*.ps1)
- [x] `python -m pytest tests/test_*.py -q` (437 passed, 2 skipped)
- [x] Full `tools/run_sanity_sweep.sh` run, all checks OK

Claude-Session: https://claude.ai/code/session_015xbWLPbiaKVsobB9FZy8kS

---
_Generated by [Claude Code](https://claude.ai/code/session_015xbWLPbiaKVsobB9FZy8kS)_