### PR TITLE
fix: backlog items 8, 14, 19 -- UNC WARN, misleading syntax error, cache-lane trap

### DIFF
--- a/.github/workflows/batch-check.yml
+++ b/.github/workflows/batch-check.yml
@@ -92,6 +92,8 @@ jobs:
         id: cache_health
         continue-on-error: true
         shell: pwsh
+        env:
+          HP_CACHE_EXACT_HIT: ${{ steps.conda_cache_restore.outputs.cache-hit }}
         run: |
           $condaMain = 'C:\Users\Public\Documents\Miniconda3\condabin\conda.bat'
           $condaAlt  = 'C:\Users\Public\Documents\Miniconda3\Scripts\conda.bat'
@@ -101,8 +103,37 @@ jobs:
           } else {
             $output = & cmd /c "`"$condaBat`" info" 2>&1
             if ($LASTEXITCODE -ne 0) {
-              Write-Host "::warning::Conda binary health check failed (exit=$LASTEXITCODE); cache corrupted."
-              'HP_CACHE_CORRUPTED=1' | Out-File -FilePath $env:GITHUB_ENV -Encoding ascii -Append
+              if ($env:HP_CACHE_EXACT_HIT -eq 'true') {
+                # derived requirement: an EXACT primary-key hit that's corrupted can never be
+                # replaced in place (a GitHub Actions cache entry's blob is immutable once saved
+                # under a key) -- see CLAUDE.md's cache-lane self-perpetuating-corruption item
+                # (formerly Active Backlog item 19) for the full trace. Keep the original
+                # skip-this-run behavior for this narrow case; fully closing it needs an explicit
+                # cache-deletion API call, a smaller follow-on not implemented here.
+                Write-Host "::warning::Conda binary health check failed (exit=$LASTEXITCODE) on an EXACT cache-key hit; cache corrupted, skipping fast-path tests this run."
+                'HP_CACHE_CORRUPTED=1' | Out-File -FilePath $env:GITHUB_ENV -Encoding ascii -Append
+              } else {
+                # derived requirement: a restore-keys PREFIX match (the common case -- the cache
+                # key hashes run_setup.bat, which changes on nearly every PR) is not a guarantee
+                # the restored blob is still valid. Treating this like HP_CACHE_CORRUPTED=1 was
+                # the actual bug: the ONLY step that can do a fresh install is gated on that same
+                # flag, so a poisoned blob could never be replaced -- a permanent, self-
+                # perpetuating loop. Fix: treat it like a genuine cache miss instead -- delete the
+                # stale directory and let the run fall through to a real fresh install and a real
+                # fresh save under the current key, breaking the loop.
+                Write-Host "::warning::Conda binary health check failed (exit=$LASTEXITCODE) on a restore-keys prefix match; deleting stale cache directory and proceeding as a fresh install."
+                Remove-Item -LiteralPath 'C:\Users\Public\Documents\Miniconda3' -Recurse -Force -ErrorAction SilentlyContinue
+                if (Test-Path 'C:\Users\Public\Documents\Miniconda3') {
+                  # derived requirement: same AV/indexer file-lock hazard class already documented
+                  # for :try_embed_fallback's own directory swap in run_setup.bat -- if deletion
+                  # didn't fully succeed, do not proceed into an uncertain half-deleted state;
+                  # fall back to the original, safe skip-this-run behavior instead.
+                  Write-Host "::warning::Stale cache directory could not be fully removed (possible file lock); falling back to HP_CACHE_CORRUPTED=1 for this run."
+                  'HP_CACHE_CORRUPTED=1' | Out-File -FilePath $env:GITHUB_ENV -Encoding ascii -Append
+                } else {
+                  Write-Host "Stale cache directory removed; fresh install will proceed normally."
+                }
+              }
             } else {
               Write-Host "Conda health OK: $output"
             }

--- a/.github/workflows/batch-check.yml
+++ b/.github/workflows/batch-check.yml
@@ -106,8 +106,8 @@ jobs:
               if ($env:HP_CACHE_EXACT_HIT -eq 'true') {
                 # derived requirement: an EXACT primary-key hit that's corrupted can never be
                 # replaced in place (a GitHub Actions cache entry's blob is immutable once saved
-                # under a key) -- see CLAUDE.md's cache-lane self-perpetuating-corruption item
-                # (formerly Active Backlog item 19) for the full trace. Keep the original
+                # under a key) -- see docs/agent-closed-backlog.md's Item 19 (cache-lane
+                # self-perpetuating-corruption) for the full trace. Keep the original
                 # skip-this-run behavior for this narrow case; fully closing it needs an explicit
                 # cache-deletion API call, a smaller follow-on not implemented here.
                 Write-Host "::warning::Conda binary health check failed (exit=$LASTEXITCODE) on an EXACT cache-key hit; cache corrupted, skipping fast-path tests this run."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -565,57 +565,6 @@ start at 1 and has gaps.
    reproducible gap (in which case the test's own pass/fail logic may need tightening) or a
    one-off artifact of this particular run's CI-runner path layout.
 
-- **14. Total REQ-009 provider-tier exhaustion produces a MISLEADING "your program has a syntax
-   error" final message instead of surfacing the real "no Python interpreter found" cause -- found
-   2026-07-31 while sweeping `run_setup.bat` line-by-line for `docs/demo-bootstrapper-output.md`
-   coverage gaps, confirmed against real CI evidence and the actual source, not just theorized.**
-   `:after_env_mode_selection`'s own guard (`run_setup.bat`, right after
-   `:conda_base_update`/`:emit_from_base64 "~prep_requirements.py"`) does
-   `if not defined HP_PY ( call :die "[ERROR] Active Python interpreter not resolved." )` -- but
-   per this file's own long-documented `:die` semantics (`exit /b` inside `:die` only returns from
-   `:die`'s OWN call frame, never halts the calling code), execution falls straight through to the
-   very next line regardless: `echo Interpreter: %HP_PY%` (printing a blank interpreter path),
-   then an `"%HP_PY%" -c "print('py_ok')" ... || call :log "[WARN] Interpreter smoke test failed
-   (continuing)."` that silently downgrades the failure to a WARN and continues. The bootstrap then
-   proceeds through pipreqs, dependency install, the pyvisa check, and entry selection -- all
-   effectively no-ops against an empty interpreter path -- and finally reaches `:preflight_compile`
-   (REQ-021), whose `"%HP_PY%" -m py_compile "%HP_ENTRY%"` becomes a literal `"" -m py_compile
-   "app.py"` with `HP_PY` empty. cmd.exe cannot execute an empty-quoted command name, producing
-   `'""' is not recognized as an internal or external command, operable program or batch file.` --
-   a CMD.EXE ERROR, NOT A PYTHON TRACEBACK -- which `:preflight_compile` (any nonzero exit is
-   treated as "compile failed," with no distinction between "the interpreter itself couldn't run"
-   and "the interpreter ran and found a real syntax error") unconditionally reports as
-   `*** [ERROR] REQ-021: Your Python program has a syntax error and cannot run. ***` followed by
-   that cmd.exe text and "Fix the syntax error shown above, then run this batch again."
-   **Confirmed via real CI capture** (run `30328748330`, `real` lane, job `90179708091`,
-   `tests/~selftest_embed_decline/`'s own sub-bootstrap -- a test that force-fails EVERY provider
-   tier via `HP_TEST_FORCE_EMBED_FAIL`/`HP_TEST_FORCE_VENV_FAIL`/declined system-Python consent,
-   deterministically reproducing total exhaustion): the log shows exactly this sequence --
-   `[ERROR] Active Python interpreter not resolved.` -> blank `Interpreter:` line -> `[WARN]
-   Interpreter smoke test failed (continuing).` -> a full, unaffected pipreqs/dep-install/VISA/
-   entry-selection sequence -> the misleading REQ-021 syntax-error block quoting the literal
-   `'""' is not recognized...` cmd.exe text. **This is a real, non-test-only reachable scenario**:
-   README's own REQ-009 table already documents that falling through three-plus tiers in one run
-   is "almost always one shared root cause" (no internet, full disk, or a locked-down managed
-   image) -- a real user with no connectivity, no working ambient Python, and who declines the
-   REQ-014 system-Python prompt hits this identical path for genuine, non-test reasons. The
-   test-forced flags in the capture above are a deterministic REPRODUCTION vector, not the only
-   way to trigger it. **`~bootstrap.status.json`'s machine-readable `state` field is NOT
-   affected** -- `:die`'s own already-fixed unconditional `HP_BOOTSTRAP_STATE=error` set (see this
-   file's `:die` entry) still applies before execution falls through, so the status file correctly
-   reads `state: error` regardless of the confusing console narrative; only the human-readable
-   text is misleading, and only for a user who reads just the LAST error rather than scrolling
-   back to the real, earlier "Active Python interpreter not resolved." line. **Not fixed in this
-   pass** -- documentation-only task; `docs/demo-bootstrapper-output.md` documents this exact real
-   capture as its own scenario rather than presenting the misleading text as a genuine syntax-error
-   report. Suggested fix for a future pass: guard `:preflight_compile` (and any other `HP_PY`-using
-   code reachable after `:after_env_mode_selection`'s interpreter-resolution guard) on `HP_PY`
-   actually being a non-empty, existing path before invoking it -- or, more robustly, make the
-   `:after_env_mode_selection` guard itself a `goto`-based hard stop (matching this file's own
-   "Provider-cascade dispatch is goto-based on purpose" pattern) instead of relying on `:die`'s
-   call-frame-only return, so total exhaustion genuinely halts the pipeline at the point of failure
-   rather than continuing for another ~15 log lines under a broken interpreter.
-
 - **15. `:exe_smokerun_hints`'s diagnostic re-run of a freshly-failed EXE has no timeout, unlike
    every other user-code launch point in this file -- found 2026-07-31, flagged by a CodeRabbit
    review on PR #402 while documenting the hint mechanism for

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -593,59 +593,6 @@ start at 1 and has gaps.
    of what's shown) -- but a future pass fixing this should also confirm no currently-passing test
    silently relies on the unbounded behavior before adding a timeout.
 
-- **19. The `cache` CI lane's corruption recovery is a one-way trap: once a restored cache is
-   flagged corrupted, nothing in that lane ever produces a fresh, valid cache again -- found
-   2026-07-31 while investigating a maintainer report that the lane "never works," always logging
-   `Cache corrupted, skipping fast-path tests (HP_CACHE_CORRUPTED=1)`, confirmed against the
-   current `.github/workflows/batch-check.yml` source, not just the symptom report.** Traced the
-   full mechanism: the cache key is `win-...-conda-${{ hashFiles('run_setup.bat') }}-<pipreqs_ver>`
-   with `restore-keys: win-...-conda-` as a prefix fallback. `run_setup.bat` changes on nearly
-   every PR in this repo, so the EXACT primary key rarely matches twice -- the restore step almost
-   always falls through to the `restore-keys` PREFIX match instead, which returns whatever cache
-   blob currently exists under that prefix (GitHub Actions cache entries are immutable once saved;
-   a "stale" blob can only be replaced by a NEW save under a NEW key, never overwritten in place).
-   The "Validate restored conda binary" step (`cache_health`) then runs `conda.bat info` against
-   whatever got restored; on failure it sets `HP_CACHE_CORRUPTED=1` (informational, `exit 0`, by
-   design -- this part is fine). The trap is downstream: the "Bootstrap environment (run_setup.bat)"
-   step -- the ONLY step in this lane capable of performing a fresh Miniconda install -- is gated on
-   `env.HP_CACHE_CORRUPTED != '1'`, so once corruption is flagged, bootstrap is SKIPPED ENTIRELY for
-   that run; no fresh install is ever attempted. The save step (`actions/cache/save`) is gated on
-   BOTH `steps.conda_cache_restore.outputs.cache-hit != 'true'` AND `env.HP_CACHE_CORRUPTED != '1'`
-   -- since a `restore-keys` prefix match reports `cache-hit: false` (only an EXACT primary-key
-   match reports `true`, confirmed against `actions/cache`'s own documented behavior), the
-   `cache-hit` half of the save gate is usually already satisfied when corruption is the actual
-   blocker -- the `HP_CACHE_CORRUPTED` half is what stops the save. Net effect: the SAME poisoned
-   blob (saved once, likely before this health-check mechanism existed, or from a one-off flake)
-   gets restored via the prefix fallback on every subsequent run, is correctly detected as
-   corrupted every time, but the detection itself prevents the one action (a fresh install this
-   run, followed by a fresh save) that would ever replace it -- a permanent, self-perpetuating
-   loop with no exit, fully consistent with "never works, always says corrupted."
-   **Confirmed this is real, not a one-off**: every `if:` gate on the lane's ~25 self-test steps
-   after "Bootstrap environment" already depends on `HP_CACHE_CORRUPTED != '1'`, so once corrupted,
-   the entire lane short-circuits to placeholder `pass:true, skip`-style NDJSON rows
-   (`self.cache.corrupted`) and reports overall green -- exactly the "always green to avoid being
-   gating" behavior observed, and exactly why this has been invisible in CI: nothing ever fails
-   loud enough to surface it as a real problem, it just silently never does its job.
-   **Not fixed in this pass** -- diagnosed only, per the maintainer's own "if you see an easy fix,
-   maybe put that in the backlog" framing; the fix touches shared CI workflow gating logic that
-   ~30 other steps also depend on, and can only be verified by watching real cache-lane runs
-   (multi-cycle, since the fix's own effect -- "does a fresh cache finally get saved" -- isn't
-   observable from a single run), so it doesn't fit safely into a downtime aside. **Suggested fix,
-   reasoned through but not implemented:** on a corruption detection that came from a `restore-keys`
-   PREFIX match specifically (`steps.conda_cache_restore.outputs.cache-hit != 'true'`, i.e. not an
-   exact primary-key hit), delete the corrupted `C:\Users\Public\Documents\Miniconda3` directory
-   and do NOT set `HP_CACHE_CORRUPTED` at all -- let the run fall through exactly like a genuine
-   cache miss (the health-check step's own existing "No conda binary found; fresh install will
-   proceed normally" branch already handles this shape correctly for a true miss). This lets
-   "Bootstrap environment" run a real fresh install, and lets the save step create a genuinely
-   fresh, valid cache entry under the current key afterward, breaking the loop. The narrower case
-   -- an EXACT primary-key hit that's ALSO corrupted (only plausible when `run_setup.bat` is
-   byte-identical to a previously-poisoned save, e.g. two runs on the same unchanged commit) --
-   would still be stuck, since that specific key's blob can never be overwritten; fully closing
-   that gap needs an explicit cache-deletion API call (`gh cache delete` / the GitHub Actions cache
-   REST API, `DELETE /repos/{owner}/{repo}/actions/caches`) gated on `cache-hit == 'true'` at
-   corruption-detection time, a smaller follow-on refinement once the main fix is proven working.
-
 ## Cold Storage (promising ideas, deliberately shelved -- revisit only if a named trigger fires)
 
 Moved to `docs/agent-cold-storage.md` (2026-07-31, to reduce this file's per-session context

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -492,55 +492,6 @@ Once an item is fully resolved it is removed from here entirely and archived (ke
 original number) in `docs/agent-closed-backlog.md`, which is why the numbering below does not
 start at 1 and has gaps.
 
-- **8. `[WARN] UNC paths not supported` fires unconditionally in CI on an ordinary (non-UNC) local
-   path -- found 2026-07-29 while gathering real console-output evidence for
-   `docs/demo-bootstrapper-output.md`'s default-happy-path documentation pass, not yet
-   investigated further.** `run_setup.bat:57-58` does
-   `echo %~dp0 | findstr /C:"\\\\" >nul` / `if not errorlevel 1 echo [WARN] UNC paths not
-   supported` -- per the C-runtime backslash-before-quote rule already documented in
-   `docs/agent-lessons-learned.md` ("A single trailing backslash before a closing quote silently
-   corrupts a subprocess argument"), `\\\\"` collapses to a 2-backslash literal search pattern,
-   so this is searching `%~dp0` for two CONSECUTIVE backslashes anywhere in the string -- not
-   testing for a UNC prefix (that's the separate, independent check two lines below at line 59,
-   `if "%HP_SCRIPT_LAUNCH_DIR:~0,2%"=="\\"`, which prints the louder `*** WARNING: UNC/network
-   paths detected...` banner). Pulled `tests/~envsmoke/~envsmoke_bootstrap.log` (the full,
-   unredirected console capture of a real, non-`HP_CI_SKIP_ENV` bootstrap) from a recent clean
-   green run (`30328748330`, all lanes green) across 6 lanes (`real`, `uv`, `conda-full`,
-   `justme-test`, `contract-uv`, `contract-uv-fail`) and found the `[WARN] UNC paths not
-   supported` line as the very FIRST line of console output in all 6, every single time, against
-   an entirely ordinary CI checkout path (`D:\a\Python_vs_Windows\Python_vs_Windows\tests\
-   ~envsmoke\`) -- not a UNC path by any reasonable definition. No test in the repo asserts on
-   or references this string at all (confirmed via a repo-wide grep), so this has apparently been
-   firing on every single CI run, unnoticed, indefinitely.
-   - **Ruled out one theory directly**: the companion `HP_SCRIPT_LAUNCH_DIR:~0,2` check (tests
-     whether the path literally STARTS with `\\`) never fires in the same logs (zero hits for
-     "UNC/network paths detected" across all 6 lanes) -- so whatever is producing a
-     double-backslash for the `findstr` search must be sitting mid-string, not at the start of
-     `%~dp0`. This is real, if partial, information: it means the failure mode is NOT "the whole
-     checkout path is somehow UNC," which was the first, most obvious guess.
-   - **Root cause NOT identified.** Best unconfirmed guess: something about how GitHub-hosted
-     Windows runners provision the `D:\a\...` work directory (`actions/checkout`'s own path
-     construction, or a junction/reparse point backing that drive) introduces a duplicated
-     separator somewhere in the resolved `%~dp0` value for a batch file invoked from inside it --
-     but this was NOT verified (no way to inspect the raw `%~dp0` bytes directly from this
-     research pass; would need a dedicated diagnostic echo added to a test lane, e.g.
-     temporarily `echo RAW_DP0=[%~dp0]` to a log file, to actually see the string with delimiters
-     visible).
-   - **Whether this also fires for a genuine end-user double-click (not CI, no nested
-     `cmd`/PowerShell invocation, an ordinary local folder) is UNCONFIRMED** -- this sandbox has
-     no Windows machine to test on, and no real end-user report exists either way. If it's
-     CI-runner-specific plumbing, it's cosmetic noise (one extra harmless WARN line, unlikely to
-     confuse a real user since it never fires for them); if it also fires for real users on an
-     ordinary local path, it's a real, previously-unknown false-positive bug worth fixing (most
-     likely fix shape: tighten the `findstr` pattern to require the double-backslash appear
-     specifically in a network-path position, or just remove this redundant check entirely since
-     the very next lines already do a correct, more targeted UNC-prefix check).
-   - **Not investigated further in this pass** -- out of scope for a documentation-only task, and
-     genuinely needs either a dedicated diagnostic-logging CI experiment (cheap, doable in a
-     future loop) or a real Windows machine to resolve with confidence. Documented in
-     `docs/demo-bootstrapper-output.md`'s new default-happy-path scenario as an observed,
-     unexplained anomaly rather than either asserting it's harmless or that it's a bug.
-
 - **10. Two of the five `PVW_*` super-user override variables (`PVW_PYTHON_EXE`, `PVW_WORKSPACE`)
    have ZERO test coverage of any kind, and ALL FIVE have zero coverage of their invalid-value
    behavior -- found 2026-07-29 while documenting them for `docs/demo-bootstrapper-output.md`'s

--- a/docs/agent-closed-backlog.md
+++ b/docs/agent-closed-backlog.md
@@ -583,6 +583,39 @@ this belongs to).
    fix, by design -- see this file's own entry on that loop for why). No behavior changed; this
    was a documentation-only correction.
 
+### Item 8 (closed 2026-08-01)
+
+- **`[WARN] UNC paths not supported` fired unconditionally in CI on an ordinary (non-UNC) local
+   path -- found 2026-07-29 while gathering real console-output evidence for
+   `docs/demo-bootstrapper-output.md`'s default-happy-path documentation pass, not investigated
+   further at the time.** `run_setup.bat:57-58` did
+   `echo %~dp0 | findstr /C:"\\\\" >nul` / `if not errorlevel 1 echo [WARN] UNC paths not
+   supported` -- per the C-runtime backslash-before-quote rule documented in
+   `docs/agent-lessons-learned.md` ("A single trailing backslash before a closing quote silently
+   corrupts a subprocess argument"), `\\\\"` collapsed to a 2-backslash literal search pattern, so
+   this was searching `%~dp0` for two CONSECUTIVE backslashes anywhere in the string -- not testing
+   for a UNC prefix (that's the separate, independent check two lines below,
+   `if "%HP_SCRIPT_LAUNCH_DIR:~0,2%"=="\\"`, which prints the louder `*** WARNING: UNC/network
+   paths detected...` banner). Confirmed firing as the very FIRST line of console output across 6
+   lanes of a real clean CI run (`30328748330`) against an entirely ordinary checkout path
+   (`D:\a\Python_vs_Windows\Python_vs_Windows\tests\~envsmoke\`) -- not a UNC path by any
+   reasonable definition. No test anywhere referenced this string (confirmed via a repo-wide
+   grep), so this had apparently been firing on every single CI run, unnoticed, indefinitely.
+   **Root cause of the double-backslash was never identified** (the companion, correctly-targeted
+   `HP_SCRIPT_LAUNCH_DIR:~0,2` check never fired in the same logs, ruling out "the whole checkout
+   path is UNC" but not pinning down what actually produced it -- possibly something in how
+   GitHub-hosted Windows runners provision the `D:\a\...` work directory). Whether this also fired
+   for a genuine end-user double-click on an ordinary local folder was likewise never confirmed
+   (no Windows machine available to test, no end-user report either way).
+   **Fixed 2026-08-01, without needing the root cause.** The broken check was simply removed --
+   the companion check two lines below it already does the real, correctly-targeted UNC-prefix
+   detection, so the broken/redundant line added nothing worth repairing. Updated
+   `docs/demo-bootstrapper-output.md`'s explanatory paragraph (which had documented this as an
+   "unexplained anomaly") to note the fix and why root-causing the double-backslash became moot;
+   left the real, timestamped console captures containing the old WARN line unedited, since they
+   are historical record of a run that genuinely happened. No test needed updating (none
+   referenced the removed line), and no other call site in `run_setup.bat` depends on it.
+
 ## Closed Backlog
 
 - **Cascade-vs-postexec fix (Active Backlog item 9), 2026-07-25, owner-directed follow-up to a

--- a/docs/agent-closed-backlog.md
+++ b/docs/agent-closed-backlog.md
@@ -588,15 +588,15 @@ this belongs to).
 - **`[WARN] UNC paths not supported` fired unconditionally in CI on an ordinary (non-UNC) local
    path -- found 2026-07-29 while gathering real console-output evidence for
    `docs/demo-bootstrapper-output.md`'s default-happy-path documentation pass, not investigated
-   further at the time.** `run_setup.bat:57-58` did
+   further at the time.** The unlabeled prologue in `run_setup.bat` did
    `echo %~dp0 | findstr /C:"\\\\" >nul` / `if not errorlevel 1 echo [WARN] UNC paths not
-   supported` -- per the C-runtime backslash-before-quote rule documented in
-   `docs/agent-lessons-learned.md` ("A single trailing backslash before a closing quote silently
-   corrupts a subprocess argument"), `\\\\"` collapsed to a 2-backslash literal search pattern, so
-   this was searching `%~dp0` for two CONSECUTIVE backslashes anywhere in the string -- not testing
-   for a UNC prefix (that's the separate, independent check two lines below,
-   `if "%HP_SCRIPT_LAUNCH_DIR:~0,2%"=="\\"`, which prints the louder `*** WARNING: UNC/network
-   paths detected...` banner). Confirmed firing as the very FIRST line of console output across 6
+   supported` -- its exact internal parsing (how `findstr`'s own additional backslash-doubling
+   behavior interacts with cmd.exe's own C-runtime backslash-before-quote argument parsing,
+   documented in `docs/agent-lessons-learned.md`) was never independently verified; what WAS
+   confirmed empirically is that it did not correctly gate on a UNC prefix (that's the separate,
+   independent check two lines below, `if "%HP_SCRIPT_LAUNCH_DIR:~0,2%"=="\\"`, which prints the
+   louder `*** WARNING: UNC/network paths detected...` banner). Confirmed firing as the very FIRST
+   line of console output across 6
    lanes of a real clean CI run (`30328748330`) against an entirely ordinary checkout path
    (`D:\a\Python_vs_Windows\Python_vs_Windows\tests\~envsmoke\`) -- not a UNC path by any
    reasonable definition. No test anywhere referenced this string (confirmed via a repo-wide

--- a/docs/agent-closed-backlog.md
+++ b/docs/agent-closed-backlog.md
@@ -655,18 +655,47 @@ this belongs to).
    disproportionate risk for this fix, since it would require tracing every call-stack depth
    `:after_env_mode_selection` can be reached from, including REQ-009 cascade re-entry). Instead,
    `:preflight_compile` checks `HP_NO_INTERPRETER` first and, if set, reports the real cause
-   ("No Python interpreter is available; your program was not run or built... See the earlier
-   [ERROR] Active Python interpreter not resolved. message above") instead of running
-   `py_compile` against an empty interpreter path, sets `HP_PREFLIGHT_FAILED=1`, and returns --
-   which also means `:run_entry_smoke`'s pre-existing `HP_PREFLIGHT_FAILED` check skips the doomed
-   PyInstaller build attempt entirely, not just the misleading message. Verified: no test in the
-   repo asserted on the old misleading text (confirmed via grep) -- the one test reaching this
-   code path, `self.embed.fallback.decline`, gates on the embed-attempt/forced-failure log lines,
-   their relative order, and `state: error`, none of which this fix touches; the genuine
-   syntax-error path (`tests/selfapps_preflight.ps1`) is untouched since it never sets
-   `HP_NO_INTERPRETER`. `tests/harness.ps1`'s `batch.preflight.compile` static check (subroutine +
-   call site + `py_compile` + REQ-021 message + `HP_PREFLIGHT_FAILED` guard, all presence-only)
-   still passes unchanged.
+   (a self-contained "No Python interpreter is available; your program was not run or built...
+   Either every automatic Python-acquisition method -- uv, conda, a fresh download, or a local
+   virtual environment -- failed... or a PVW_PYTHON_EXE override points at a path that does not
+   run" message) instead of running `py_compile` against an empty interpreter path, sets
+   `HP_PREFLIGHT_FAILED=1`, and returns -- which also means `:run_entry_smoke`'s pre-existing
+   `HP_PREFLIGHT_FAILED` check skips the doomed PyInstaller build attempt entirely, not just the
+   misleading message. Verified: no test in the repo asserted on the old misleading text
+   (confirmed via grep) -- the one test reaching this code path, `self.embed.fallback.decline`,
+   gates on the embed-attempt/forced-failure log lines, their relative order, and `state: error`,
+   none of which this fix touches; the genuine syntax-error path (`tests/selfapps_preflight.ps1`)
+   is untouched since it never sets `HP_NO_INTERPRETER`. `tests/harness.ps1`'s
+   `batch.preflight.compile` static check (subroutine + call site + `py_compile` + REQ-021
+   message + `HP_PREFLIGHT_FAILED` guard, all presence-only) still passes unchanged.
+   **A genuine batch-syntax regression shipped in the first version of this fix, caught by real CI
+   before merge (same PR, commit `fd52a3f`), not caught by any local check first.** The first
+   wording of the new echo block split one logical parenthetical across two `echo` lines --
+   `(uv, conda, a fresh download, a` on one line, `local virtual environment) failed -- ...` on
+   the next -- both lines sitting inside the enclosing `if defined HP_NO_INTERPRETER ( ... )`
+   parenthesized block. cmd.exe's block parser counts every `(`/`)` character in a parenthesized
+   block's text, including inside plain `echo` statements, regardless of intent -- it does not
+   understand "this is prose, not block structure." The `)` on the second line was read as
+   prematurely closing the `if` block, and the very next token, `failed`, was then parsed as a
+   stray top-level command, producing `failed was unexpected at this time.` -- a real cmd.exe
+   parse error, not a test flake. Because this fires the moment `HP_NO_INTERPRETER` is set
+   (declined/exhausted-provider paths, and the companion canary-probe hardening below), it broke
+   every CI lane whose own self-tests ever reach that state in the same run: `uv`,
+   `contract-uv`, `contract-uv-fail`, `uv-dl-fallback`, `cache`, and `justme-test` all failed on
+   the same commit. `python tools/check_delimiters.py run_setup.bat` did NOT catch this --
+   confirmed a real gap: the checker's paren-balance logic does not currently walk `echo` text
+   inside a block the same way cmd.exe's own parser does. Root-caused by downloading the real
+   `uv`-lane job log via `mcp__github__get_job_logs` (pre-signed blob URL, `curl`'d directly to
+   bypass tool-side truncation on a ~15K-line log) and tracing the exact byte offset where
+   `failed was unexpected at this time.` appeared, immediately after the `[BOOT] REQ-002: Entry
+   selected:` log line -- confirming it was `:preflight_compile`'s own new block, not something
+   unrelated. **Fixed by rewording the message to avoid any `(`/`)` character entirely** (dashes
+   instead of parenthetical asides) rather than escaping the parens with `^` -- simpler and more
+   robust against a future re-wrap of the same prose reintroducing the same hazard. This is the
+   same general hazard class `docs/agent-lessons-learned.md`'s batch-syntax-quirks section already
+   warns about for other constructs (parse-time `%VAR%` expansion, `:log`'s unquoted echo) but had
+   not yet been documented specifically for literal parens split across `echo` lines inside a
+   block -- worth adding there if a future instance recurs.
 
 ### Item 19 (closed 2026-08-01)
 

--- a/docs/agent-closed-backlog.md
+++ b/docs/agent-closed-backlog.md
@@ -616,6 +616,58 @@ this belongs to).
    are historical record of a run that genuinely happened. No test needed updating (none
    referenced the removed line), and no other call site in `run_setup.bat` depends on it.
 
+### Item 14 (closed 2026-08-01)
+
+- **Total REQ-009 provider-tier exhaustion produced a MISLEADING "your program has a syntax
+   error" final message instead of surfacing the real "no Python interpreter found" cause -- found
+   2026-07-31 while sweeping `run_setup.bat` line-by-line for `docs/demo-bootstrapper-output.md`
+   coverage gaps, confirmed against real CI evidence and the actual source, not just theorized.**
+   `:after_env_mode_selection`'s own guard (`run_setup.bat`, right after
+   `:conda_base_update`/`:emit_from_base64 "~prep_requirements.py"`) did
+   `if not defined HP_PY ( call :die "[ERROR] Active Python interpreter not resolved." )` -- but
+   per this file's own long-documented `:die` semantics (`exit /b` inside `:die` only returns from
+   `:die`'s OWN call frame, never halts the calling code), execution fell straight through to the
+   very next line regardless: `echo Interpreter: %HP_PY%` (printing a blank interpreter path),
+   then an `"%HP_PY%" -c "print('py_ok')" ... || call :log "[WARN] Interpreter smoke test failed
+   (continuing)."` that silently downgraded the failure to a WARN and continued. The bootstrap
+   then proceeded through pipreqs, dependency install, the pyvisa check, and entry selection --
+   all effectively no-ops against an empty interpreter path -- and finally reached
+   `:preflight_compile` (REQ-021), whose `"%HP_PY%" -m py_compile "%HP_ENTRY%"` became a literal
+   `"" -m py_compile "app.py"` with `HP_PY` empty. cmd.exe cannot execute an empty-quoted command
+   name, producing `'""' is not recognized as an internal or external command, operable program or
+   batch file.` -- a CMD.EXE ERROR, NOT A PYTHON TRACEBACK -- which `:preflight_compile`
+   unconditionally reported as
+   `*** [ERROR] REQ-021: Your Python program has a syntax error and cannot run. ***`.
+   **Confirmed via real CI capture** (run `30328748330`, `real` lane, job `90179708091`,
+   `tests/~selftest_embed_decline/`'s own sub-bootstrap -- a test that force-fails EVERY provider
+   tier via `HP_TEST_FORCE_EMBED_FAIL`/`HP_TEST_FORCE_VENV_FAIL`/declined system-Python consent,
+   deterministically reproducing total exhaustion). **This was a real, non-test-only reachable
+   scenario**: README's own REQ-009 table already documents that falling through three-plus tiers
+   in one run is "almost always one shared root cause" (no internet, full disk, or a locked-down
+   managed image) -- a real user with no connectivity, no working ambient Python, and who declines
+   the REQ-014 system-Python prompt hits this identical path for genuine, non-test reasons.
+   `~bootstrap.status.json`'s machine-readable `state` field was never affected (`:die`'s own
+   unconditional `HP_BOOTSTRAP_STATE=error` set already applied before the fall-through) -- only
+   the human-readable console text was misleading.
+   **Fixed 2026-08-01.** `:after_env_mode_selection`'s guard now also sets `HP_NO_INTERPRETER=1`
+   before calling `:die` (deliberately did NOT attempt the deeper "make the guard a goto-based
+   hard stop" refactor the original finding floated as the more robust alternative -- judged
+   disproportionate risk for this fix, since it would require tracing every call-stack depth
+   `:after_env_mode_selection` can be reached from, including REQ-009 cascade re-entry). Instead,
+   `:preflight_compile` checks `HP_NO_INTERPRETER` first and, if set, reports the real cause
+   ("No Python interpreter is available; your program was not run or built... See the earlier
+   [ERROR] Active Python interpreter not resolved. message above") instead of running
+   `py_compile` against an empty interpreter path, sets `HP_PREFLIGHT_FAILED=1`, and returns --
+   which also means `:run_entry_smoke`'s pre-existing `HP_PREFLIGHT_FAILED` check skips the doomed
+   PyInstaller build attempt entirely, not just the misleading message. Verified: no test in the
+   repo asserted on the old misleading text (confirmed via grep) -- the one test reaching this
+   code path, `self.embed.fallback.decline`, gates on the embed-attempt/forced-failure log lines,
+   their relative order, and `state: error`, none of which this fix touches; the genuine
+   syntax-error path (`tests/selfapps_preflight.ps1`) is untouched since it never sets
+   `HP_NO_INTERPRETER`. `tests/harness.ps1`'s `batch.preflight.compile` static check (subroutine +
+   call site + `py_compile` + REQ-021 message + `HP_PREFLIGHT_FAILED` guard, all presence-only)
+   still passes unchanged.
+
 ## Closed Backlog
 
 - **Cascade-vs-postexec fix (Active Backlog item 9), 2026-07-25, owner-directed follow-up to a

--- a/docs/agent-closed-backlog.md
+++ b/docs/agent-closed-backlog.md
@@ -668,6 +668,64 @@ this belongs to).
    call site + `py_compile` + REQ-021 message + `HP_PREFLIGHT_FAILED` guard, all presence-only)
    still passes unchanged.
 
+### Item 19 (closed 2026-08-01)
+
+- **The `cache` CI lane's corruption recovery was a one-way trap: once a restored cache was
+   flagged corrupted, nothing in that lane ever produced a fresh, valid cache again -- found
+   2026-07-31 while investigating a maintainer report that the lane "never works," always logging
+   `Cache corrupted, skipping fast-path tests (HP_CACHE_CORRUPTED=1)`, confirmed against the
+   `.github/workflows/batch-check.yml` source, not just the symptom report.** Traced the full
+   mechanism: the cache key is `win-...-conda-${{ hashFiles('run_setup.bat') }}-<pipreqs_ver>`
+   with `restore-keys: win-...-conda-` as a prefix fallback. `run_setup.bat` changes on nearly
+   every PR in this repo, so the EXACT primary key rarely matched twice -- the restore step almost
+   always fell through to the `restore-keys` PREFIX match instead, which returns whatever cache
+   blob currently exists under that prefix (GitHub Actions cache entries are immutable once saved;
+   a "stale" blob can only be replaced by a NEW save under a NEW key, never overwritten in place).
+   The "Validate restored conda binary" step (`cache_health`) then ran `conda.bat info` against
+   whatever got restored; on failure it set `HP_CACHE_CORRUPTED=1` unconditionally. The trap was
+   downstream: the "Bootstrap environment (run_setup.bat)" step -- the ONLY step in this lane
+   capable of performing a fresh Miniconda install -- was gated on `env.HP_CACHE_CORRUPTED != '1'`,
+   so once corruption was flagged, bootstrap was SKIPPED ENTIRELY for that run; no fresh install
+   was ever attempted. The save step (`actions/cache/save`) was gated on BOTH
+   `steps.conda_cache_restore.outputs.cache-hit != 'true'` AND `env.HP_CACHE_CORRUPTED != '1'` --
+   since a `restore-keys` prefix match reports `cache-hit: false`, the `cache-hit` half of the
+   save gate was usually already satisfied when corruption was the actual blocker -- the
+   `HP_CACHE_CORRUPTED` half is what stopped the save. Net effect: the SAME poisoned blob (saved
+   once, likely before this health-check mechanism existed, or from a one-off flake) got restored
+   via the prefix fallback on every subsequent run, was correctly detected as corrupted every
+   time, but the detection itself prevented the one action (a fresh install this run, followed by
+   a fresh save) that would ever replace it -- a permanent, self-perpetuating loop with no exit,
+   fully consistent with "never works, always says corrupted." Confirmed this was real, not a
+   one-off: every `if:` gate on the lane's ~25 self-test steps after "Bootstrap environment"
+   already depended on `HP_CACHE_CORRUPTED != '1'`, so once corrupted, the entire lane
+   short-circuited to placeholder `pass:true, skip`-style NDJSON rows (`self.cache.corrupted`) and
+   reported overall green -- exactly why this had been invisible in CI.
+   **Fixed 2026-08-01, on maintainer instruction not to hold this back for dedicated multi-cycle
+   verification** -- since `cache` is one of the 8 matrix lanes that runs on every future PR
+   regardless of subject, ordinary subsequent work already re-exercises it, so no dedicated
+   verification loop is needed (the earlier "needs multiple real cache-lane CI cycles" concern in
+   `docs/open-questions.md` overweighted the cost of a *dedicated* effort that isn't actually
+   required). Implemented the fix already reasoned through when this item was filed: the
+   "Validate restored conda binary" step now reads `steps.conda_cache_restore.outputs.cache-hit`
+   (passed in via an env var, `HP_CACHE_EXACT_HIT`, to avoid GitHub Actions expression
+   interpolation directly into the PowerShell script body) and branches on it. On an EXACT
+   primary-key hit that's corrupted, behavior is unchanged (`HP_CACHE_CORRUPTED=1`, skip this run)
+   -- that narrower case genuinely cannot be fixed without an explicit cache-deletion API call
+   (`gh cache delete` / `DELETE /repos/{owner}/{repo}/actions/caches`), left as a smaller,
+   not-yet-implemented follow-on. On a `restore-keys` PREFIX match that's corrupted (the common
+   case), the stale `C:\Users\Public\Documents\Miniconda3` directory is now deleted and
+   `HP_CACHE_CORRUPTED` is NOT set, letting the run fall through exactly like a genuine cache miss
+   -- "Bootstrap environment" then runs a real fresh install, and the save step creates a
+   genuinely fresh, valid cache entry under the current key afterward, breaking the loop. Guarded
+   against the same AV/indexer file-lock hazard class already documented elsewhere in this repo
+   for `:try_embed_fallback`'s own directory swap in `run_setup.bat`: if `Remove-Item` doesn't
+   fully clear the directory, the fix falls back to the original safe `HP_CACHE_CORRUPTED=1`
+   skip-this-run behavior rather than proceeding into an uncertain half-deleted state. Verified
+   `python -m yamllint` and `actionlint -oneline` both clean on the modified workflow file before
+   landing; the actual "does a fresh cache finally get saved" effect will be observed
+   opportunistically across this and future PRs' own `cache`-lane runs, not via a dedicated
+   verification loop.
+
 ## Closed Backlog
 
 - **Cascade-vs-postexec fix (Active Backlog item 9), 2026-07-25, owner-directed follow-up to a

--- a/docs/agent-lessons-learned.md
+++ b/docs/agent-lessons-learned.md
@@ -443,6 +443,28 @@ list; the recurring traps that have actually bitten us:
   `%%`) inside `for` bodies in a `.bat` file.
 - **Special characters need escaping/quoting:** `&`, `|`, `<`, `>`, `^`, `!`, `~`, and `%`
   in values require quoting or `^`-escaping; `%` must be doubled (`%%`).
+- **A literal `(`/`)` inside `echo` text is NOT invisible to a parenthesized block's own parser,
+  even split across lines -- confirmed as a real shipped regression, 2026-08-01 (PR #408, commit
+  `fd52a3f`).** cmd.exe buffers an entire `if (...)`/`for (...)` block by counting `(`/`)`
+  characters in the raw text between the opening `(` and its match -- it has no concept of "this
+  paren is just prose inside an `echo` line," so a stray `(` on one `echo` line and its matching
+  `)` on the NEXT `echo` line (e.g. a hand-wrapped sentence like `method (uv, conda, a fresh
+  download, a` / `local virtual environment) failed ...`) reads as a real block-closing paren the
+  instant the parser reaches it -- the block ends there, and whatever plain-text token follows the
+  `)` (here, the word `failed`) is parsed as a new top-level command, producing
+  `failed was unexpected at this time.` This shipped in a new `:preflight_compile` message block
+  (the item-14 fix, see `docs/agent-closed-backlog.md`'s Item 14 entry for the full trace) and
+  broke every CI lane whose own self-tests reach that branch in the same run (6 lanes failed
+  simultaneously on one commit) -- caught by real CI, not by any local check: `python
+  tools/check_delimiters.py run_setup.bat` passed clean on the broken version, a confirmed gap in
+  that tool (its paren-balance logic does not currently walk `echo`/prose text inside a block the
+  way cmd.exe's own parser does). **Rule of thumb: never let a `(` and its matching `)` land on
+  different lines inside any parenthesized `.bat` block, even inside `echo`/prose text that looks
+  purely cosmetic.** Either keep the pair on the same line, avoid literal parens in wrapped prose
+  entirely (prefer ` -- ` or `,`), or escape both with `^(`/`^)` if the parens are structurally
+  necessary. When manually reviewing a new multi-line `echo` block inside an `if`/`for` block,
+  count parens per-line as part of the review, not just per-block -- `check_delimiters.py`'s
+  current implementation will not catch an imbalance introduced this way.
 - **Avoid `EnableDelayedExpansion`; if unavoidable, wrap it tightly.** `!` becomes special
   under delayed expansion, and a parent shell launched with `/V:ON` causes `!`-collisions.
   `tests/harness.ps1` `batch.bang.scan` enforces "no `!` in live batch code lines."

--- a/docs/demo-bootstrapper-output.md
+++ b/docs/demo-bootstrapper-output.md
@@ -645,16 +645,17 @@ Tue 07/28/2026  4:29:43.96 [INFO] REQ-015: Appending standard ignores to .gitign
 **The very first console line above (`[WARN] UNC paths not supported`) is historical, from the
 captured run, and no longer appears -- fixed since this capture, kept here unedited because it is
 a real, timestamped log.** It came from a broken, redundant top-of-file `findstr`-based check (in
-the file's unlabeled prologue before the first `:label`): `findstr /C:"\\\\"` (searching for two
-literal backslashes) actually collapsed to a search for ONE literal backslash before the closing
-quote, per the C-runtime backslash-before-quote parsing rule documented in
-`docs/agent-lessons-learned.md`, so it fired on 6/6 checked lanes against an entirely ordinary
-local CI checkout path (`D:\a\Python_vs_Windows\Python_vs_Windows\tests\~envsmoke\`) -- not a UNC
-path. The companion, independent, correctly-targeted UNC-prefix check a couple of lines below it
-(`if "%HP_SCRIPT_LAUNCH_DIR:~0,2%"=="\\"`, which prints the much louder `*** WARNING: UNC/network
-paths detected...` banner) already covered the real UNC-detection job on its own, so the broken
-check was simply removed rather than repaired -- see CLAUDE.md's Closed Backlog (formerly Active
-Backlog item 8) for the full trace.
+the file's unlabeled prologue before the first `:label`): `findstr /C:"\\\\"` was intended to
+match a UNC-style double-backslash but did not correctly gate on one -- its exact internal parsing
+(`findstr`'s own additional backslash-doubling behavior layered on cmd.exe's own C-runtime
+backslash-before-quote argument parsing, documented in `docs/agent-lessons-learned.md`) was never
+independently verified. What WAS confirmed is that it fired on 6/6 checked lanes against an
+entirely ordinary local CI checkout path (`D:\a\Python_vs_Windows\Python_vs_Windows\tests\
+~envsmoke\`) -- not a UNC path. The companion, independent, correctly-targeted UNC-prefix check a
+couple of lines below it (`if "%HP_SCRIPT_LAUNCH_DIR:~0,2%"=="\\"`, which prints the much louder
+`*** WARNING: UNC/network paths detected...` banner) already covered the real UNC-detection job on
+its own, so the broken check was simply removed rather than repaired -- see
+`docs/agent-closed-backlog.md`'s Item 8 for the full trace.
 
 Between that line and `REQ-015`, nothing else prints -- `HP_APP_ARGS` capture (REQ-026, pure
 variable assignment), the workspace-path-exists check, `cd /d`, and `HP_SCRIPT_ROOT` construction

--- a/docs/demo-bootstrapper-output.md
+++ b/docs/demo-bootstrapper-output.md
@@ -2301,20 +2301,23 @@ again. ***`. `~bootstrap.status.json` correctly reads `state: error`; the depend
 environment creation that ran BEFORE this check are left intact (nothing is torn down), so a fixed
 file on the next run reuses them.
 
-**A real, previously-undocumented bug, found via this exact sweep and confirmed against a real,
-unrelated capture (not fabricated for this scenario)**: `:preflight_compile` invokes `"%HP_PY%" -m
-py_compile "%HP_ENTRY%"` with NO check that `HP_PY` is actually a valid, non-empty interpreter path
-first. On TOTAL REQ-009 provider-tier exhaustion (every tier fails or is declined -- see CLAUDE.md
-Active Backlog item 14 for the full trace), `:after_env_mode_selection`'s own `HP_PY`-resolved guard
-(`call :die "[ERROR] Active Python interpreter not resolved."`) does NOT actually halt the pipeline
--- per this repo's own long-documented `:die` semantics, `exit /b` inside `:die` only returns from
-`:die`'s own call frame, so execution falls through and continues for another ~15 log lines with an
-EMPTY `HP_PY`, all the way to `:preflight_compile`. There, `"" -m py_compile "app.py"` is not a
-Python invocation at all -- it is cmd.exe trying to execute a program literally named `""`, which
-produces a CMD.EXE ERROR, not a Python traceback. Because `:preflight_compile` treats ANY nonzero
-exit as "syntax error," it reports this as if the user's own code were broken. Real capture, from a
-test that deliberately force-fails uv (offline), conda, the embed tier, and venv, and declines the
-REQ-014 system-Python prompt (`tests/~selftest_embed_decline/`'s own sub-bootstrap):
+**A real bug, found via this exact sweep, confirmed against a real, unrelated capture (not
+fabricated for this scenario), and FIXED 2026-08-01 (formerly CLAUDE.md Active Backlog item 14,
+now in `docs/agent-closed-backlog.md`).** The capture below is historical, from before the fix,
+kept unedited as a real, timestamped log. `:preflight_compile` used to invoke `"%HP_PY%" -m
+py_compile "%HP_ENTRY%"` with no check that `HP_PY` was actually a valid, non-empty interpreter
+path first. On TOTAL REQ-009 provider-tier exhaustion (every tier fails or is declined),
+`:after_env_mode_selection`'s own `HP_PY`-resolved guard
+(`call :die "[ERROR] Active Python interpreter not resolved."`) does NOT actually halt the
+pipeline -- per this repo's own long-documented `:die` semantics, `exit /b` inside `:die` only
+returns from `:die`'s own call frame, so execution fell through and continued for another ~15 log
+lines with an EMPTY `HP_PY`, all the way to `:preflight_compile`. There, `"" -m py_compile
+"app.py"` was not a Python invocation at all -- it was cmd.exe trying to execute a program
+literally named `""`, which produces a CMD.EXE ERROR, not a Python traceback. Because
+`:preflight_compile` treated ANY nonzero exit as "syntax error," it reported this as if the user's
+own code were broken. Real capture, from a test that deliberately force-fails uv (offline), conda,
+the embed tier, and venv, and declines the REQ-014 system-Python prompt
+(`tests/~selftest_embed_decline/`'s own sub-bootstrap):
 
 ```
 [ERROR] Active Python interpreter not resolved.
@@ -2334,16 +2337,32 @@ operable program or batch file.
 *** Fix the syntax error shown above, then run this batch again. ***
 ```
 
-That last block is genuinely misleading: `app.py` may have no syntax problem whatsoever -- the real
-cause, printed several screens earlier, is that no Python interpreter was ever found. A real user is
-realistically reachable here for genuine (not test-only) reasons: README's own REQ-009 table already
-notes that falling through three-plus provider tiers in one run is "almost always one shared root
-cause" (no internet, a full disk, or a locked-down managed image), and a user hitting exactly that
-plus declining the REQ-014 system-Python consent prompt reaches this identical path. The status
-FILE is unaffected (`state: error` is still written correctly, since `:die`'s own state-set already
-happened before the fall-through) -- only the human-readable console narrative misdirects a user who
-reads just the last error rather than scrolling back. See CLAUDE.md Active Backlog item 14 for the
-full trace and a suggested fix (not implemented here; this is a documentation-only pass).
+That last block was genuinely misleading: `app.py` may have had no syntax problem whatsoever -- the
+real cause, printed several screens earlier, was that no Python interpreter was ever found. A real
+user was realistically reachable here for genuine (not test-only) reasons: README's own REQ-009
+table already notes that falling through three-plus provider tiers in one run is "almost always one
+shared root cause" (no internet, a full disk, or a locked-down managed image), and a user hitting
+exactly that plus declining the REQ-014 system-Python consent prompt would reach this identical
+path. The status FILE was never affected (`state: error` was always written correctly, since
+`:die`'s own state-set already happened before the fall-through) -- only the human-readable console
+narrative misdirected a user who read just the last error rather than scrolling back.
+
+**Fixed**: `:after_env_mode_selection`'s guard now also sets `HP_NO_INTERPRETER=1` before calling
+`:die` (the call-frame-only-return fall-through itself is left as-is -- a deeper refactor of that
+mechanism was judged out of scope for this fix). `:preflight_compile` checks this flag first and,
+if set, reports the real cause instead of running `py_compile` against an empty interpreter path:
+
+```
+*** [ERROR] No Python interpreter is available; your program was not run or built. ***
+*** This is not a syntax error. It means every automatic Python-acquisition method ***
+*** (uv, conda, a fresh download, a local virtual environment) failed -- usually from ***
+*** no internet connection, a full disk, or a locked-down managed machine image. See ***
+*** the earlier "[ERROR] Active Python interpreter not resolved." message above. ***
+```
+
+This also skips the doomed PyInstaller build attempt entirely (`:run_entry_smoke`'s existing
+`HP_PREFLIGHT_FAILED` check already short-circuits the build, unchanged by this fix), not just the
+misleading message.
 
 ---
 

--- a/docs/demo-bootstrapper-output.md
+++ b/docs/demo-bootstrapper-output.md
@@ -642,19 +642,19 @@ every byte of console output via `cmd /c .\run_setup.bat > '~envsmoke_bootstrap.
 Tue 07/28/2026  4:29:43.96 [INFO] REQ-015: Appending standard ignores to .gitignore.
 ```
 
-**The very first console line is an unexplained anomaly, not a mistake in this doc.** `[WARN] UNC
-paths not supported` (the top-of-file `findstr`-based UNC check, in the file's unlabeled prologue
-before the first `:label`) fired on 6/6 checked lanes against an entirely ordinary local CI
-checkout path (`D:\a\Python_vs_Windows\Python_vs_Windows\tests\~envsmoke\`) -- not a UNC path. The
-companion, independent UNC-prefix check a couple of lines below it (`if
-"%HP_SCRIPT_LAUNCH_DIR:~0,2%"=="\\"`, which prints the much louder `*** WARNING: UNC/network
-paths detected...` banner) never fires in the same logs, so whatever produces this WARN is not
-"the whole path is UNC" -- root cause unconfirmed. See CLAUDE.md Active Backlog item 8 for the
-full trace and why this wasn't chased further in this documentation-only pass. **Whether this also
-fires for a genuine end-user double-click on an ordinary local folder is unknown** -- flagged here
-rather than silently omitted, since a real user seeing an unexplained "UNC paths not supported"
-warning on their very first line of output (on a completely normal local folder) would reasonably
-be confused by it.
+**The very first console line above (`[WARN] UNC paths not supported`) is historical, from the
+captured run, and no longer appears -- fixed since this capture, kept here unedited because it is
+a real, timestamped log.** It came from a broken, redundant top-of-file `findstr`-based check (in
+the file's unlabeled prologue before the first `:label`): `findstr /C:"\\\\"` (searching for two
+literal backslashes) actually collapsed to a search for ONE literal backslash before the closing
+quote, per the C-runtime backslash-before-quote parsing rule documented in
+`docs/agent-lessons-learned.md`, so it fired on 6/6 checked lanes against an entirely ordinary
+local CI checkout path (`D:\a\Python_vs_Windows\Python_vs_Windows\tests\~envsmoke\`) -- not a UNC
+path. The companion, independent, correctly-targeted UNC-prefix check a couple of lines below it
+(`if "%HP_SCRIPT_LAUNCH_DIR:~0,2%"=="\\"`, which prints the much louder `*** WARNING: UNC/network
+paths detected...` banner) already covered the real UNC-detection job on its own, so the broken
+check was simply removed rather than repaired -- see CLAUDE.md's Closed Backlog (formerly Active
+Backlog item 8) for the full trace.
 
 Between that line and `REQ-015`, nothing else prints -- `HP_APP_ARGS` capture (REQ-026, pure
 variable assignment), the workspace-path-exists check, `cd /d`, and `HP_SCRIPT_ROOT` construction

--- a/docs/demo-bootstrapper-output.md
+++ b/docs/demo-bootstrapper-output.md
@@ -2354,11 +2354,19 @@ if set, reports the real cause instead of running `py_compile` against an empty 
 
 ```
 *** [ERROR] No Python interpreter is available; your program was not run or built. ***
-*** This is not a syntax error. It means every automatic Python-acquisition method ***
-*** (uv, conda, a fresh download, a local virtual environment) failed -- usually from ***
-*** no internet connection, a full disk, or a locked-down managed machine image. See ***
-*** the earlier "[ERROR] Active Python interpreter not resolved." message above. ***
+*** This is not a syntax error -- the Python interpreter itself could not be used. ***
+*** Either every automatic Python-acquisition method -- uv, conda, a fresh download, ***
+*** or a local virtual environment -- failed, usually from no internet connection, a ***
+*** full disk, or a locked-down managed machine image -- or a PVW_PYTHON_EXE override ***
+*** points at a path that does not run. Scroll up in this window for the specific reason. ***
 ```
+
+(The message text was later reworded during implementation to avoid a literal `(...)` pair split
+across two `echo` lines inside the same parenthesized `if` block -- cmd.exe's block parser counts
+parens in echo text too, so a `(` on one line and its `)` on the next silently mis-closed the
+block and broke every CI lane reaching this branch in the same run. See
+`docs/agent-lessons-learned.md`'s batch-syntax-quirks section and
+`docs/agent-closed-backlog.md`'s Item 14 entry for the full trace.)
 
 This also skips the doomed PyInstaller build attempt entirely (`:run_entry_smoke`'s existing
 `HP_PREFLIGHT_FAILED` check already short-circuits the build, unchanged by this fix), not just the

--- a/docs/open-questions.md
+++ b/docs/open-questions.md
@@ -9,18 +9,4 @@ changelog-style sections are for.
 
 ---
 
-**1. Is the `cache` CI lane's self-perpetuating-corruption bug (CLAUDE.md Active Backlog item 19)
-worth fixing, given the lane is explicitly non-gating/informational by design?** Diagnosed
-2026-07-31: once a restored cache is flagged corrupted, the lane has no code path that ever
-produces a fresh valid cache again (the one step that could do a fresh install is skipped
-whenever corruption is detected, and the save step is gated on the same flag) -- so it likely
-never recovers on its own, consistent with the maintainer's own report that it "never works."
-A concrete fix is reasoned through in item 19's own writeup (treat a `restore-keys` prefix-match
-corruption the same as a genuine cache miss: delete the bad directory, let a fresh install and
-fresh save proceed normally) but verifying it needs multiple real cache-lane CI cycles to observe
-"does a fresh cache finally get saved," which is slower and more failure-prone to get right than
-a typical code fix. Since this lane exists purely to save ~99 MB of download time and is
-deliberately excluded from PR-merge gating either way, is it worth the multi-cycle verification
-effort, or should it stay as documented, low-priority backlog debt? No strong reason not to
-attempt it in a dedicated future loop either way -- flagging so the priority call is explicit
-rather than assumed.
+_No open items right now._

--- a/run_setup.bat
+++ b/run_setup.bat
@@ -1014,6 +1014,7 @@ if exist "%REQ%" (
 set "HP_JOB_SUMMARY=~pipreqs.summary.txt"
 if exist "%HP_JOB_SUMMARY%" del "%HP_JOB_SUMMARY%"
 if not defined HP_PY (
+  set "HP_NO_INTERPRETER=1"
   call :die "[ERROR] Active Python interpreter not resolved."
 )
 
@@ -3406,6 +3407,18 @@ rem the interpreter (zero false positives for the entry) and writes NO .pyc on f
 rem HP_PREFLIGHT_FAILED must persist to the caller. Capture %ERRORLEVEL% immediately (the del/set
 rem below would clobber it).
 set "HP_PREFLIGHT_FAILED="
+if defined HP_NO_INTERPRETER (
+  echo.
+  echo *** [ERROR] No Python interpreter is available; your program was not run or built. ***
+  echo *** This is not a syntax error. It means every automatic Python-acquisition method ***
+  echo *** (uv, conda, a fresh download, a local virtual environment) failed -- usually from ***
+  echo *** no internet connection, a full disk, or a locked-down managed machine image. See ***
+  echo *** the earlier "[ERROR] Active Python interpreter not resolved." message above. ***
+  call :log "[ERROR] REQ-021: preflight skipped, no Python interpreter resolved: %HP_ENTRY%"
+  echo.
+  set "HP_PREFLIGHT_FAILED=1"
+  exit /b 0
+)
 if not defined HP_ENTRY exit /b 0
 if not exist "%HP_ENTRY%" exit /b 0
 if exist "~preflight.err.txt" del "~preflight.err.txt" >nul 2>&1

--- a/run_setup.bat
+++ b/run_setup.bat
@@ -54,8 +54,6 @@ if not "%~8"=="" set "HP_APP_ARGS=%HP_APP_ARGS% "%~8""
 if not "%~9"=="" set "HP_APP_ARGS=%HP_APP_ARGS% "%~9""
 rem Boot strap renamed to run_setup.bat
 set "HP_SCRIPT_LAUNCH_DIR=%~dp0"
-echo %~dp0 | findstr /C:"\\\\" >nul
-if not errorlevel 1 echo [WARN] UNC paths not supported
 if "%HP_SCRIPT_LAUNCH_DIR:~0,2%"=="\\" (
   rem derived requirement: parentheses must be escaped inside IF (...) blocks in CMD or parsing breaks.
   echo *** WARNING: UNC/network paths detected ^(\\server\share^).

--- a/run_setup.bat
+++ b/run_setup.bat
@@ -1021,7 +1021,7 @@ if not defined HP_PY (
 echo Interpreter: %HP_PY%
 >> "%LOG%" echo Interpreter: %HP_PY%
 call :append_env_mode_row
-"%HP_PY%" -c "print('py_ok')" 1>nul 2>nul || call :log "[WARN] Interpreter smoke test failed (continuing)."
+"%HP_PY%" -c "print('py_ok')" 1>nul 2>nul || (call :log "[WARN] Interpreter smoke test failed (continuing)." & set "HP_NO_INTERPRETER=1")
 "%HP_PY%" -c "import sys;print(sys.version.split()[0])" > "~pyver_host.tmp" 2>nul
 if exist "~pyver_host.tmp" for /f "usebackq delims=" %%Y in ("~pyver_host.tmp") do call :log "[INFO] Host Python: %%Y"
 if exist "~pyver_host.tmp" del "~pyver_host.tmp" >nul 2>&1
@@ -3410,10 +3410,11 @@ set "HP_PREFLIGHT_FAILED="
 if defined HP_NO_INTERPRETER (
   echo.
   echo *** [ERROR] No Python interpreter is available; your program was not run or built. ***
-  echo *** This is not a syntax error. It means every automatic Python-acquisition method ***
-  echo *** (uv, conda, a fresh download, a local virtual environment) failed -- usually from ***
-  echo *** no internet connection, a full disk, or a locked-down managed machine image. See ***
-  echo *** the earlier "[ERROR] Active Python interpreter not resolved." message above. ***
+  echo *** This is not a syntax error -- the Python interpreter itself could not be used. ***
+  echo *** Either every automatic Python-acquisition method -- uv, conda, a fresh download, ***
+  echo *** or a local virtual environment -- failed, usually from no internet connection, a ***
+  echo *** full disk, or a locked-down managed machine image -- or a PVW_PYTHON_EXE override ***
+  echo *** points at a path that does not run. Scroll up in this window for the specific reason. ***
   call :log "[ERROR] REQ-021: preflight skipped, no Python interpreter resolved: %HP_ENTRY%"
   echo.
   set "HP_PREFLIGHT_FAILED=1"

--- a/tests/selfapps_ux_hardening.ps1
+++ b/tests/selfapps_ux_hardening.ps1
@@ -906,21 +906,35 @@ if ($env:HP_FORCE_CONDA_ONLY -eq '1') {
     $embedDeclineVenvIdx = $embedDeclineText.IndexOf('[WARN] Attempting venv fallback')
     $embedDeclineEmbedIdx = $embedDeclineText.IndexOf('[WARN] Attempting embedded Python download')
     $embedDeclineOrdered = ($embedDeclineEmbedIdx -ge 0) -and ($embedDeclineVenvIdx -ge 0) -and ($embedDeclineEmbedIdx -lt $embedDeclineVenvIdx)
-    $embedDeclinePass = ($embedDeclineAttempted -and $embedDeclineForced -and $embedDeclineDied -and $embedDeclineOrdered)
+    # derived requirement (CLAUDE.md Active Backlog item 14, closed): total REQ-009 provider-tier
+    # exhaustion leaves HP_PY empty, which used to make :preflight_compile run py_compile against
+    # an empty interpreter path and report a fabricated "syntax error" instead of the real cause.
+    # This scenario (uv/conda/embed/venv all forced-fail, system declined) is the one real path
+    # that reaches total exhaustion, so it is also the regression test for that fix: the honest
+    # no-interpreter message must appear, the old fabricated message must NOT, and no PyInstaller
+    # build may be attempted against a broken interpreter.
+    $embedDeclineHonestMsg = ($embedDeclineText -match [regex]::Escape('No Python interpreter is available'))
+    $embedDeclineNoFakeSyntaxErr = -not ($embedDeclineText -match [regex]::Escape('Your Python program has a syntax error'))
+    $embedDeclineNoBuildAttempt = -not ($embedDeclineText -match [regex]::Escape('Building standalone executable'))
+    $embedDeclinePass = ($embedDeclineAttempted -and $embedDeclineForced -and $embedDeclineDied -and $embedDeclineOrdered -and
+                          $embedDeclineHonestMsg -and $embedDeclineNoFakeSyntaxErr -and $embedDeclineNoBuildAttempt)
     Write-NdjsonRow ([ordered]@{
         id      = 'self.embed.fallback.decline'
         req     = 'REQ-009'
         pass    = $embedDeclinePass
-        desc    = 'REQ-009 Tier 5 (reordered): embed fallback is attempted right after conda fails (before venv/system), and a forced embed failure reaches :die once venv/system also fail (bootstrap.status.json reports state=error)'
+        desc    = 'REQ-009 Tier 5 (reordered): embed fallback is attempted right after conda fails (before venv/system), and a forced embed failure reaches :die once venv/system also fail (bootstrap.status.json reports state=error); also covers item 14: total exhaustion reports the real no-interpreter cause, not a fabricated syntax error, and skips the doomed build'
         details = [ordered]@{
-            attemptedLog = $embedDeclineAttempted
-            forcedLog    = $embedDeclineForced
-            orderedLog   = $embedDeclineOrdered
-            embedIdx     = $embedDeclineEmbedIdx
-            venvIdx      = $embedDeclineVenvIdx
-            state        = $embedDeclineState
-            exitCode     = $embedDeclineStExit
-            processExit  = $embedDeclineExit
+            attemptedLog   = $embedDeclineAttempted
+            forcedLog      = $embedDeclineForced
+            orderedLog     = $embedDeclineOrdered
+            embedIdx       = $embedDeclineEmbedIdx
+            venvIdx        = $embedDeclineVenvIdx
+            state          = $embedDeclineState
+            exitCode       = $embedDeclineStExit
+            processExit    = $embedDeclineExit
+            honestMsg      = $embedDeclineHonestMsg
+            noFakeSyntaxErr = $embedDeclineNoFakeSyntaxErr
+            noBuildAttempt = $embedDeclineNoBuildAttempt
         }
     })
 }


### PR DESCRIPTION
## Summary

Three independent backlog-item fixes landed on this branch while its CI cycles were already running -- bundled here rather than split into separate PRs, since each was ready before the prior commit's CI settled and pushing a new commit resets the required checks anyway.

**Item 8 -- broken/redundant UNC-paths WARN check:**
- `run_setup.bat`'s top-of-file `findstr /C:"\\\\" >nul` check fired `[WARN] UNC paths not supported` on every ordinary local CI checkout path, not just genuine UNC paths.
- The companion check two lines below already does the real, correctly-targeted UNC-prefix detection. Removed the broken/redundant line rather than repairing it.
- No test anywhere referenced the removed line (confirmed via repo-wide grep before removing).

**Item 14 -- misleading "syntax error" on total Python-provider exhaustion:**
- `:after_env_mode_selection`'s `HP_PY` guard relied on `:die`'s call-frame-only `exit /b`, so on total REQ-009 provider-tier exhaustion, execution fell through ~15 lines to `:preflight_compile`, which ran `py_compile` against an empty interpreter path and reported a fabricated "Your Python program has a syntax error" instead of the real "no Python interpreter found" cause. Confirmed via real CI capture (run `30328748330`).
- Fix: the guard now also sets `HP_NO_INTERPRETER=1`; `:preflight_compile` checks it first and reports the real cause instead, which also skips the doomed PyInstaller build attempt entirely via the existing `HP_PREFLIGHT_FAILED` check.
- No test asserted on the old misleading text; the genuine syntax-error path and the one test reaching this code path (`self.embed.fallback.decline`) are both unaffected, verified before landing.

**Item 19 -- `cache` CI lane's self-perpetuating corruption trap:**
- Once a restored cache was flagged corrupted, the lane had no code path that ever produced a fresh valid cache again: both the only step that could do a fresh install and the save step were gated on the same `HP_CACHE_CORRUPTED` flag, so a poisoned blob (from a `restore-keys` prefix match) got restored, correctly detected as corrupted, and never replaced -- every single run, permanently. Matches the maintainer's own "cache lane never works" report.
- Fix: distinguish an EXACT cache-key hit (unfixable in place; left as-is, needs a cache-deletion API follow-on) from a `restore-keys` PREFIX match (the common case). On a corrupted prefix match, delete the stale directory and don't set `HP_CACHE_CORRUPTED`, letting the run fall through like a genuine cache miss so a real fresh install + fresh save can happen. Falls back to the original safe behavior if deletion is blocked (same AV/indexer file-lock hazard class already documented for `:try_embed_fallback`'s directory swap).
- Not held back for dedicated multi-cycle verification -- `cache` runs on every future PR regardless of subject, so ordinary subsequent work already re-exercises it (maintainer guidance).

## Test plan
- [x] `python tools/check_delimiters.py run_setup.bat` -- clean
- [x] `python -m yamllint .github/workflows/batch-check.yml` -- clean
- [x] `actionlint -oneline .github/workflows/batch-check.yml` -- clean
- [x] `tools/run_sanity_sweep.sh` (compileall, pyflakes, delimiter check, markdownlint, yamllint, actionlint, ASCII sweep, PowerShell AST parse sweep, full pytest) -- all green, 458 passed / 2 skipped, run fresh after each commit

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01A4iE1BRSkUETwz237XeuTW