### PR TITLE
docs: confirm conda_avail relocation via first real conda-full run

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -833,6 +833,18 @@ further.)*
   follow-up commit. Watch that first run closely before proceeding to step 2 (wiring the 27
   conditions).
 
+  **First real `conda-full` run watched, 2026-07-27 (PR #395's merge run, run 30266482736):
+  confirmed positive.** Downloaded the `ci_test_results-selftest-conda-full-30266482736-1`
+  artifact directly (not just the console log) and read the `diag.conda.available` NDJSON row:
+  `{"id":"diag.conda.available","pass":true,"desc":"Miniconda availability diagnostic
+  (non-gating, unwired)","details":{"available":true}}` -- `available` flips to `true` exactly as
+  predicted, confirming the relocated step's premise now genuinely holds in this repo's real CI
+  shape. **This is read-only verification only, not authorization to proceed to step 2.** The
+  owner's explicit go-ahead already covered (and was scoped to) step 1's move; step 2 (wiring the
+  27 `if:` conditions) still needs its own separate, explicit go-ahead per the reasoning above --
+  two independent bugs from this exact mechanism is reason enough to keep that a deliberate,
+  owner-confirmed step rather than something a single green run alone unlocks.
+
 ## Cold Storage (promising ideas, deliberately shelved -- revisit only if a named trigger fires)
 
 **Scope, and how this differs from Active Backlog and Known Findings**: an Active Backlog item is


### PR DESCRIPTION
## Summary

Doc-only follow-up closing the verification loop CLAUDE.md's own conda_avail relocation note (PR #394) asked for: "Watch that first run closely before proceeding to step 2 (wiring the 27 conditions)."

- Downloaded the `ci_test_results-selftest-conda-full-*` NDJSON artifact directly from PR #395's merge run (30266482736) rather than relying on the console log, and confirmed the `diag.conda.available` row: `{"id":"diag.conda.available","pass":true,...,"details":{"available":true}}` -- `available` correctly flips to `true` now that the step sits after `selfapps_envsmoke.ps1`'s real conda install, exactly as the relocation predicted.
- This is read-only verification only, not a step-2 implementation. Wiring the 27 `if:` conditions to `conda_avail` still needs its own separate, explicit owner sign-off, per the existing reasoning in CLAUDE.md (two independent bugs already came out of this exact mechanism across PR #390/#391/#392).

## Test plan

- [x] `tools/run_sanity_sweep.sh CLAUDE.md` -- all checks OK (doc-only diff, no code touched)

Claude-Session: https://claude.ai/code/session_015xbWLPbiaKVsobB9FZy8kS


---
_Generated by [Claude Code](https://claude.ai/code/session_015xbWLPbiaKVsobB9FZy8kS)_