### PR TITLE
Item 31: close Scenario 25's demo-doc quote-count shortfall

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -544,17 +544,17 @@ is not.
   that can collapse without losing accuracy or completeness, and cut it. Do not sacrifice
   correctness or completeness for terseness -- the goal is removing WORDS, not INFORMATION.
 
-- **Item 31: `docs/demo-bootstrapper-output.md` still has 6 scenarios below the 5-quote house-rule
+- **Item 31: `docs/demo-bootstrapper-output.md` still has 5 scenarios below the 5-quote house-rule
   minimum** (2026-08-08 audit; the 6 real `[TEST]`-line violations found in the same audit were
   fixed same-day, and Scenario 40d's own shortfall was fixed same-day too -- this item is ONLY the
   remaining quote-count shortfalls below, not a re-run of the whole audit). Each needs additional
   genuine (real-capture or source-derived,
   `[Extrapolated Branch]`-labeled if not independently confirmed) console-output quotes added,
   not fabricated ones:
-  - Scenario 25 (pandas/openpyxl heuristic augmentation) -- only 1 real quote today, needs 4 more;
-    the worst shortfall in the doc. Real additional material likely exists near
-    `self.exe.warnfix.real`'s own captured evidence or genuine warnfix/install lines around the
-    heuristic firing.
+  - (Scenario 25, pandas/openpyxl heuristic augmentation, already fixed 2026-08-09 -- added a real
+    bootstrap-console capture from `self.exe.warnfix.real`'s own scratch directory in the SAME CI
+    run/job, showing the heuristic-installed `openpyxl` genuinely bundled and usable in a frozen
+    EXE, `wrote out.xlsx` and all -- 6 new real quotes, well past the 5-quote minimum.)
   - "Reactive-only failure hint" (Part VIII, a standalone entry after Scenario 40) -- 2 quotes,
     needs 3 more. No CI run has exercised a real Nuitka compiler failure yet, so any addition here
     is necessarily `[Extrapolated Branch]` from source.
@@ -569,7 +569,7 @@ is not.
     VIII.)
   A handful of other scenarios sit right at the 5-6 quote line (Scenarios 2, 7, 10, 14, 16, 20,
   21, 22, 27, 39, 40c) -- not violations, but worth a second pass for margin if this item is ever
-  picked up as a larger push rather than just closing the 6 genuine shortfalls above.
+  picked up as a larger push rather than just closing the 5 genuine shortfalls above.
 
 - **Item 32: hint when zero `.py` files are found but a `.py.txt` (hidden-extension) file
   exists.** Moved here from Cold Storage 2026-08-08 (a CodeRabbit review finding correctly caught

--- a/docs/demo-bootstrapper-output.md
+++ b/docs/demo-bootstrapper-output.md
@@ -1875,9 +1875,9 @@ detected, per REQ-019's suppression-only convention.
 **What's tested:** `pandas_excel.translate`/`.conda.install`/`.conda.install.req006`/`.runtime`,
 `self.pandas.openpyxl.install`/`.import` (`tests/selfapps_pandas_excel.ps1`, `conda-full` lane, all
 real and passing) -- plus a genuinely SEPARATE test that happens to exercise the same heuristic in
-a different scratch directory, `self.exe.warnfix.real` (`tests/selftest.ps1`'s `real` scenario,
-`conda-full` lane, also real and passing, `desc: "Heuristic pre-installed openpyxl via pandas
-heuristic; EXE succeeded"`).
+a different scratch directory, `self.exe.warnfix.real` (`tests/selfapps_warnfix.ps1`'s `real`
+scenario, `conda-full` lane, also real and passing, `desc: "Heuristic pre-installed openpyxl via
+pandas heuristic; EXE succeeded"`).
 
 **Source:** REAL CI CAPTURE, run `30328748330`, job `90179708094` (`conda-full` lane).
 
@@ -1929,6 +1929,31 @@ module named PIL - imported by openpyxl.drawing.image (optional)`, not a real ga
 "selfapps_pandas_excel.ps1" note) -- the SAME heuristic logic also runs for uv/venv/embed/system
 providers via `requirements.txt` write-back (CLAUDE.md's own "Deep research pass" Closed Backlog
 entry on this exact fix), just not captured here since this test is conda-only by design.
+
+That claim is directly confirmed by `self.exe.warnfix.real`'s own real bootstrap console capture from
+the SAME CI run (`tests/~selftest_warnfix_real/~warnfix_real_bootstrap.log`) -- a full `run_setup.bat`
+run whose `requirements.txt` declares only `pandas` (triggering the identical heuristic rule shown
+above), while the app's own source imports `openpyxl` directly and writes `out.xlsx` via
+`openpyxl.Workbook()` rather than through pandas -- deliberately isolating the heuristic-provisioned
+package as the only thing under test. This run reaches an actual build and EXE smoke test:
+
+```
+[INFO] Building standalone executable -- this may take a minute or two...
+[INFO] PyInstaller produced dist\_selftest_warnfix_real.exe
+[INFO] EXE smokerun: testing dist\_selftest_warnfix_real.exe
+wrote out.xlsx
+[INFO] EXE smokerun: exited 0 (ok)
+[STATUS] Run Status: SUCCESS (Exit Code: 0)
+```
+
+`wrote out.xlsx` is the app's own `print()` output, reached only after `openpyxl.Workbook().save()`
+succeeds inside the frozen EXE -- direct, unambiguous proof the heuristic-installed `openpyxl` was
+genuinely bundled and usable at runtime, not just resolved by conda's solver. This same real run
+separately hit unrelated warnfix repair failures (`multiprocessing`, `pyimod02_importers`, `vms_lib`,
+`java`, `win32pdh` -- none are real installable packages, a PyInstaller warn-scan false-positive class
+distinct from this heuristic) and a declined REQ-009 cascade prompt; neither affected the pandas/
+openpyxl outcome, since `openpyxl` was already correctly provisioned by the heuristic before the
+build ever started.
 
 ---
 


### PR DESCRIPTION
## Summary

Follow-up to PR #423's audit (CLAUDE.md Active Backlog Item 31): `docs/demo-bootstrapper-output.md`'s
Scenario 25 (pandas/openpyxl heuristic dependency augmentation) had only 1 real console quote against
the doc's own 5-quote house-rule minimum -- the worst shortfall flagged in the audit.

- Added a second real bootstrap-console capture, pulled from the SAME CI run/job as the scenario's
  existing evidence (`self.exe.warnfix.real`'s own scratch directory, `tests/~selftest_warnfix_real/`)
  -- a full `run_setup.bat` run whose `requirements.txt` declares only `pandas` (triggering the same
  heuristic rule already shown) while the app itself imports `openpyxl` directly and prints
  `wrote out.xlsx` only after a real `openpyxl.Workbook().save()` succeeds inside the frozen EXE.
  This is direct, unambiguous proof the heuristic-installed package is genuinely bundled and usable
  at runtime, not just resolved by conda's solver. 6 new real quotes added, well past the minimum.
- Fixed a pre-existing factual error found while sourcing this: `self.exe.warnfix.real` is emitted
  by `tests/selfapps_warnfix.ps1`, not `tests/selftest.ps1` as the doc previously said (confirmed
  directly via source grep).
- Updated CLAUDE.md's Item 31 tracking to reflect Scenario 25 as resolved (5 shortfalls remain, was 6).

No `run_setup.bat` changes; no code paths touched.

## Test plan

- [x] `tools/run_sanity_sweep.sh` -- all clean, 515 passed / 3 skipped.
- [x] New quotes verified against the real CI job log (run `30328748330`, job `90179708094`,
      `conda-full` lane), downloaded and grepped directly rather than reconstructed from memory.
- [x] Stub app source (`tests/selfapps_warnfix.ps1`'s `real` scenario) read directly to confirm
      `wrote out.xlsx` is genuine `print()` output from the app itself.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A4iE1BRSkUETwz237XeuTW)_