### PR TITLE
ci: relocate conda_avail (unwired) + repo-wide ASCII cleanup

### DIFF
--- a/.github/workflows/batch-check.yml
+++ b/.github/workflows/batch-check.yml
@@ -1961,7 +1961,7 @@ jobs:
             Add-Content $env:GITHUB_STEP_SUMMARY -Value "_tests\\~test-summary.txt not found_"
           }
 
-      - name: Summarize self-tests (NDJSON → Job Summary)
+      - name: Summarize self-tests (NDJSON -> Job Summary)
         if: ${{ !cancelled() }}
         uses: actions/github-script@v8
         with:
@@ -1985,8 +1985,8 @@ jobs:
             rows.sort((a,b) => rank(a) - rank(b) || String(a.id||'').localeCompare(String(b.id||'')));
 
             const bullets = rows.map(r => {
-              const icon = r.pass === true ? '✅' : r.pass === false ? '❌' : '•';
-              const desc = r.desc ? ` — ${r.desc}` : '';
+              const icon = r.pass === true ? '[PASS]' : r.pass === false ? '[FAIL]' : '[-]';
+              const desc = r.desc ? ` -- ${r.desc}` : '';
               return `${icon} ${r.id || '(no id)'}${desc}`;
             });
 
@@ -1994,7 +1994,7 @@ jobs:
             await summary
               .addHeading('Self-test results', 2)
               .addList(bullets)
-              .addRaw(`\n**Totals:** PASS ${passCt} · FAIL ${failCt}\n`)
+              .addRaw(`\n**Totals:** PASS ${passCt} - FAIL ${failCt}\n`)
               .write();
 
             // Optional tails (non-fatal if missing)
@@ -2043,7 +2043,7 @@ jobs:
             $text = Get-Content -Raw -LiteralPath $found
             if ($null -eq $text) { $text = "" }
             if ($text.Length -eq 0) {
-              "### $title ($found — empty)" | Out-File -Append $env:GITHUB_STEP_SUMMARY
+              "### $title ($found -- empty)" | Out-File -Append $env:GITHUB_STEP_SUMMARY
               return
             }
             if ($text.Length -gt $max) { $text = $text.Substring(0,$max) + "`n... [truncated]" }
@@ -2686,7 +2686,7 @@ jobs:
           $html = @"
           <!doctype html>
           <meta charset="utf-8">
-          <title>CI Diagnostics — run ${{ github.run_id }}</title>
+          <title>CI Diagnostics -- run ${{ github.run_id }}</title>
           <style>
             body{font-family:ui-monospace,Consolas,monospace;white-space:pre-wrap;margin:24px}
             h1,h2{font-family:ui-sans-serif,system-ui}

--- a/.github/workflows/batch-check.yml
+++ b/.github/workflows/batch-check.yml
@@ -270,37 +270,6 @@ jobs:
             'pipreqs summary not generated.' | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
           }
 
-      - name: Check Miniconda availability (diagnostic only -- no longer gates downstream steps)
-        # derived requirement (found 2026-07-27, real-CI-confirmed): this check's own premise was
-        # wrong for THIS repo's own CI shape. It was designed on the assumption that the earlier
-        # "Bootstrap environment (run_setup.bat)" step (matrix.mode == conda-full, HP_FORCE_CONDA_
-        # ONLY=1) would itself perform the first real Miniconda install, so gating downstream
-        # conda-dependent steps on "is conda already on disk" would only ever skip in the rare
-        # case that install genuinely failed. In reality that step runs against THIS repo's own
-        # root (no loose .py files -- it's testing the empty-repo/no_python_files graceful-exit
-        # path, not a real app), so it NEVER installs Miniconda -- and because every downstream
-        # selfapps step capable of performing the FIRST real install was ALSO gated on this same
-        # check, the conda-full lane could never bootstrap conda for the first time again: a
-        # circular self-skip. Confirmed via the GitHub Actions API against two real runs (efd7a5c
-        # and fd7a046, PR #390) -- ~27 real/conda-full-only self-tests silently "skipped" every
-        # single run, at the exact same timestamp, with the job still reporting overall SUCCESS
-        # (skipped steps don't fail a job), so it merged without the coverage loss ever surfacing.
-        # Downstream !cancelled()-conditions were reverted to their pre-item-7 unconditional form
-        # (matrix.mode == 'conda-full', no conda_avail dependency) -- see CLAUDE.md Active Backlog
-        # for the follow-up: either wire this check in at a point where a real install has
-        # actually had a chance to happen, or remove it if the redundant-retry risk it was meant
-        # to prevent doesn't materialize in practice. The step itself is left in place (harmless,
-        # informational Write-Host only) since nothing currently consumes its output.
-        if: ${{ !cancelled() }}
-        id: conda_avail
-        shell: pwsh
-        run: |
-          $condaMain = 'C:\Users\Public\Documents\Miniconda3\condabin\conda.bat'
-          $condaAlt  = 'C:\Users\Public\Documents\Miniconda3\Scripts\conda.bat'
-          $avail = (Test-Path -LiteralPath $condaMain) -or (Test-Path -LiteralPath $condaAlt)
-          "available=$($avail.ToString().ToLowerInvariant())" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding ascii -Append
-          Write-Host "Miniconda available at shared path: $avail"
-
       - name: "Self-test: empty repo behavior"
         if: ${{ !cancelled() && env.HP_CACHE_CORRUPTED != '1' }}
         shell: pwsh
@@ -352,6 +321,46 @@ jobs:
         shell: pwsh
         run: |
           & tests\selfapps_envsmoke.ps1
+
+      - name: "Check Miniconda availability (diagnostic only -- not yet wired to any if: condition)"
+        # derived requirement (moved here 2026-07-27, correcting item 7's original placement): this
+        # check previously ran right after "Bootstrap environment (run_setup.bat)" -- but that step
+        # runs against THIS repo's own root (no loose .py files, the empty-repo/no_python_files
+        # graceful-exit path), so it never installs Miniconda. Every downstream selfapps step
+        # capable of performing the FIRST real install was ALSO gated on that same premature check,
+        # producing a circular self-skip: confirmed via the GitHub Actions API against the CI runs
+        # for two real commits on PR #390 (efd7a5c, fd7a046) that ~27 real/conda-full-only self-
+        # tests silently "skipped" every run while the job still reported overall SUCCESS. See
+        # CLAUDE.md's Active Backlog item 7 for the full incident writeup and PR #391 for the
+        # revert that restored those steps to unconditional (matrix.mode == 'conda-full') form.
+        #
+        # This step is now positioned right after "Self-test: real env smoke (CI-only)"
+        # (selfapps_envsmoke.ps1) instead -- traced 2026-07-27 as the genuine first selfapps step
+        # that performs a REAL, unconditional run_setup.bat bootstrap under HP_FORCE_CONDA_ONLY=1
+        # (its own script comment: "FULL bootstrap here: do NOT set HP_CI_SKIP_ENV"; every earlier
+        # candidate -- selfapps_single.ps1/selfapps_entry.ps1/selfapps_isolation.ps1/
+        # selfapps_envname.ps1 -- sets HP_CI_SKIP_ENV=1 and never touches conda at all; selftests.ps1
+        # only replays a captured log; selfapps_size.ps1 is a static byte-size check). Under
+        # conda-full specifically, HP_FORCE_CONDA_ONLY=1 blocks every venv/system fallback envsmoke's
+        # own script would otherwise allow, so a nonzero exit there can only mean the conda install
+        # itself failed -- making this the correct point to sample "is conda now really available."
+        #
+        # Deliberately NOT yet wired to any if: condition in this same commit. This mechanism has
+        # already produced two real, independently-discovered bugs in quick succession (the
+        # premature-gate bug this comment describes, and a distinct CodeRabbit-caught wording slip
+        # on the PR that reverted it) -- landing the corrected POSITION on its own first, with zero
+        # steps depending on it yet, lets the very first conda-full run after this change prove
+        # (via the job summary / step logs) that `available` now correctly flips to 'true' once
+        # envsmoke's real install succeeds, before any gating logic is re-added in a follow-up PR.
+        if: ${{ !cancelled() && env.HP_CACHE_CORRUPTED != '1' }}
+        id: conda_avail
+        shell: pwsh
+        run: |
+          $condaMain = 'C:\Users\Public\Documents\Miniconda3\condabin\conda.bat'
+          $condaAlt  = 'C:\Users\Public\Documents\Miniconda3\Scripts\conda.bat'
+          $avail = (Test-Path -LiteralPath $condaMain) -or (Test-Path -LiteralPath $condaAlt)
+          "available=$($avail.ToString().ToLowerInvariant())" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding ascii -Append
+          Write-Host "Miniconda available at shared path: $avail"
 
       - name: "Self-test: uv contract assertions (contract-uv* only)"
         if: ${{ matrix.mode == 'contract-uv' || matrix.mode == 'contract-uv-fail' }}

--- a/.github/workflows/batch-check.yml
+++ b/.github/workflows/batch-check.yml
@@ -361,6 +361,18 @@ jobs:
           $avail = (Test-Path -LiteralPath $condaMain) -or (Test-Path -LiteralPath $condaAlt)
           "available=$($avail.ToString().ToLowerInvariant())" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding ascii -Append
           Write-Host "Miniconda available at shared path: $avail"
+          # derived requirement: this diagnostic's own output was previously observable
+          # (Write-Host + step output) but had no NDJSON row -- CodeRabbit flagged the gap on
+          # PR #394. Non-gating (pass is always true; this step never fails the job), so it is
+          # safe to record even before any downstream if: condition depends on it.
+          $row = [ordered]@{
+            id      = 'diag.conda.available'
+            pass    = $true
+            desc    = 'Miniconda availability diagnostic (non-gating, unwired)'
+            details = [ordered]@{ available = $avail }
+          } | ConvertTo-Json -Compress -Depth 8
+          $row | Add-Content 'tests\~test-results.ndjson' -Encoding Ascii
+          $row | Add-Content 'ci_test_results.ndjson' -Encoding Ascii
 
       - name: "Self-test: uv contract assertions (contract-uv* only)"
         if: ${{ matrix.mode == 'contract-uv' || matrix.mode == 'contract-uv-fail' }}
@@ -1988,6 +2000,7 @@ jobs:
 
             const passCt = rows.filter(r => r.pass === true).length;
             const failCt = rows.filter(r => r.pass === false).length;
+            const unknownCt = rows.length - passCt - failCt;
 
             // Prefer self.* and entry.* at the top
             const rank = r => (r.id||'').startsWith('self.') || (r.id||'').startsWith('entry.') ? 0 : 1;
@@ -2003,7 +2016,7 @@ jobs:
             await summary
               .addHeading('Self-test results', 2)
               .addList(bullets)
-              .addRaw(`\n**Totals:** PASS ${passCt} - FAIL ${failCt}\n`)
+              .addRaw(`\n**Totals:** PASS ${passCt} - FAIL ${failCt}${unknownCt > 0 ? ` - UNKNOWN ${unknownCt}` : ''}\n`)
               .write();
 
             // Optional tails (non-fatal if missing)

--- a/.github/workflows/pr-automerge.yml
+++ b/.github/workflows/pr-automerge.yml
@@ -107,7 +107,7 @@ jobs:
                 if (pr.mergeable === 'MERGEABLE') {
                   try {
                     await github.rest.pulls.merge({ owner, repo, pull_number: number, merge_method: 'squash' });
-                    core.info(`#${number}: Merged directly (viewerCanEnable=false path) ✅`);
+                    core.info(`#${number}: Merged directly (viewerCanEnable=false path) [OK]`);
                   } catch (mergeErr) {
                     core.info(`#${number}: Direct merge failed: ${mergeErr.message || String(mergeErr)}`);
                   }
@@ -119,7 +119,7 @@ jobs:
                 await github.graphql(enable, { id: pr.id });
                 const { data: after } = await github.rest.pulls.get({ owner, repo, pull_number: number });
                 if (after.auto_merge) {
-                  core.info(`#${number}: Auto-merge enabled (Squash) via PAT ✅`);
+                  core.info(`#${number}: Auto-merge enabled (Squash) via PAT [OK]`);
                 } else {
                   core.info(`#${number}: enable via PAT reported success, but REST auto_merge is null (will rely on diagnostics).`);
                 }
@@ -131,7 +131,7 @@ jobs:
                 if (pr.mergeable === 'MERGEABLE') {
                   try {
                     await github.rest.pulls.merge({ owner, repo, pull_number: number, merge_method: 'squash' });
-                    core.info(`#${number}: Merged directly (PR was immediately mergeable) ✅`);
+                    core.info(`#${number}: Merged directly (PR was immediately mergeable) [OK]`);
                   } catch (mergeErr) {
                     core.info(`#${number}: Direct merge failed: ${mergeErr.message || String(mergeErr)}`);
                   }
@@ -172,7 +172,7 @@ jobs:
                 await github.graphql(enable, { id: prRest.node_id || prRest.id /* node_id expected */ });
                 const { data: after } = await github.rest.pulls.get({ owner, repo, pull_number: number });
                 if (after.auto_merge) {
-                  core.info(`#${number}: Auto-merge enabled (Squash) via GITHUB_TOKEN ✅`);
+                  core.info(`#${number}: Auto-merge enabled (Squash) via GITHUB_TOKEN [OK]`);
                 } else {
                   core.info(`#${number}: enable via GITHUB_TOKEN reported success, but REST auto_merge is null (permissions likely).`);
                 }
@@ -184,7 +184,7 @@ jobs:
                 if (prRest.mergeable === true) {
                   try {
                     await github.rest.pulls.merge({ owner, repo, pull_number: number, merge_method: 'squash' });
-                    core.info(`#${number}: Merged directly (PR was immediately mergeable) ✅`);
+                    core.info(`#${number}: Merged directly (PR was immediately mergeable) [OK]`);
                   } catch (mergeErr) {
                     core.info(`#${number}: Direct merge failed: ${mergeErr.message || String(mergeErr)}`);
                   }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -812,6 +812,27 @@ further.)*
   currently-unused `conda_avail` step to right after `selfapps_envsmoke.ps1`, re-point the same
   36 `if:` conditions at it), pending the owner's explicit go-ahead.
 
+  **Owner explicitly authorized proceeding ("if confident then implement or register open
+  question," same day) -- split into two staged PRs rather than one shot, since one shot is
+  exactly the pattern that produced both prior bugs.** Step 1 (this commit): moved the existing
+  `conda_avail` step from right after "Bootstrap environment" to right after "Self-test: real env
+  smoke (CI-only)" (`selfapps_envsmoke.ps1`) -- **deliberately left completely unwired, zero `if:`
+  conditions reference it yet.** A genuinely new wrinkle surfaced mid-implementation, worth
+  recording since it wasn't visible from the trace alone: in the ORIGINAL (buggy) design,
+  `selfapps_envsmoke.ps1` itself was one of the 9 "every non-corrupted lane" steps gated behind
+  `conda_avail` -- but envsmoke is now the PRODUCER of the signal this step reads, not a consumer,
+  so it must stay unconditional (`!cancelled() && env.HP_CACHE_CORRUPTED != '1'`, no `conda_avail`
+  clause) or the exact same circularity would return in a new spot. The other 8 steps in that
+  "every lane" category (empty-repo, single-entry, entry-selection, isolation, env-name, reqspec,
+  UX-hardening, system-Python-consent) are likewise NOT candidates for the gate going forward --
+  the real target is specifically the 27 steps already enumerated above as "silently skipped"
+  (22 `real/conda-full` + 5 `conda-full`-only), which all sit after envsmoke in file order.
+  Landing the corrected POSITION on its own first, with nothing depending on it, lets the very
+  next `conda-full` CI run prove (via its own step log) that `available` now correctly flips to
+  `'true'` once envsmoke's real install succeeds -- before any gating logic is re-added in a
+  follow-up commit. Watch that first run closely before proceeding to step 2 (wiring the 27
+  conditions).
+
 ## Cold Storage (promising ideas, deliberately shelved -- revisit only if a named trigger fires)
 
 **Scope, and how this differs from Active Backlog and Known Findings**: an Active Backlog item is

--- a/docs/agent-ndjson.md
+++ b/docs/agent-ndjson.md
@@ -206,7 +206,8 @@ self.corrupt.conda.detect,
 self.corrupt.conda.heal.decline,
 self.corrupt.conda.heal.accept,
 self.corrupt.conda.override_exit,
-self.corrupt.uv.detect
+self.corrupt.uv.detect,
+diag.conda.available
 ```
 
 `self.corrupt.conda.override_exit` (CLAUDE.md Active Backlog item 12) covers the
@@ -528,6 +529,16 @@ self.interactive.stdin.roundtrip
   recovery loop's own rebuilds -- a REPEATED module name would be rejected by
   `~hidden_import_scan.py`'s own tried-list exclusion and stop the loop early via "no next hidden
   import found", never reaching the iteration cap this test needs to exercise.
+- `diag.conda.available` (inline `.github/workflows/batch-check.yml`, the "Check Miniconda
+  availability (diagnostic only -- not yet wired to any if: condition)" step -- see CLAUDE.md
+  Active Backlog item 7's `conda_avail` history) is always `pass: true` (non-gating; the step
+  itself never fails the job) and carries `details.available` (`true`/`false`) reflecting whether
+  Miniconda was found at the shared `%PUBLIC%\Documents\Miniconda3` path at that point in the job.
+  Added on PR #394 per a CodeRabbit finding: the step's own `Write-Host`/output had been observable
+  since PR #390 with no NDJSON row. Present in every non-`HP_CACHE_CORRUPTED` lane run regardless
+  of `matrix.mode`, since the step itself has no lane restriction (only its future `if:` wiring,
+  deferred pending owner sign-off per the same backlog item, will restrict its meaning to
+  `real`/`conda-full`).
 - A row absent from the diag site means the test script either was not reached, threw
   before the `Write-NdjsonRow` call, or the lane skipped that selfapps file.
 - Rows gated by `pyFileCount` (e.g. `entry.single.direct`) will be absent whenever the

--- a/promo/avc-icon-dark-base.svg
+++ b/promo/avc-icon-dark-base.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="64" height="64" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Armchair Vibe Coding icon">
-  <title>Armchair Vibe Coding — icon</title>
+  <title>Armchair Vibe Coding -- icon</title>
   <!-- Background -->
   <rect x="0" y="0" width="64" height="64" rx="12" fill="#121212"/>
   <!-- Couch back -->

--- a/promo/avc-icon-dark-contrast.svg
+++ b/promo/avc-icon-dark-contrast.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="64" height="64" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Armchair Vibe Coding icon">
-  <title>Armchair Vibe Coding — icon</title>
+  <title>Armchair Vibe Coding -- icon</title>
   <!-- Background -->
   <rect x="0" y="0" width="64" height="64" rx="12" fill="#121212"/>
   <!-- Couch back -->

--- a/promo/avc-icon-purplebg-whitecouch.svg
+++ b/promo/avc-icon-purplebg-whitecouch.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="64" height="64" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Armchair Vibe Coding icon">
-  <title>Armchair Vibe Coding — icon</title>
+  <title>Armchair Vibe Coding -- icon</title>
   <!-- Background -->
   <rect x="0" y="0" width="64" height="64" rx="12" fill="#5C33FF"/>
   <!-- Couch back -->

--- a/promo/avc_horizontal.svg
+++ b/promo/avc_horizontal.svg
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Armchair Vibe Coding logo kit (v1) — 2025-10-25 02:46:35
+<!-- Armchair Vibe Coding logo kit (v1) - 2025-10-25 02:46:35
 Palette:
   Deep Violet #5B2A86
   Electric Cyan #00D1FF
   Charcoal #222428
   Soft Gray #8A8F98
 Guidelines:
-  • Transparent background. Flat shapes, no gradients.
-  • Icon is readable from 32px up. Keep ≥12px margin when placed in a circle/square.
-  • Primary on light: Deep Violet fills, Cyan accents. Invert for dark backgrounds.
+  - Transparent background. Flat shapes, no gradients.
+  - Icon is readable from 32px up. Keep >=12px margin when placed in a circle/square.
+  - Primary on light: Deep Violet fills, Cyan accents. Invert for dark backgrounds.
 -->
 <svg xmlns="http://www.w3.org/2000/svg" width="960" height="512" viewBox="0 0 960 512" fill="none">
 <g transform="translate(-20,0) scale(0.9)">

--- a/promo/avc_icon.svg
+++ b/promo/avc_icon.svg
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Armchair Vibe Coding logo kit (v1) — 2025-10-25 02:46:35
+<!-- Armchair Vibe Coding logo kit (v1) - 2025-10-25 02:46:35
 Palette:
   Deep Violet #5B2A86
   Electric Cyan #00D1FF
   Charcoal #222428
   Soft Gray #8A8F98
 Guidelines:
-  • Transparent background. Flat shapes, no gradients.
-  • Icon is readable from 32px up. Keep ≥12px margin when placed in a circle/square.
-  • Primary on light: Deep Violet fills, Cyan accents. Invert for dark backgrounds.
+  - Transparent background. Flat shapes, no gradients.
+  - Icon is readable from 32px up. Keep >=12px margin when placed in a circle/square.
+  - Primary on light: Deep Violet fills, Cyan accents. Invert for dark backgrounds.
 -->
 <svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512" fill="none">
 

--- a/promo/avc_stacked.svg
+++ b/promo/avc_stacked.svg
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Armchair Vibe Coding logo kit (v1) — 2025-10-25 02:46:35
+<!-- Armchair Vibe Coding logo kit (v1) - 2025-10-25 02:46:35
 Palette:
   Deep Violet #5B2A86
   Electric Cyan #00D1FF
   Charcoal #222428
   Soft Gray #8A8F98
 Guidelines:
-  • Transparent background. Flat shapes, no gradients.
-  • Icon is readable from 32px up. Keep ≥12px margin when placed in a circle/square.
-  • Primary on light: Deep Violet fills, Cyan accents. Invert for dark backgrounds.
+  - Transparent background. Flat shapes, no gradients.
+  - Icon is readable from 32px up. Keep >=12px margin when placed in a circle/square.
+  - Primary on light: Deep Violet fills, Cyan accents. Invert for dark backgrounds.
 -->
 <svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512" fill="none">
 <g transform="translate(0,-24)">

--- a/tools/diag/publish_index.py
+++ b/tools/diag/publish_index.py
@@ -2060,9 +2060,7 @@ def _as_text_preview(path: Path, max_bytes: int = MIRROR_TEXT_LIMIT) -> str:
         ]
         for info in infos[:200]:
             lines.append(
-                "- {0} (compressed {1:,} bytes -> {2:,} bytes)".format(
-                    info.filename, info.compress_size, info.file_size
-                )
+                f"- {info.filename} (compressed {info.compress_size:,} bytes -> {info.file_size:,} bytes)"
             )
         if len(infos) > 200:
             lines.append(f"- ... {len(infos) - 200} additional entries omitted ...")

--- a/tools/diag/publish_index.py
+++ b/tools/diag/publish_index.py
@@ -1621,7 +1621,7 @@ def _iterate_status_display(
     lowered = normalized.lower()
     # derived requirement: people and agents routinely escalated on the word
     # "missing" when CI was actually green and iterate intentionally skipped.
-    # Only treat the run as green when there is explicit success evidence —
+    # Only treat the run as green when there is explicit success evidence --
     # either the STATUS.txt keyword or a confirmed success conclusion from run.json
     # (batch_passed=True). A bare run-id format is NOT sufficient because
     # _batch_status emits that format whenever an archive exists, even for
@@ -2060,7 +2060,7 @@ def _as_text_preview(path: Path, max_bytes: int = MIRROR_TEXT_LIMIT) -> str:
         ]
         for info in infos[:200]:
             lines.append(
-                "- {0} (compressed {1:,} bytes → {2:,} bytes)".format(
+                "- {0} (compressed {1:,} bytes -> {2:,} bytes)".format(
                     info.filename, info.compress_size, info.file_size
                 )
             )
@@ -3767,16 +3767,16 @@ def _build_markdown(
             normalized = _absolute_site_href(context, rel, run_scoped=True)
             display_name = Path(rel).name
             size_bytes = _safe_file_size(file)
-            size = f"{size_bytes:,} bytes" if size_bytes is not None else "—"
+            size = f"{size_bytes:,} bytes" if size_bytes is not None else "--"
             mirror_obj = ensure_txt_mirror(file)
             if mirror_obj and mirror_obj.exists():
                 mirror_rel = _relative_to_diag(mirror_obj, diag)
                 mirror_link = _absolute_site_href(context, mirror_rel, run_scoped=True)
                 lines.append(
-                    f"- {display_name}: [Preview (.txt)]({mirror_link}) ([Download]({normalized})) — {size}"
+                    f"- {display_name}: [Preview (.txt)]({mirror_link}) ([Download]({normalized})) -- {size}"
                 )
             else:
-                lines.append(f"- {display_name}: [Download]({normalized}) — {size}")
+                lines.append(f"- {display_name}: [Download]({normalized}) -- {size}")
 
     inventory_lines = _resolve_inventory_lines(context)
     if inventory_lines:
@@ -4186,7 +4186,7 @@ def _write_html(
             href = _escape_href(normalized)
             text = _escape_html(Path(rel).as_posix())
             size_bytes = _safe_file_size(file)
-            size_text = f"{size_bytes:,} bytes" if size_bytes is not None else "—"
+            size_text = f"{size_bytes:,} bytes" if size_bytes is not None else "--"
             size = _escape_html(size_text)
             mirror_obj = ensure_txt_mirror(file)
             if mirror_obj and mirror_obj.exists():
@@ -4195,7 +4195,7 @@ def _write_html(
                 mirror_href = _escape_href(mirror_norm)
                 html.append(
                     "<li>{0}: <a href=\"{1}\">Preview (.txt)</a> "
-                    "(<a href=\"{2}\">Download</a>) — {3}</li>".format(
+                    "(<a href=\"{2}\">Download</a>) -- {3}</li>".format(
                         text,
                         mirror_href or "",
                         href or "",
@@ -4204,7 +4204,7 @@ def _write_html(
                 )
             else:
                 html.append(
-                    f"<li>{text}: <a href=\"{href}\">Download</a> — {size}</li>"
+                    f"<li>{text}: <a href=\"{href}\">Download</a> -- {size}</li>"
                 )
         html.append("</ul>")
         html.append("</section>")

--- a/tools/run_prechecks.ps1
+++ b/tools/run_prechecks.ps1
@@ -63,10 +63,10 @@ function Get-TableRow {
     )
 
     switch ($Status) {
-        'passed' { return '✅ Passed' }
-        'failed' { return '❌ Failed' }
-        'warning' { return '⚠️ Warning' }
-        'skipped' { return '➖ Skipped' }
+        'passed' { return '[PASS] Passed' }
+        'failed' { return '[FAIL] Failed' }
+        'warning' { return '[WARN] Warning' }
+        'skipped' { return '[-] Skipped' }
         default { return $Status }
     }
 }


### PR DESCRIPTION
## Summary

Two independent, low-risk commits, both owner-authorized ("if confident then implement or register open question. Remove all non ascii while you are at it so ascii sweep repo wide reports clean too").

- **`400574f` chore: repo-wide ASCII cleanup.** Replaced non-ASCII glyphs (em/en dashes, arrows, checkmark/cross/warning emoji, bullets) with ASCII equivalents across `.github/workflows/batch-check.yml`, `.github/workflows/pr-automerge.yml`, `tools/diag/publish_index.py`, `tools/run_prechecks.ps1`, and 6 `promo/*.svg` files. Found and fixed a real bug along the way: `--` is illegal inside XML `<!-- ... -->` comment content (not just at the delimiters) -- 3 SVGs briefly broke XML parsing until fixed to use a single hyphen there instead; all 6 SVGs re-verified via `xml.dom.minidom.parse()`. 4 promo PNGs were confirmed (via `file`) to be genuine binary image data, not text with false-positive matches, and were left untouched. `tools/run_sanity_sweep.sh`'s repo-wide ASCII sweep now reports clean.
- **`7610ad6` ci: move conda_avail to right after the real first-install step (unwired).** Step 1 of the staged conda_avail re-wiring plan from CLAUDE.md's Active Backlog: the existing `conda_avail` diagnostic step (currently unused after PR #391's revert) is relocated from right after "Bootstrap environment" (which never touches conda -- it runs against this repo's own empty root) to right after `selfapps_envsmoke.ps1` ("Self-test: real env smoke (CI-only)"), the genuine first selfapps step that performs a real, unconditional `run_setup.bat` bootstrap under `HP_FORCE_CONDA_ONLY=1`. Deliberately left with **zero `if:` conditions referencing it** in this commit -- this mechanism has already produced two real, independently-discovered bugs in quick succession (the original premature-gate design in #390, a CodeRabbit-caught wording slip on #392), so this lands the corrected *position* on its own first, verifiable via the step's own log output on the next `conda-full` run, before any gating logic is reintroduced in a follow-up PR.

CLAUDE.md updated in the same commit with the full trace and staging rationale.

## Test plan

- [x] `python -m compileall -q .`
- [x] `python -m pyflakes .`
- [x] `python tools/check_delimiters.py run_setup.bat`
- [x] `markdownlint-cli2 CLAUDE.md` (clean, only the expected permanent baseline finding)
- [x] `python -m yamllint .github/workflows/`
- [x] `actionlint -oneline .github/workflows/*.yml`
- [x] Repo-wide ASCII sweep -- clean
- [x] PowerShell AST parse sweep (tests/*.ps1, tools/*.ps1)
- [x] `python -m pytest tests/test_*.py -q` (437 passed, 2 skipped)
- [x] 6 modified SVGs re-verified as valid XML via `xml.dom.minidom.parse()`
- [x] Full `tools/run_sanity_sweep.sh` run, all checks OK

Claude-Session: https://claude.ai/code/session_015xbWLPbiaKVsobB9FZy8kS


---
_Generated by [Claude Code](https://claude.ai/code/session_015xbWLPbiaKVsobB9FZy8kS)_