### PR TITLE
Docs: close Item 28 (confirmed via real CI), file Item 29 for pyproj DLL gap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -544,7 +544,7 @@ start at 1 and has gaps.
   `packaging.version` case verbatim (which this run did not hit at all -- plausibly because a
   package-version difference in the conda solve changed pygrib's own import order; not
   independently confirmed, and not important to the fix's own correctness either way).
-  **The NEW blocker this run hits**: the iteration-2 rebuild's own PyInstaller build log shows 8
+  **The NEW blocker this run hits**: the iteration-2 rebuild's own PyInstaller build log shows 9
   fresh `WARNING: Library not found: could not resolve 'proj_9.dll'` lines, one for each of
   `pyproj`'s compiled extensions (`list`, `database`, `_version`, `_transformer`, `_sync`,
   `_network`, `_geod`, `_crs`, `_context`) -- these `.pyd` files were never part of the bundle

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -530,117 +530,61 @@ Once an item is fully resolved it is removed from here entirely and archived (ke
 original number) in `docs/agent-closed-backlog.md`, which is why the numbering below does not
 start at 1 and has gaps.
 
-- **Item 28: `pygrib`'s compiled extension needs `numpy` and `packaging` as hidden imports before
-  the app can run at all, and `self.layered_e2e.chain`'s `mech3Pass` check (specifically
-  `--hidden-import=colorama`) never gets a chance to fire because of it.** Found via the first
-  real CI confirmation of Item 24's own fix (commit `45ec269`, `cache`-lane run `31208498606`,
-  `~layered_e2e_bootstrap.log`) -- now that `eccodes.dll` bundling genuinely works (Item 24
-  closed), the frozen EXE gets further than ever before and hits a NEW, earlier failure:
-  `ModuleNotFoundError: No module named 'numpy'` on the first post-DLL-bundle smoke run.
-  `:hidden_import_recover` correctly identifies and fixes this (`--hidden-import=numpy`, iter
-  1/3), but the NEXT smoke run then fails on `packaging` (`--hidden-import=packaging`, iter 2/3)
-  -- both are genuine, correctly-diagnosed hidden-import gaps (`pygrib`'s Cython-generated
-  extension apparently imports both at the C level, invisible to PyInstaller's static AST scan,
-  the same general blind spot `--hidden-import` auto-recovery exists to patch one module at a
-  time). After the `packaging` fix, the run still fails (`Entry smoke exit=1`), but the loop does
-  NOT attempt a 3rd rebuild -- the final failure's own signature apparently isn't a plain
-  `ModuleNotFoundError` for an installed module (only a generic `[HINT][RUNTIME_MISMATCH]` fires,
-  not a `[HINT][HIDDEN_IMPORT]` one), so `:hidden_import_recover`'s strict gate correctly declines
-  rather than guessing.
-  **Root-caused 2026-08-08** by pulling the actual per-attempt artifacts from the same CI run
-  (`diag-selftest-cache-31208498606-1`'s `~selftest_layered_e2e/dist/~layered_e2e_exe.log`,
-  the exact rebuild's own captured stderr, not visible in the concatenated bootstrap log the
-  original investigation used) and cross-referencing pygrib's own real published source
-  (`jswhit/pygrib` tag `v2.1.8rel`, matching the exact version this run installed, confirmed via
-  `~warnfile.txt`'s `pygrib==2.1.8`). The 3rd, unfixed failure is:
-
-  ```
-  File "src/pygrib/_pygrib.pyx", line 14, in init pygrib._pygrib
-  ImportError: cannot import name version
-  ```
-
-  `_pygrib.pyx` line 14 is genuinely `from packaging import version` -- confirmed directly against
-  the real source file. This is a **submodule** gap, not an attribute gap: `--hidden-import=packaging`
-  (iter 2's fix) only guarantees PyInstaller's modulegraph follows whatever `packaging/__init__.py`
-  itself statically imports; it does not guarantee every real submodule under `packaging/` gets
-  bundled, and the ONLY thing that references `packaging.version` here is pygrib's own COMPILED
-  Cython extension -- invisible to PyInstaller's source-level scan the same way `eccodes.dll`
-  (Item 24) and `numpy`/`packaging` themselves were invisible, just one level deeper (a missing
-  submodule of an already-hidden-imported package, rather than a missing top-level package).
-  **Confirms `:hidden_import_recover`'s strict gate is declining CORRECTLY, not missing an easy
-  win.** The observed message, `ImportError: cannot import name version` -- no quotes around
-  `version`, no `from 'packaging'` clause -- is NOT the pattern `~hidden_import_scan.py`'s own
-  docstring already discusses and excludes (CPython's `ImportError: cannot import name 'Y' from
-  'Z'`, added in 3.7+). It is Cython's own hand-rolled `__Pyx_ImportFrom` error format, which
-  carries neither the source package name nor quoting -- genuinely NOT parseable into a
-  `--hidden-import` target from the runtime signal alone; the only reason `packaging.version` is
-  known here at all is external evidence (reading pygrib's real, versioned source), not anything
-  derivable from the frozen EXE's own stderr at runtime. Broadening the strict gate to guess "the
-  previous iteration's hidden-imported package, plus the failing name, might be a real submodule"
-  was considered and explicitly rejected: nothing in the runtime signal actually ties the failing
-  name to that specific package (a coincidental `find_spec` hit on an unrelated but real submodule
-  would silently burn an iteration on the wrong fix), and this repo's own hard-won rule for this
-  exact subsystem (see `docs/agent-lessons-learned.md`'s "--hidden-import auto-recovery must stay
-  STRICT") is to keep this loop narrowly proven-correct rather than cleverer-but-riskier.
-  **Practical effect on `self.layered_e2e.chain`**: `chainPass` stays `false`, but for a reason
-  entirely OUTSIDE Item 24's own scope -- `mech3Pass` requires the literal log text
-  `[REPAIR][HIDDEN_IMPORT] Adding --hidden-import=colorama`, and colorama's own gap (deliberately
-  built into the test's own `app.py` via `importlib.import_module`, specifically to exercise
-  hidden-import recovery) is never reached because `pygrib`'s own numpy/packaging/packaging.version
-  chain intervenes first and doesn't resolve within the current mechanism's scope.
-  **The correct general mechanism for this failure class is `--collect-submodules`, not
-  `--hidden-import`, but the existing `HP_COLLECT_SUBMODULES` double-gate doesn't reach it either**
-  -- it requires the package be imported by the USER'S OWN project source (AST-scanned), and
-  `packaging` here is a transitive dependency of `pygrib`, never referenced by the test app's own
-  `app.py`. A real fix needs one of: (a) add `packaging` to `HP_COLLECT_SUBMODULES`'s curated set
-  gated on "installed AND already `--hidden-import`ed this run" instead of "imported by user
-  source" (a new gate condition, not just a new curated entry); or (b) extend `:hidden_import_recover`
-  itself so that once ANY package is added via `--hidden-import=X`, the SAME rebuild also passes
-  `--collect-submodules=X` for that package -- broader than strictly necessary (collects every
-  submodule of `X`, not just the one actually needed) but structurally safe (no name-guessing, no
-  cross-package inference) and directly addresses the mechanism gap this investigation found.
-  **Implemented 2026-08-08, option (b).** `:hidden_import_recover` now builds a second flag
-  accumulator, `HP_PYI_HID_COLLECT`, alongside the existing `HP_PYI_HIDDEN_IMPORTS` -- each loop
-  iteration appends both `--hidden-import=%HP_NEXT_HIDDEN%` AND
-  `--collect-submodules=%HP_NEXT_HIDDEN%` for the SAME `%HP_NEXT_HIDDEN%`, and both flag lists are
-  passed to the SAME PyInstaller rebuild call. This is additive to the existing strict detection
-  gate, not a relaxation of it: `~hidden_import_scan.py` still only ever returns a target from a
-  genuine `ModuleNotFoundError` for an installed module (see
-  `docs/agent-lessons-learned.md`'s "--hidden-import auto-recovery must stay STRICT" entry, which
-  this change does not touch) -- the new flag only changes what happens for a target the strict
-  gate ALREADY decided to act on, ensuring that package's own submodules are collected in the same
-  pass rather than needing a separate, undiagnosable failure to surface later. `[REPAIR][HIDDEN_IMPORT]
-  Adding --hidden-import=X` log lines now read `Adding --hidden-import=X --collect-submodules=X`;
-  every existing test/doc assertion matching that log line as a PREFIX substring (not full-line)
-  continues to match unchanged (`self.exe.hidden_import`, `self.exe.hidden_import.exhaust`'s
-  3-occurrence count, `self.layered_e2e.chain`'s `mech3Pass` check, `batch.pyi.hidden_import.recover`'s
-  static wiring guard) -- verified by tracing each one's own match pattern, not just by running the
-  cross-platform test subset (the real proof needs Windows CI). `tests/selfapps_hidden_import.ps1`
-  extended with `collectLogged`/`collectPaired` assertions (the one new test this loop adds) --
-  both read the SAME `:log` line, so they prove the intended flag text was composed and logged
-  together, not that the real PyInstaller argv actually received it (no runtime artifact captures
-  the literal invoked command line; cmd.exe echo is off and PyInstaller does not print its own
-  argv). `tests/harness.ps1`'s own new `$hiCollectInject` check is the independent SOURCE-LEVEL
-  proof instead -- it confirms `%HP_PYI_HID_COLLECT%` genuinely sits in `run_setup.bat`'s own
-  PyInstaller command-line text right after `%HP_PYI_HIDDEN_IMPORTS%`, a static text match, not an
-  observation of cmd.exe's own runtime expansion or the actual invoked argv (no artifact in this
-  repo captures that; confirming it would need a real Windows run). Two CodeRabbit review findings
-  on this fix's own PR caught successive overclaims here: first, that the two
-  `selfapps_hidden_import.ps1` checks alone were independent proof of the real invocation
-  (corrected to route that claim through `$hiCollectInject` instead); second, that
-  `$hiCollectInject` itself proves the flag "reaches the real command line" rather than merely
-  being present in the source text -- the actual runtime argv is confirmed only by a real Windows
-  CI run, not by any check in this repo today.
-  **NOT YET CONFIRMED in real CI** -- same status this repo requires before treating a fix like
-  this as settled (see the Item 24 precedent: implemented, then confirmed via a real
-  `cache`-lane run before being considered closed). The next `self.layered_e2e.chain` run should
-  show iteration 2's `packaging` rebuild also collecting `packaging.version`, letting the EXE get
-  past pygrib's own import chain far enough to finally reach colorama's own hidden-import gap
-  (`mech3Pass`) and, if that also succeeds, flip `chainPass` to `true` for the first time. If it
-  doesn't, capture the SAME kind of raw per-attempt artifact this investigation used
-  (`dist/~layered_e2e_exe.log`, not the concatenated bootstrap log) before guessing further.
-  Low urgency: this only affects the `cache`-lane, non-gating `self.layered_e2e.chain` test; it
-  does not block any lane that gates PR merges.
+- **Item 29: `:dll_bundle_recover` never re-scans for native-DLL warnings surfaced by a LATER
+  `:hidden_import_recover` rebuild -- only the very first build, before any hidden-import
+  iteration, is ever checked.** Found via the first real CI confirmation of Item 28's own fix
+  (merge commit `bd5d4df3`, `cache`-lane run `31256064576`,
+  `~selftest_layered_e2e/~layered_e2e_bootstrap.log` and `~setup.log`). Item 28's fix is confirmed
+  working exactly as designed: this run's hidden-import loop correctly added
+  `--hidden-import=numpy --collect-submodules=numpy` (iter 1/3), then, after the next smoke run
+  failed with a genuine `ModuleNotFoundError: No module named 'pyproj'`, correctly added
+  `--hidden-import=pyproj --collect-submodules=pyproj` (iter 2/3) -- the paired-flag mechanism
+  fired for real, for a target (`pyproj`) never previously observed in this chain, which is
+  stronger evidence for the fix's general correctness than reproducing the original
+  `packaging.version` case verbatim (which this run did not hit at all -- plausibly because a
+  package-version difference in the conda solve changed pygrib's own import order; not
+  independently confirmed, and not important to the fix's own correctness either way).
+  **The NEW blocker this run hits**: the iteration-2 rebuild's own PyInstaller build log shows 8
+  fresh `WARNING: Library not found: could not resolve 'proj_9.dll'` lines, one for each of
+  `pyproj`'s compiled extensions (`list`, `database`, `_version`, `_transformer`, `_sync`,
+  `_network`, `_geod`, `_crs`, `_context`) -- these `.pyd` files were never part of the bundle
+  before this run's `--collect-submodules=pyproj` (Item 28's own fix) pulled them in for the first
+  time, so this native-DLL gap could not have been detected any earlier than this exact rebuild.
+  The final EXE's own captured stderr confirms the runtime consequence:
+  `ImportError: DLL load failed while importing _context: The specified module could not be
+  found.` -- `mech3Pass` (`hiddenAdding`/`hiddenRecovered`, scoped specifically to `colorama`'s own
+  hidden-import gap) stays `false` because the chain never reaches colorama at all; `chainPass`
+  stays `false` for the same reason. `mech4Pass` (the `eccodes.dll` bundling Item 24 fixed) is
+  unaffected and still passes -- confirming this is a genuinely NEW, one-level-deeper gap, not a
+  regression of anything already fixed.
+  **Root cause**: `:dll_bundle_recover` is called exactly once, from `:run_entry_smoke` right
+  before the FIRST `:run_exe_smokerun` call (see `docs/agent-interconnect.md`'s "Conda native-DLL
+  bundling repair loop" section) -- a deliberate design choice at the time (react to a build-time
+  warning instead of waiting for a runtime failure, see that section's "Detects at BUILD time, not
+  runtime" note), but it did not anticipate a LATER rebuild -- one triggered by
+  `:hidden_import_recover`'s own loop, itself reacting to a runtime `ModuleNotFoundError` -- ever
+  introducing a NEW native-DLL warning of its own. `proj_9.dll` was never checked because the
+  single `:dll_bundle_recover` call already ran and exited (having found and bundled `eccodes.dll`)
+  long before `pyproj` was ever added to the build.
+  **Not yet confirmed whether `proj_9.dll` is actually locatable** the way `eccodes.dll` was
+  (`locate_dll()`'s double-gate requires the DLL to genuinely exist under the conda env's
+  `Library\bin`, searched recursively) -- very likely yes, following the same conda-forge Windows
+  packaging convention `eccodes.dll` already confirmed (a conda-forge `proj` package missing its
+  own runtime DLL would mean `pyproj` is broken for every user, not just under PyInstaller), but
+  the CI artifact captured for this run only covers the test's own app directory, not the shared
+  Miniconda installation tree, so this is inference from convention, not direct confirmation.
+  **Fix direction (not yet implemented, deliberately deferred to its own loop)**: either (a) call
+  `:dll_bundle_recover`'s own detection step again after `:hidden_import_recover`'s loop finishes
+  (a second pass, catching any DLL warning a hidden-import rebuild introduced), or (b) interleave
+  the two loops so each `:hidden_import_recover` rebuild is itself followed by a DLL-warning
+  re-scan before the next smoke run. Either needs the same care already documented for this
+  subsystem's other cross-loop interactions: `HP_PYI_DLLBIND` must keep reaching EVERY later
+  rebuild command (already true today, re-verify it stays true), the 3-iteration caps on each loop
+  need to interact sensibly (a DLL fix consuming a hidden-import iteration budget, or vice versa,
+  would need a considered design rather than an accidental one), and any new call site needs the
+  same tried-list/re-entry-safety guarantees `:dll_bundle_recover` and `:hidden_import_recover`
+  each already have on their own. Low urgency: only affects the `cache`-lane, non-gating
+  `self.layered_e2e.chain` test; does not block any lane that gates PR merges.
 
 ## Cold Storage (promising ideas, deliberately shelved -- revisit only if a named trigger fires)
 

--- a/docs/agent-closed-backlog.md
+++ b/docs/agent-closed-backlog.md
@@ -1617,6 +1617,43 @@ this belongs to).
      empty-name-guard fallback used later in the file (`:env_state_check_done`'s
      `if "%ENVNAME%"=="" (...) set "ENVNAME=env"`).
 
+### Item 28 (closed 2026-08-08)
+
+- **`:hidden_import_recover` pairing `--collect-submodules=X` with each `--hidden-import=X` it
+  adds (CLAUDE.md's own prior root-cause finding: `pygrib`'s compiled extension needing
+  `packaging.version`, a submodule invisible to a bare `--hidden-import=packaging`).**
+  Implemented in PR #419 (`:hidden_import_recover` builds a second flag accumulator,
+  `HP_PYI_HID_COLLECT`, alongside `HP_PYI_HIDDEN_IMPORTS` -- each loop iteration appends both
+  `--hidden-import=X` and `--collect-submodules=X` for the same target, both reaching the same
+  PyInstaller rebuild call) and merged same day. See PR #419's own description for the full
+  mechanism trace and the log-line-format-change compatibility audit (every existing
+  test/doc consumer of `[REPAIR][HIDDEN_IMPORT] Adding --hidden-import=X` matches it as a prefix
+  substring, so none needed code changes).
+  **CONFIRMED via real CI evidence (merge commit `bd5d4df3`, `cache`-lane run `31256064576`,
+  `~selftest_layered_e2e/~layered_e2e_bootstrap.log` and `~setup.log`), closing this item.** The
+  paired-flag mechanism fired for real, twice, in the first post-merge run:
+  `[REPAIR][HIDDEN_IMPORT] Adding --hidden-import=numpy --collect-submodules=numpy; rebuilding EXE
+  (iter 1/3).` then, after a genuine `ModuleNotFoundError: No module named 'pyproj'` on the next
+  smoke run, `Adding --hidden-import=pyproj --collect-submodules=pyproj; rebuilding EXE (iter
+  2/3).` -- confirming the fix works for a real target (`pyproj`) never previously observed in
+  this chain, not just the originally-investigated `packaging` case (which this particular run
+  did not hit at all, plausibly due to a package-version difference in the conda solve changing
+  pygrib's own import order -- not independently confirmed, and immaterial to the fix's own
+  correctness: what matters is that the strict gate fired and the paired flags were both applied
+  whenever it did).
+  **`chainPass` itself is STILL `false` on this same run, but for a reason entirely OUTSIDE this
+  item's own scope**: now that `--collect-submodules=pyproj` bundles `pyproj`'s own compiled
+  extensions for the first time, those extensions (`list`, `database`, `_version`,
+  `_transformer`, `_sync`, `_network`, `_geod`, `_crs`, `_context` -- all 8 confirmed via the
+  rebuild's own PyInstaller build-log warnings) surface a NEW native-DLL dependency
+  (`proj_9.dll`) that could not have been detected any earlier than this exact rebuild, and the
+  existing `:dll_bundle_recover` mechanism (Item 24) only ever runs once, before the very first
+  smoke attempt -- it never gets a chance to react to a DLL warning introduced by a LATER
+  `:hidden_import_recover` rebuild. This is a genuinely new, one-level-deeper gap, not a
+  continuation of this item's own scope -- filed as its own Active Backlog item (Item 29) rather
+  than reopening this one, mirroring the exact same "each fix reveals the next layer" pattern
+  that originally produced this item out of Item 24's own closure.
+
 ## Closed Backlog
 
 - **Cascade-vs-postexec fix (Active Backlog item 9), 2026-07-25, owner-directed follow-up to a

--- a/docs/agent-closed-backlog.md
+++ b/docs/agent-closed-backlog.md
@@ -1644,7 +1644,7 @@ this belongs to).
   **`chainPass` itself is STILL `false` on this same run, but for a reason entirely OUTSIDE this
   item's own scope**: now that `--collect-submodules=pyproj` bundles `pyproj`'s own compiled
   extensions for the first time, those extensions (`list`, `database`, `_version`,
-  `_transformer`, `_sync`, `_network`, `_geod`, `_crs`, `_context` -- all 8 confirmed via the
+  `_transformer`, `_sync`, `_network`, `_geod`, `_crs`, `_context` -- all 9 confirmed via the
   rebuild's own PyInstaller build-log warnings) surface a NEW native-DLL dependency
   (`proj_9.dll`) that could not have been detected any earlier than this exact rebuild, and the
   existing `:dll_bundle_recover` mechanism (Item 24) only ever runs once, before the very first

--- a/docs/agent-interconnect.md
+++ b/docs/agent-interconnect.md
@@ -129,7 +129,8 @@ by PyInstaller" signal) -- any subroutine that can produce `dist\<env>.exe` via 
 than PyInstaller should set an analogous marker and extend this guard to check it.
 
 **`:hidden_import_recover` now pairs `--collect-submodules=X` with every `--hidden-import=X` it
-adds (CLAUDE.md Item 28, implemented 2026-08-08).** A `--hidden-import=X` target alone only
+adds (`docs/agent-closed-backlog.md`'s Item 28, closed 2026-08-08 -- confirmed via real CI evidence
+the same day, see that entry for the trace).** A `--hidden-import=X` target alone only
 guarantees PyInstaller follows whatever `X`'s own `__init__.py` statically imports -- it does not
 guarantee every real submodule under `X/` is bundled. A compiled C extension ELSEWHERE in the app
 (invisible to PyInstaller's static scan the same way the original missing import was) can still
@@ -487,7 +488,9 @@ an array with no command-line re-tokenizing step for the simulation to catch a r
 real CI run is what actually confirmed it. **Also confirmed the mech3 prediction was directionally
 right but not the whole story**: the EXE does get further now, but hits a NEW, deeper gap first
 (`pygrib`'s own extension needs `numpy`/`packaging` as hidden imports before colorama's own gap is
-ever reached) -- see CLAUDE.md's Item 28 for the full trace of this separately-scoped finding.
+ever reached) -- see `docs/agent-closed-backlog.md`'s Item 28 entry for the full trace of this
+separately-scoped finding (closed 2026-08-08; its own fix uncovered a further, deeper gap now
+tracked as CLAUDE.md's Item 29).
 
 ---
 

--- a/docs/agent-lessons-learned.md
+++ b/docs/agent-lessons-learned.md
@@ -510,7 +510,9 @@ substitute for a hazard that is Windows-only by construction. **Confirmed via re
 located and bundled for the first time (`[REPAIR][DLL_BUNDLE] Bundling native DLL dependency:
 eccodes.dll (found at ...\Library\bin\eccodes.dll)...` -> `Native-DLL bundling complete`),
 closing CLAUDE.md's Item 24. `chainPass` itself is still `false` on that same run, but for a
-separately-scoped reason now that this fix let the EXE get further -- see CLAUDE.md's Item 28.
+separately-scoped reason now that this fix let the EXE get further -- see
+`docs/agent-closed-backlog.md`'s Item 28 entry (closed 2026-08-08, its own fix in turn uncovered
+CLAUDE.md's Item 29).
 
 ---
 
@@ -856,7 +858,8 @@ It is deliberately gated on TWO conditions and it is a mistake to relax either:
    `except ImportError: from ._fallback import ...` where the fallback was not collected) is
    `--collect-submodules`/`--collect-all` territory (Slice 1 / a future Slice 3), **not** the
    hidden-import token extractor. **Confirmed correct against a real production-like case, not
-   just reasoning, via CLAUDE.md Item 28's root-cause investigation**: `pygrib` 2.1.8's own
+   just reasoning, via `docs/agent-closed-backlog.md`'s Item 28 root-cause investigation**:
+   `pygrib` 2.1.8's own
    compiled `_pygrib.pyx` does `from packaging import version` at its own line 14 (confirmed
    directly against pygrib's real published source) -- a genuine missing-SUBMODULE gap
    (`packaging.version`, not covered by an earlier `--hidden-import=packaging` since that only


### PR DESCRIPTION
## Summary

Docs-only follow-up loop on CLAUDE.md Active Backlog Item 28, per the watchdog trigger's
"continue if work to do, active backlog" instruction, and the explicit check-in ask to confirm
`self.layered_e2e.chain`'s `chainPass` after PR #419 merged.

**Item 28's fix is CONFIRMED working, via real CI evidence** (merge commit `bd5d4df3`,
`cache`-lane run `31256064576`, `~selftest_layered_e2e/~layered_e2e_bootstrap.log` and
`~setup.log`, pulled directly via targeted HTTP-range zip reads rather than trusting job
conclusion alone). The paired `--collect-submodules`/`--hidden-import` mechanism fired for real,
twice, in the first post-merge run:

```
[REPAIR][HIDDEN_IMPORT] Adding --hidden-import=numpy --collect-submodules=numpy; rebuilding EXE (iter 1/3).
[REPAIR][HIDDEN_IMPORT] Adding --hidden-import=pyproj --collect-submodules=pyproj; rebuilding EXE (iter 2/3).
```

This confirms the fix for a real target (`pyproj`) never previously observed in this chain --
arguably stronger evidence than reproducing the originally-investigated `packaging.version` case
verbatim (which this particular run did not hit at all). Moved Item 28 to
`docs/agent-closed-backlog.md` as closed, updating its own citations in
`docs/agent-interconnect.md` and `docs/agent-lessons-learned.md` to point at the new location.

**The same run uncovered a genuinely new, one-level-deeper blocker**, filed as a fresh Active
Backlog item (Item 29): now that `--collect-submodules=pyproj` bundles `pyproj`'s own compiled
extensions for the first time, the rebuild's own PyInstaller build log shows 8 fresh
`Library not found: could not resolve 'proj_9.dll'` warnings (one per `.pyd`: `list`, `database`,
`_version`, `_transformer`, `_sync`, `_network`, `_geod`, `_crs`, `_context`). The final EXE's
captured stderr confirms the runtime consequence:

```
ImportError: DLL load failed while importing _context: The specified module could not be found.
```

`:dll_bundle_recover` (Item 24's own mechanism) never gets a chance to react to this, since it
only runs once, before the very first smoke attempt -- before `:hidden_import_recover`'s own
loop ever adds `pyproj` to the build. `mech4Pass` (the `eccodes.dll` fix) is unaffected;
`mech3Pass`/`chainPass` stay `false` because the chain never reaches colorama's own gap. No code
change in this loop -- root-cause investigation and backlog filing only, mirroring how Item 28's
own root cause (PR #418) was docs-only before its fix (PR #419) landed separately.

## Test plan

- [x] `tools/run_sanity_sweep.sh` -- all clean, 515 passed / 3 skipped (docs-only change).
- [x] Full `markdownlint-cli2` (not just the sanity sweep's MD029 subset) on all touched docs --
      clean.
- [x] No `run_setup.bat` edit, so no delimiter/payload-sync concerns.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A4iE1BRSkUETwz237XeuTW)_