### PR TITLE
ci: add top-level lane field to conda_avail/conda_avail_gate NDJSON rows

### DIFF
--- a/.github/workflows/batch-check.yml
+++ b/.github/workflows/batch-check.yml
@@ -371,6 +371,7 @@ jobs:
           # paired tripwire step immediately below) -- it only ever reports the observed fact.
           $row = [ordered]@{
             id      = 'diag.conda.available'
+            lane    = $env:HP_CI_LANE
             pass    = $true
             desc    = 'Miniconda availability diagnostic (raw fact only; see diag.conda.available.gate for the enforced judgment)'
             details = [ordered]@{ available = $avail }
@@ -406,9 +407,10 @@ jobs:
           if ($env:HP_CI_LANE -ne 'conda-full') {
             $row = [ordered]@{
               id      = 'diag.conda.available.gate'
+              lane    = $env:HP_CI_LANE
               pass    = $true
               desc    = 'Miniconda availability gate (enforced judgment; conda-full only)'
-              details = [ordered]@{ skip = $true; reason = 'not-conda-full'; lane = $env:HP_CI_LANE }
+              details = [ordered]@{ skip = $true; reason = 'not-conda-full' }
             } | ConvertTo-Json -Compress -Depth 8
             $row | Add-Content 'tests\~test-results.ndjson' -Encoding Ascii
             $row | Add-Content 'ci_test_results.ndjson' -Encoding Ascii
@@ -417,6 +419,7 @@ jobs:
           if ($avail -eq 'true') {
             $row = [ordered]@{
               id      = 'diag.conda.available.gate'
+              lane    = $env:HP_CI_LANE
               pass    = $true
               desc    = 'Miniconda availability gate (enforced judgment; conda-full only)'
               details = [ordered]@{ available = $avail }
@@ -427,6 +430,7 @@ jobs:
           }
           $row = [ordered]@{
             id      = 'diag.conda.available.gate'
+            lane    = $env:HP_CI_LANE
             pass    = $false
             desc    = 'Miniconda availability gate (enforced judgment; conda-full only)'
             details = [ordered]@{ available = $avail }


### PR DESCRIPTION
## Summary

Follow-up to #397 (already merged), addressing a CodeRabbit finding that landed after that PR's own CI run had already started (so it's shipping as its own small commit rather than being squeezed into an already-in-flight run, same pattern as #395/#396).

- `HP_CI_LANE` is documented to tag every NDJSON row via a top-level `lane` field, and every other row emitted in this job already does this (confirmed directly against a real `conda-full` artifact from #397's own merge run). The two new `diag.conda.available`/`diag.conda.available.gate` row shapes introduced by #397 omitted it.
- Added `lane = $env:HP_CI_LANE` to all four manually-constructed row shapes (the `diag.conda.available` row, and the skip/pass/fail shapes of `diag.conda.available.gate`), and removed the now-redundant `lane` key that had been nested under `details` in the skip shape.

Pure additive/consistency fix -- no logic change, no behavior change to the gate or tripwire themselves.

## Test plan

- [x] `python -m compileall -q .`
- [x] `python -m pyflakes .`
- [x] `python tools/check_delimiters.py run_setup.bat`
- [x] `markdownlint-cli2 CLAUDE.md` (clean, only the expected permanent baseline finding)
- [x] `python -m yamllint .github/workflows/`
- [x] `actionlint -oneline .github/workflows/*.yml`
- [x] Repo-wide ASCII sweep -- clean
- [x] PowerShell AST parse sweep (tests/*.ps1, tools/*.ps1)
- [x] `python -m pytest tests/test_*.py -q` (437 passed, 2 skipped)
- [x] Full `tools/run_sanity_sweep.sh` run, all checks OK

Claude-Session: https://claude.ai/code/session_015xbWLPbiaKVsobB9FZy8kS


---
_Generated by [Claude Code](https://claude.ai/code/session_015xbWLPbiaKVsobB9FZy8kS)_