### PR TITLE
ci: add missing backslash-variant artifact path for test-results.ndjson

### DIFF
--- a/.github/workflows/batch-check.yml
+++ b/.github/workflows/batch-check.yml
@@ -1885,6 +1885,7 @@ jobs:
             tests\~selftest-summary.txt
             tests/~test-summary.txt
             tests/~test-results.ndjson
+            tests\~test-results.ndjson
             tests/extracted/**
           if-no-files-found: ignore
           include-hidden-files: true


### PR DESCRIPTION
## Summary

Follow-up to #394 (already merged), addressing a CodeRabbit re-review finding that landed after that PR's CI run started (so it's shipping as its own small, one-line commit rather than being squeezed into an already-in-flight run).

- **`d5efdac` ci: add missing backslash-variant artifact path for test-results.ndjson.** `.github/workflows/batch-check.yml`'s "Upload test logs" step listed `tests/~test-results.ndjson` (forward-slash) but was missing its required backslash sibling `tests\~test-results.ndjson`. This is a real, pre-existing gap (not introduced by #394 -- that PR only relocated an unrelated diagnostic step elsewhere in the file) -- every other entry in that same path list carries both spellings, per this repo's own convention (AGENTS.md: "any new observable log line, disk file, or assertion-detectable behavior must produce an NDJSON row and have its artifact path added to the `batch-check.yml` test-logs upload using both existing slash-style variants").

## Test plan

- [x] `python -m compileall -q .`
- [x] `python -m pyflakes .`
- [x] `python tools/check_delimiters.py run_setup.bat`
- [x] `markdownlint-cli2 CLAUDE.md` (clean, only the expected permanent baseline finding)
- [x] `python -m yamllint .github/workflows/`
- [x] `actionlint -oneline .github/workflows/*.yml`
- [x] Repo-wide ASCII sweep -- clean
- [x] PowerShell AST parse sweep (tests/*.ps1, tools/*.ps1)
- [x] `python -m pytest tests/test_*.py -q` (437 passed, 2 skipped)
- [x] Full `tools/run_sanity_sweep.sh` run, all checks OK

Claude-Session: https://claude.ai/code/session_015xbWLPbiaKVsobB9FZy8kS


---
_Generated by [Claude Code](https://claude.ai/code/session_015xbWLPbiaKVsobB9FZy8kS)_