### PR TITLE
Item 31: close all remaining quote-count shortfalls, fix real ordering bug

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -544,41 +544,6 @@ is not.
   that can collapse without losing accuracy or completeness, and cut it. Do not sacrifice
   correctness or completeness for terseness -- the goal is removing WORDS, not INFORMATION.
 
-- **Item 31: `docs/demo-bootstrapper-output.md` still has 3 scenarios below the 5-quote house-rule
-  minimum** (2026-08-08 audit; the 6 real `[TEST]`-line violations found in the same audit were
-  fixed same-day, and Scenario 40d's own shortfall was fixed same-day too -- this item is ONLY the
-  remaining quote-count shortfalls below, not a re-run of the whole audit). Each needs additional
-  genuine (real-capture or source-derived,
-  `[Extrapolated Branch]`-labeled if not independently confirmed) console-output quotes added,
-  not fabricated ones:
-  - (Scenario 25, pandas/openpyxl heuristic augmentation, already fixed 2026-08-09 -- added a real
-    bootstrap-console capture from `self.exe.warnfix.real`'s own scratch directory in the SAME CI
-    run/job, showing the heuristic-installed `openpyxl` genuinely bundled and usable in a frozen
-    EXE, `wrote out.xlsx` and all -- 6 new real quotes, well past the 5-quote minimum.)
-  - "Reactive-only failure hint" (Part VIII, a standalone entry after Scenario 40) -- 2 quotes,
-    needs 3 more. No CI run has exercised a real Nuitka compiler failure yet, so any addition here
-    is necessarily `[Extrapolated Branch]` from source.
-  - (Scenario 23 / Scenario 36, `HP_PVW_KNOWN_IDEMPOTENT`, already fixed 2026-08-09 -- while sourcing
-    more real quotes from the same job log, found and fixed a genuine ordering bug in both: the
-    prose claimed the discovery run fires "right after entry selection returns," but `run_setup.bat`
-    actually calls `:determine_entry` TWICE (an early, silent pass right after provider selection
-    that `:pvw_known_idempotent_run`'s own gate depends on, and a later one, after the entire
-    dependency-install phase, that's the one that actually echoes "Chosen entry: ..."); the real
-    captured log confirms discovery fires right after `[BOOT] REQ-009: Selected Python provider:
-    UV.`, well before any entry announcement. Both scenarios now quote the provider-selection line
-    before and the real "Chosen entry"/"Entry selected" pair after -- 6 and 6 quotes respectively,
-    both past the minimum, and both now factually correct about the ordering.)
-  - Scenario 26 (Conda base periodic update) -- 3 quotes, needs 2 more.
-  - Scenario 41 (Interactive verification: live-tee, activity-aware kill) -- 3 quotes, needs 2
-    more; CI answers scripted stdin so no real interactive capture exists, likely
-    `[Extrapolated Branch]` from source.
-  - (Scenario 40d already fixed same-day, trivially -- was 1 line short, added the real
-    `[INFO] REQ-016: Post-flight briefing printed.` closing line already used elsewhere in Part
-    VIII.)
-  A handful of other scenarios sit right at the 5-6 quote line (Scenarios 2, 7, 10, 14, 16, 20,
-  21, 22, 27, 39, 40c) -- not violations, but worth a second pass for margin if this item is ever
-  picked up as a larger push rather than just closing the 3 genuine shortfalls above.
-
 - **Item 32: hint when zero `.py` files are found but a `.py.txt` (hidden-extension) file
   exists.** Moved here from Cold Storage 2026-08-08 (a CodeRabbit review finding correctly caught
   that the Cold Storage entry's own "Trigger to thaw" text admitted no real trigger was blocking

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -544,7 +544,7 @@ is not.
   that can collapse without losing accuracy or completeness, and cut it. Do not sacrifice
   correctness or completeness for terseness -- the goal is removing WORDS, not INFORMATION.
 
-- **Item 31: `docs/demo-bootstrapper-output.md` still has 5 scenarios below the 5-quote house-rule
+- **Item 31: `docs/demo-bootstrapper-output.md` still has 3 scenarios below the 5-quote house-rule
   minimum** (2026-08-08 audit; the 6 real `[TEST]`-line violations found in the same audit were
   fixed same-day, and Scenario 40d's own shortfall was fixed same-day too -- this item is ONLY the
   remaining quote-count shortfalls below, not a re-run of the whole audit). Each needs additional
@@ -558,8 +558,16 @@ is not.
   - "Reactive-only failure hint" (Part VIII, a standalone entry after Scenario 40) -- 2 quotes,
     needs 3 more. No CI run has exercised a real Nuitka compiler failure yet, so any addition here
     is necessarily `[Extrapolated Branch]` from source.
-  - Scenario 23 / Scenario 36 (`HP_PVW_KNOWN_IDEMPOTENT`, share the same 3-line source block) --
-    3 quotes each, need 2 more each.
+  - (Scenario 23 / Scenario 36, `HP_PVW_KNOWN_IDEMPOTENT`, already fixed 2026-08-09 -- while sourcing
+    more real quotes from the same job log, found and fixed a genuine ordering bug in both: the
+    prose claimed the discovery run fires "right after entry selection returns," but `run_setup.bat`
+    actually calls `:determine_entry` TWICE (an early, silent pass right after provider selection
+    that `:pvw_known_idempotent_run`'s own gate depends on, and a later one, after the entire
+    dependency-install phase, that's the one that actually echoes "Chosen entry: ..."); the real
+    captured log confirms discovery fires right after `[BOOT] REQ-009: Selected Python provider:
+    UV.`, well before any entry announcement. Both scenarios now quote the provider-selection line
+    before and the real "Chosen entry"/"Entry selected" pair after -- 6 and 5 quotes respectively,
+    both past the minimum, and both now factually correct about the ordering.)
   - Scenario 26 (Conda base periodic update) -- 3 quotes, needs 2 more.
   - Scenario 41 (Interactive verification: live-tee, activity-aware kill) -- 3 quotes, needs 2
     more; CI answers scripted stdin so no real interactive capture exists, likely
@@ -569,7 +577,7 @@ is not.
     VIII.)
   A handful of other scenarios sit right at the 5-6 quote line (Scenarios 2, 7, 10, 14, 16, 20,
   21, 22, 27, 39, 40c) -- not violations, but worth a second pass for margin if this item is ever
-  picked up as a larger push rather than just closing the 5 genuine shortfalls above.
+  picked up as a larger push rather than just closing the 3 genuine shortfalls above.
 
 - **Item 32: hint when zero `.py` files are found but a `.py.txt` (hidden-extension) file
   exists.** Moved here from Cold Storage 2026-08-08 (a CodeRabbit review finding correctly caught

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -566,7 +566,7 @@ is not.
     dependency-install phase, that's the one that actually echoes "Chosen entry: ..."); the real
     captured log confirms discovery fires right after `[BOOT] REQ-009: Selected Python provider:
     UV.`, well before any entry announcement. Both scenarios now quote the provider-selection line
-    before and the real "Chosen entry"/"Entry selected" pair after -- 6 and 5 quotes respectively,
+    before and the real "Chosen entry"/"Entry selected" pair after -- 6 and 6 quotes respectively,
     both past the minimum, and both now factually correct about the ordering.)
   - Scenario 26 (Conda base periodic update) -- 3 quotes, needs 2 more.
   - Scenario 41 (Interactive verification: live-tee, activity-aware kill) -- 3 quotes, needs 2

--- a/docs/agent-closed-backlog.md
+++ b/docs/agent-closed-backlog.md
@@ -1745,6 +1745,55 @@ this belongs to).
   real in one run, each mechanism handing off to the next exactly as designed across three
   successive items (24, 28, 29).
 
+### Item 31 (closed 2026-08-09)
+
+- **`docs/demo-bootstrapper-output.md` had 7 scenarios below the doc's own 5-quote house-rule
+  minimum** (2026-08-08 audit, filed the same day the house rule itself was added -- PR #423).
+  Closed across three follow-up PRs, each adding genuine (real-capture or source-derived,
+  `[Extrapolated Branch]`-labeled where not independently confirmed) console-output quotes, never
+  fabricated ones:
+  - **Scenario 40d** (fixed same-day as the audit, in PR #423 itself) -- was 1 line short; added
+    the real `[INFO] REQ-016: Post-flight briefing printed.` closing line already used elsewhere
+    in Part VIII.
+  - **Scenario 25** (pandas/openpyxl heuristic augmentation, PR #424, the worst shortfall at only
+    1 real quote) -- added a real bootstrap-console capture from `self.exe.warnfix.real`'s own
+    scratch directory in the SAME CI run/job as the scenario's existing evidence, showing the
+    heuristic-installed `openpyxl` genuinely bundled and usable in a frozen EXE (`wrote out.xlsx`
+    and all) -- 6 new real quotes. Also fixed a pre-existing factual error found while sourcing
+    this: `self.exe.warnfix.real` is emitted by `tests/selfapps_warnfix.ps1`, not
+    `tests/selftest.ps1` as the doc previously said.
+  - **Scenario 23 / Scenario 36** (`HP_PVW_KNOWN_IDEMPOTENT` execute-mode discovery, PR #425) --
+    while sourcing more real quotes from the same job log, found and fixed a genuine ordering bug
+    in both: the prose claimed the discovery run fires "right after entry selection returns," but
+    `run_setup.bat` actually calls `:determine_entry` TWICE (an early, silent pass right after
+    provider selection that `:pvw_known_idempotent_run`'s own gate depends on, and a later one,
+    after the entire dependency-install phase, that's the one that actually echoes "Chosen
+    entry: ..."); the real captured log confirmed discovery fires right after `[BOOT] REQ-009:
+    Selected Python provider: UV.`, well before any entry announcement. Both scenarios now quote
+    the provider-selection line before and the real "Chosen entry"/"Entry selected" pair after --
+    6 quotes each, both now factually correct about the ordering.
+  - **"Reactive-only failure hint"** (Part VIII, PR #425) -- its own section title promised
+    coverage of "both Tier A and requirement 9's real-build-failure paths" but only ever quoted
+    ONE of the two (`:offer_optimized_build`'s failure message). Added the genuinely distinct
+    Tier A (`:try_nuitka_tier_a`) failure messages from source (`[Extrapolated Branch]`, since no
+    CI run has exercised a real Nuitka compiler failure) -- both call sites' exact literal text,
+    including the second, rarer trigger (Nuitka reports success but never produces the EXE) --
+    bringing the section to 5 quotes and making it actually cover what its own title claimed.
+  - **Scenario 26** (Conda base periodic update, PR #425) -- added the genuinely common "last
+    update < 30 days ago" skip branch (a real, deterministic literal string from source, not
+    previously documented at all -- more common in practice than the "first install" skip already
+    shown, since it's what fires on every ordinary repeat bootstrap within the 30-day window) and
+    the update-failure branch's own line (previously only described in prose, not quoted) --
+    5 quotes total.
+  - **Scenario 41** (Interactive verification: live-tee, activity-aware kill, PR #425) -- added
+    the PID-display line and the live-teed program's own real stdout (`hello-from-stub`),
+    cross-cited from an EARLIER real capture in the same doc (run `30328748330`, job
+    `90179708091`) that already confirmed both as genuine, working console output belonging to
+    this exact mechanism -- 5 quotes total.
+  A handful of scenarios sitting right at the 5-6 quote line (Scenarios 2, 7, 10, 14, 16, 20, 21,
+  22, 27, 39, 40c) were flagged as worth a second pass for margin but were never violations and
+  were not part of this item's own closure criteria.
+
 ## Closed Backlog
 
 - **Cascade-vs-postexec fix (Active Backlog item 9), 2026-07-25, owner-directed follow-up to a

--- a/docs/demo-bootstrapper-output.md
+++ b/docs/demo-bootstrapper-output.md
@@ -1802,15 +1802,19 @@ real and passing).
 This is an opt-in super-user flag (not part of the default happy path -- Part I never sets it):
 when defined, `run_setup.bat` skips straight to actually RUNNING the entry file live via
 `uvx autopep723 <entry>` for dependency discovery, before pipreqs or any static analysis even
-starts. `:pvw_known_idempotent_run` is called right after entry selection returns (immediately
-after the `if defined HP_PVW_KNOWN_IDEMPOTENT ...` gate), so the very next thing on screen after
-the entry is chosen (the same "Chosen entry: ..." moment Scenario 2 covers) is this discovery run.
-Real capture, `self.pvw_idempotent.discovery`, including the entry script's
+starts. `:pvw_known_idempotent_run` is gated on an EARLY, silent entry-determination pass that
+runs right after the Python provider is selected -- `run_setup.bat` determines the entry file
+TWICE: once here, quietly, just to populate `HP_ENTRY` for this and a couple of other early-stage
+checks, and once again much later, after the entire dependency-install phase, which is the pass
+that actually announces itself on screen (the "Chosen entry: ..." moment Scenario 2 covers). So
+this discovery run fires right after the provider line below, well BEFORE the entry is ever
+announced on screen. Real capture, `self.pvw_idempotent.discovery`, including the entry script's
 own live stdout passed straight through mid-run (real NDJSON detail confirms
 `stdoutPassthroughFound:true, appRan:true` -- not captured or suppressed, the exact design point
 `tools/pvw_known_idempotent.py` exists to preserve):
 
 ```
+[BOOT] REQ-009: Selected Python provider: UV.
 [INFO] REQ-005.13: HP_PVW_KNOWN_IDEMPOTENT set; running entry via uvx autopep723 for execute-mode discovery.
 t2-idempotent-ok
 [INFO] REQ-005.13: execute-mode discovery run succeeded (RAN:persisted).
@@ -1824,7 +1828,13 @@ persisted back into the PEP 723 header via `uv add --script`, then re-extracted 
 `requirements.txt` so the rest of the pipeline (pipreqs, Tier 1 autopep723 merge, the actual
 install) sees it too. Deliberately ADDITIVE, not a replacement for pipreqs -- pipreqs and Tier 1's
 own `autopep723 check` merge still run normally afterward to catch anything a single execution
-path didn't happen to exercise.
+path didn't happen to exercise. Only once that entire dependency-install phase finishes does the
+bootstrapper reach the LATER, canonical entry announcement:
+
+```
+Chosen entry: app.py
+[BOOT] REQ-002: Entry selected: app.py
+```
 
 ---
 
@@ -2916,6 +2926,7 @@ real user).
 Scenario 23 -- repeated here only for continuity with the file changes below):
 
 ```
+[BOOT] REQ-009: Selected Python provider: UV.
 [INFO] REQ-005.13: HP_PVW_KNOWN_IDEMPOTENT set; running entry via uvx autopep723 for execute-mode discovery.
 t2-idempotent-ok
 [INFO] REQ-005.13: execute-mode discovery run succeeded (RAN:persisted).
@@ -2923,7 +2934,16 @@ t2-idempotent-ok
 
 (`t2-idempotent-ok` is the app's own live stdout, inherited straight through the discovery run --
 real NDJSON detail confirms `stdoutPassthroughFound:true`, the exact design point
-`tools/pvw_known_idempotent.py` exists to preserve; see `docs/agent-interconnect.md`.)
+`tools/pvw_known_idempotent.py` exists to preserve; see `docs/agent-interconnect.md`.) See
+Scenario 23 for why this discovery run fires right after provider selection, well before the
+entry file is ever announced on screen -- not right after, despite the file changes shown below
+happening in the same early pass. That later announcement, from the SAME real capture, comes only
+after the entire dependency-install phase finishes:
+
+```
+Chosen entry: app.py
+[BOOT] REQ-002: Entry selected: app.py
+```
 
 **Output, `app.py` (same file, now carrying a PEP 723 header `uv add --script` wrote in place):**
 this is the STANDARD shape `uv add --script` is documented to produce (see

--- a/docs/demo-bootstrapper-output.md
+++ b/docs/demo-bootstrapper-output.md
@@ -3303,10 +3303,11 @@ Real, verbatim console dump (`~selftest_optbuild_decline\~optbuild_decline_boots
 
 #### Reactive-only failure hint (both Tier A and requirement 9's real-build-failure paths)
 
-Fires only on a GENUINE Nuitka compiler failure (not the `forcefail`/`HP_TEST_FORCE_NUITKA_FAIL`
-test hooks, which bypass it entirely). No CI run to date has exercised a real Nuitka compiler
-failure, so this is sourced from `run_setup.bat` rather than a console capture -- both call sites
-below are this exact deterministic literal text, not an approximation.
+Fires on either of two genuine failure conditions -- a real Nuitka compiler failure, or Nuitka
+reporting success while never actually producing `dist\<env>.exe` -- and never on the
+`forcefail`/`HP_TEST_FORCE_NUITKA_FAIL` test hooks, which bypass it entirely. No CI run to date has
+exercised either genuine failure, so this is sourced from `run_setup.bat` rather than a console
+capture -- both call sites below are this exact deterministic literal text, not an approximation.
 
 **Tier A (`:try_nuitka_tier_a`)** -- the AV-Safe Build Path fallback that runs when the ORIGINAL
 PyInstaller build has already failed. A genuine Nuitka failure here means every build tool tried

--- a/docs/demo-bootstrapper-output.md
+++ b/docs/demo-bootstrapper-output.md
@@ -1986,11 +1986,18 @@ correctly skips rather than updating a base that was just installed moments ago:
 [INFO] Conda base update: skipped (first install).
 ```
 
-**`[Extrapolated Branch]`** -- the actual 30-day-elapsed UPDATE-firing branch (`:cbu_run`) is not
-exercised by any current CI run (the only flag that could force it is deliberately disabled, per
-the note above). Once the timestamp in `~conda.lastupdate`
-is more than 30 days old, the subroutine's two `:log` calls are these exact, deterministic literal
-strings -- not an approximation, the source text itself:
+**`[Extrapolated Branch]`** -- the two other real-world branches are not exercised by any current
+CI run (the only flag that could force the update path is deliberately disabled, per the note
+above), but each is an exact, deterministic literal string straight from source, not an
+approximation. The far more common case for a REPEAT run within the 30-day window -- most real
+projects, re-bootstrapped many times during ordinary development -- is a second kind of skip, one
+that genuinely checks `~conda.lastupdate`'s timestamp rather than assuming a fresh install:
+
+```
+[INFO] Conda base update: skipped (last update < 30 days ago).
+```
+
+Once that timestamp finally IS more than 30 days old, `:cbu_run` fires for real:
 
 ```
 [INFO] Conda base update: running (>=30 days since last update or no record).
@@ -2001,11 +2008,17 @@ Between those two lines, `conda update -n base --all --override-channels -c cond
 with its output redirected straight to `~setup.log` (`>> "%LOG%" 2>&1`) -- conda's own real
 update-solve output (package list, versions, download progress) never reaches the console, matching
 this doc's "Console vs. `~setup.log`" convention. If the update itself fails (a nonzero exit from
-that command), the second line is `[WARN] Conda base update failed; continuing.` instead -- the
-bootstrap is never blocked by a failed base update either way. This branch realistically only fires
-for a long-lived, repeatedly-reused project folder -- not the fresh-checkout scenarios this document
-otherwise captures -- and is correctly out of scope for a dedicated CI test: a forced-update test
-previously broke conda's own solver in shared CI runners, an accepted, documented tradeoff
+that command), the second line is this instead -- the bootstrap is never blocked by a failed base
+update either way:
+
+```
+[WARN] Conda base update failed; continuing.
+```
+
+The update-firing branch realistically only fires for a long-lived, repeatedly-reused project
+folder well past its 30-day mark -- not the fresh-checkout scenarios this document otherwise
+captures -- and is correctly out of scope for a dedicated CI test: a forced-update test previously
+broke conda's own solver in shared CI runners, an accepted, documented tradeoff
 (`docs/agent-ndjson.md`'s "conda-full lane rows" section).
 
 ---
@@ -3290,9 +3303,30 @@ Real, verbatim console dump (`~selftest_optbuild_decline\~optbuild_decline_boots
 
 #### Reactive-only failure hint (both Tier A and requirement 9's real-build-failure paths)
 
-Fires only on a GENUINE Nuitka compiler failure (not the `forcefail` test hook, which bypasses it
-entirely). No CI run to date has exercised a real Nuitka compiler failure, so this is sourced from
-`run_setup.bat` rather than a console capture:
+Fires only on a GENUINE Nuitka compiler failure (not the `forcefail`/`HP_TEST_FORCE_NUITKA_FAIL`
+test hooks, which bypass it entirely). No CI run to date has exercised a real Nuitka compiler
+failure, so this is sourced from `run_setup.bat` rather than a console capture -- both call sites
+below are this exact deterministic literal text, not an approximation.
+
+**Tier A (`:try_nuitka_tier_a`)** -- the AV-Safe Build Path fallback that runs when the ORIGINAL
+PyInstaller build has already failed. A genuine Nuitka failure here means every build tool tried
+has now failed:
+
+```
+[WARN] Fallback build did not complete successfully.
+[WARN] Hint: if you have Visual Studio 2022 (or newer) with the 'Desktop development with C++' workload installed, this fallback should use it automatically -- no extra setup needed. If not, installing the free Visual Studio Build Tools with that workload can help this fallback succeed.
+```
+
+A second, distinct trigger inside the same subroutine -- Nuitka reports success but never actually
+produces `dist\<env>.exe` -- gets the identical hint after a different first line:
+
+```
+[WARN] Fallback build finished but did not produce dist\<env>.exe.
+```
+
+**Requirement 9 (`:offer_optimized_build`)** -- a much lower-stakes case: PyInstaller already
+succeeded and the user's app is already working; this only fires if the user explicitly opted into
+building an OPTIONAL, faster/more-reliable Nuitka version on top of an already-working build:
 
 ```
 [WARN] Optimized build did not complete; your app is still ready to use as-is.
@@ -3346,6 +3380,22 @@ Three things this one line is doing:
    of Scenario 43's ambiguous-exit panels.
 3. **Still warns it's a throwaway pass, not the user's real, saveable session** -- this verification
    EXE is never reused; only the file it's already tested is kept for later double-clicks.
+
+**Two more real lines belong to the SAME live-tee mechanism** and are already confirmed as genuine,
+working console output (not just source text) in an earlier real capture -- run `30328748330`, job
+`90179708091` ("real" lane), `tests/~selftest_stub/~stub_bootstrap.log`:
+
+```
+[INFO] Process ID 6076. If it seems stuck: Task Manager > Details tab > find this PID > End Task (this window stays open).
+hello-from-stub
+```
+
+The PID line is `tools/exe_smokerun.ps1`'s own stuck-program recovery aid (see
+`docs/agent-interconnect.md`'s "Process-ID display for stuck-program recovery" section), printed
+right after the verification process starts. `hello-from-stub` is that real run's own stub
+program's live stdout, teed through the SAME chunk-based `ReadAsync` reader landing exactly between
+the PID line and the eventual `EXE smokerun: exited 0 (ok)` line -- precisely where a real user's
+own program output appears, live, as it happens, not buffered until the process exits.
 
 The `hidden_import` recovery loop's own separate, narrower verification check (see README.md's
 "Verifying a fresh build is activity-aware and announced" bullet, which calls this exact exception


### PR DESCRIPTION
## Summary

Follow-up to PR #423's audit (CLAUDE.md Active Backlog Item 31) and PR #424's first fix. This PR
now closes out **every** remaining scenario the audit flagged, and moves Item 31 to
`docs/agent-closed-backlog.md` as fully resolved.

**Scenario 23 / Scenario 36** (`HP_PVW_KNOWN_IDEMPOTENT` execute-mode discovery) each had only 3
real console quotes against the doc's 5-quote house-rule minimum. While sourcing additional real
quotes from the actual CI job log (run `30328748330`, job `90179708109`, `uv` lane), traced the
real call order in `run_setup.bat` and found a genuine, pre-existing factual bug in both scenarios'
own prose: they claimed the discovery run fires "right after entry selection returns... the very
next thing on screen after the entry is chosen." That's wrong. `:determine_entry` is actually
called **twice** -- an early, silent pass right after the Python provider is selected (the one
`:pvw_known_idempotent_run`'s own gate depends on), and a later pass, reached only after the
entire dependency-install phase completes, that's the one which actually echoes "Chosen entry:
..." on screen. The real captured log confirms this directly. Both scenarios now quote the
provider-selection line before and the real "Chosen entry"/"Entry selected" pair after -- 6 quotes
each, both now factually correct about the ordering.

**"Reactive-only failure hint"** (Part VIII): its own section title promised coverage of "both
Tier A and requirement 9's real-build-failure paths" but only ever quoted requirement 9's. Added
the genuinely distinct Tier A (`:try_nuitka_tier_a`) failure messages from source
(`[Extrapolated Branch]`, since no CI run has exercised a real Nuitka compiler failure) -- the
section now actually covers what its own title claims. 5 quotes total (was 2).

**Scenario 26** (Conda base periodic update): added the "last update < 30 days ago" skip branch --
a real, deterministic literal string from source, not previously documented at all, and in
practice more common than the "first install" skip already shown (it's what fires on every
ordinary repeat bootstrap within the 30-day window) -- plus the update-failure line, previously
only described in prose, not quoted. 5 quotes total (was 3).

**Scenario 41** (Interactive verification: live-tee, activity-aware kill): added the PID-display
line and the live-teed program's own real stdout (`hello-from-stub`), cross-cited from an earlier
real capture already in the same doc (run `30328748330`, job `90179708091`) that already confirmed
both as genuine, working console output belonging to this exact mechanism. 5 quotes total (was 3).

**Item 31 is now fully resolved** -- moved from CLAUDE.md's Active Backlog to
`docs/agent-closed-backlog.md`'s Closed Active Backlog Items section (keeping its original
number), consolidating the full resolution history across all three PRs (#423/#424/#425) in one
place.

No `run_setup.bat` changes; no code paths touched -- documentation-accuracy fixes only.

## Test plan

- [x] `tools/run_sanity_sweep.sh` -- all clean, 515 passed / 3 skipped.
- [x] Ordering claim (Scenario 23/36) verified directly against `run_setup.bat` source (both
      `:determine_entry` call sites and the single `:record_chosen_entry` call site traced by
      hand) and against the real CI job log, not assumed.
- [x] All new quotes sourced from either a real, downloaded CI job log or `run_setup.bat`'s own
      current literal source text (never fabricated), each labeled per the doc's own sourcing
      convention.
- [x] Markdown paren-balance checked on every edited section after editing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A4iE1BRSkUETwz237XeuTW)_