### PR TITLE
Item 34 loop 1: house rule + dedupe cross-file duplication in auto-loaded docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -542,24 +542,25 @@ is not.
   fix was wrong, third fix confirmed via CI run N") wearing reference-doc clothes, not restated
   prose. Scoped as three separate loops (see `docs/agent-closed-backlog.md`'s Item 23/30 entries
   for the prior compression history this builds on):
-  1. Add a house-rule line to the top of all three auto-loaded docs codifying "distill to the
-     load-bearing rule; move the narrative/provenance to `docs/agent-closed-backlog.md`" as the
-     ongoing editing principle. Then dedupe the two confirmed cross-file duplications: the cmd.exe
-     `%`-pairing sanitizer saga told at length in both `agent-interconnect.md`'s DLL-bundling
-     section and `agent-lessons-learned.md`'s ":log echoes UNQUOTED" entry; and the
-     `self.dll_bundle.recover` NDJSON row's mechanism explained at length in both
-     `agent-interconnect.md` and `agent-ndjson.md`. Pick one canonical home per fact, leave a
-     one-line pointer everywhere else -- zero information loss, since the fact still lives
-     somewhere.
-  2. Move CLAUDE.md's own "Known Findings" section to `docs/agent-closed-backlog.md` -- it is
-     explicitly "diagnosed, no action warranted," which is verbatim that file's own stated scope
-     ("read on demand... when investigating something that feels like it was already done"), so it
-     doesn't belong in the always-loaded file at all.
-  3. Distill CLAUDE.md's dependency-strategy essay (pipreqs pin rationale, pipreqs invocation
-     rationale, the warnfix `SKIP`-set walkthrough, the 6 Bootstrap Architecture Principles) down
-     to the load-bearing rule per topic, moving the multi-paragraph justification to a reference
-     doc. Table-ify the per-payload paragraph descriptions in "run_setup.bat Rules" (payload name /
-     decodes to / purpose / canonical source, one line each) instead of a paragraph per payload.
+  - **Loop 1 (DONE, PR #429):** added the house-rule line to the top of all three auto-loaded
+    docs codifying "distill to the load-bearing rule; move the narrative/provenance to
+    `docs/agent-closed-backlog.md`" as the ongoing editing principle, and deduped the two confirmed
+    cross-file duplications: the cmd.exe `%`-pairing sanitizer saga told at length in both
+    `agent-interconnect.md`'s DLL-bundling section and `agent-lessons-learned.md`'s ":log echoes
+    UNQUOTED" entry (canonical home: lessons-learned.md); and the `self.dll_bundle.recover` NDJSON
+    row's mechanism explained at length in both `agent-interconnect.md` and `agent-ndjson.md`
+    (canonical home: agent-ndjson.md). Zero information loss -- each fact still lives at its one
+    canonical home, with a one-line pointer left everywhere else.
+  - **Loop 2 (open):** move CLAUDE.md's own "Known Findings" section to
+    `docs/agent-closed-backlog.md` -- it is explicitly "diagnosed, no action warranted," which is
+    verbatim that file's own stated scope ("read on demand... when investigating something that
+    feels like it was already done"), so it doesn't belong in the always-loaded file at all.
+  - **Loop 3 (open):** distill CLAUDE.md's dependency-strategy essay (pipreqs pin rationale,
+    pipreqs invocation rationale, the warnfix `SKIP`-set walkthrough, the 6 Bootstrap Architecture
+    Principles) down to the load-bearing rule per topic, moving the multi-paragraph justification
+    to a reference doc. Table-ify the per-payload paragraph descriptions in "run_setup.bat Rules"
+    (payload name / decodes to / purpose / canonical source, one line each) instead of a paragraph
+    per payload.
   **Deliberately keeping "Periodic Maintenance Checks" in CLAUDE.md, NOT moved out** -- owner
   decision: the quarterly Claude Code Remote trigger's own reliability isn't confirmed yet, so this
   section staying always-loaded is an intentional fallback until that trigger has enough of a track

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -533,7 +533,37 @@ text (see below) rather than leaving the section silently blank** -- an empty se
 marker is easy to mistake for a rendering glitch or an accidental deletion; an explicit statement
 is not.
 
-**Nothing here.** All items above have been resolved and moved to `docs/agent-closed-backlog.md`.
+- **Item 34: restructure the three auto-loaded knowledge docs (`docs/agent-interconnect.md`,
+  `docs/agent-lessons-learned.md`, `docs/agent-ndjson.md`) around a "distill to the load-bearing
+  rule" house rule, moving narrative/provenance out to `docs/agent-closed-backlog.md`.** Follow-up
+  to the Item 30 compression pass (PR #428), which found that further sentence-level trimming was
+  a saturated lever on `agent-interconnect.md` specifically (~0.2% word reduction) -- the file's
+  bulk is chronological incident-log narrative ("bug found via review, first fix was wrong, second
+  fix was wrong, third fix confirmed via CI run N") wearing reference-doc clothes, not restated
+  prose. Scoped as three separate loops (see `docs/agent-closed-backlog.md`'s Item 23/30 entries
+  for the prior compression history this builds on):
+  1. Add a house-rule line to the top of all three auto-loaded docs codifying "distill to the
+     load-bearing rule; move the narrative/provenance to `docs/agent-closed-backlog.md`" as the
+     ongoing editing principle. Then dedupe the two confirmed cross-file duplications: the cmd.exe
+     `%`-pairing sanitizer saga told at length in both `agent-interconnect.md`'s DLL-bundling
+     section and `agent-lessons-learned.md`'s ":log echoes UNQUOTED" entry; and the
+     `self.dll_bundle.recover` NDJSON row's mechanism explained at length in both
+     `agent-interconnect.md` and `agent-ndjson.md`. Pick one canonical home per fact, leave a
+     one-line pointer everywhere else -- zero information loss, since the fact still lives
+     somewhere.
+  2. Move CLAUDE.md's own "Known Findings" section to `docs/agent-closed-backlog.md` -- it is
+     explicitly "diagnosed, no action warranted," which is verbatim that file's own stated scope
+     ("read on demand... when investigating something that feels like it was already done"), so it
+     doesn't belong in the always-loaded file at all.
+  3. Distill CLAUDE.md's dependency-strategy essay (pipreqs pin rationale, pipreqs invocation
+     rationale, the warnfix `SKIP`-set walkthrough, the 6 Bootstrap Architecture Principles) down
+     to the load-bearing rule per topic, moving the multi-paragraph justification to a reference
+     doc. Table-ify the per-payload paragraph descriptions in "run_setup.bat Rules" (payload name /
+     decodes to / purpose / canonical source, one line each) instead of a paragraph per payload.
+  **Deliberately keeping "Periodic Maintenance Checks" in CLAUDE.md, NOT moved out** -- owner
+  decision: the quarterly Claude Code Remote trigger's own reliability isn't confirmed yet, so this
+  section staying always-loaded is an intentional fallback until that trigger has enough of a track
+  record to be trusted as the sole delivery mechanism.
 
 ## Cold Storage (promising ideas, deliberately shelved -- revisit only if a named trigger fires)
 

--- a/docs/agent-interconnect.md
+++ b/docs/agent-interconnect.md
@@ -300,10 +300,10 @@ gets silently discarded by a later one's rebuild.
 
 **`HP_DLL_DETECTED`/`HP_NEXT_DLL`/`HP_NEXT_DLL_PATH` reach `:log`'s UNQUOTED echo AND the
 `call`-triggered second-expansion-pass hazard -- see `docs/agent-lessons-learned.md`'s ":log
-echoes UNQUOTED" entry for the full mechanism and fix history.** All three values are derived from
-PyInstaller's own build-log warning text (`_PATTERN`'s regex extracts whatever sits between quotes
-in `Library not found: could not resolve 'X.dll'`), which can legally contain any of
-`&`/`|`/`<`/`>`/`%`/`^`. Sanitized copies (`HP_DLL_DETECTED_SAFE`/`HP_NEXT_DLL_SAFE`/
+echoes UNQUOTED" entry for the full mechanism and fix history.** `HP_DLL_DETECTED`/`HP_NEXT_DLL`
+are derived from PyInstaller's own build-log warning text (`_PATTERN`'s regex extracts whatever
+sits between quotes in `Library not found: could not resolve 'X.dll'`), which can legally contain
+any of `&`/`|`/`<`/`>`/`%`/`^`. Sanitized copies (`HP_DLL_DETECTED_SAFE`/`HP_NEXT_DLL_SAFE`/
 `HP_NEXT_DLL_PATH_SAFE`, computed by `tools/dll_pct_sanitize.ps1`) are used ONLY in `:log` calls --
 every functional use of the raw value (the tried-file byte-copy via `type`, the quoted
 `--add-binary` PyInstaller argument) is untouched, so this cannot desync the tried-list dedup

--- a/docs/agent-interconnect.md
+++ b/docs/agent-interconnect.md
@@ -298,42 +298,26 @@ line explicitly includes `%HP_PYI_DLLBIND%` alongside `%HP_PYI_EXPAT% %HP_PYI_CO
 own accumulated flags through EVERY later rebuild command the same way, or an earlier loop's fix
 gets silently discarded by a later one's rebuild.
 
-**A fifth real bug found via review: `HP_DLL_DETECTED`/`HP_NEXT_DLL`/`HP_NEXT_DLL_PATH` reached
-`:log`'s UNQUOTED echo AND the `call`-triggered second-expansion-pass hazard, both already
-documented in `docs/agent-lessons-learned.md`'s ":log echoes UNQUOTED" entry -- see that entry for
-the full mechanism (why `<`/`>`/`&`/`|` corrupt an unquoted `:log` echo, why `call` additionally
-makes `%`/`^` dangerous) and the three-rounds-of-getting-the-fix-wrong saga (a doubled-`%%`
-cmd.exe substitution silently produced empty output; the PowerShell replacement text then itself
-had an unpaired `%` corrupting an adjacent `%LOG%` reference) that ends with the current fix
-below.** All three values are derived from PyInstaller's own build-log warning text (`_PATTERN`'s
-regex extracts whatever sits between quotes in `Library not found: could not resolve 'X.dll'`),
-which can legally contain any of `&`/`|`/`<`/`>`/`%`/`^`.
-
-**Current fix: `HP_DLL_DETECTED_SAFE`/`HP_NEXT_DLL_SAFE`/`HP_NEXT_DLL_PATH_SAFE` are computed by
-`tools/dll_pct_sanitize.ps1` (`HP_DLL_PCT_SANITIZE`), an emitted `.ps1` file invoked via `-File
-"path" arg1 arg2...` rather than inline `-Command` text -- this is what finally eliminated the bug
-class structurally (a `-File` invocation's script body is never handed to cmd.exe's tokenizer at
-all, so there's no `%`-pairing hazard left to get wrong a fourth time).** Used ONLY in `:log`
-calls -- every functional use of the raw value (the tried-file byte-copy via `type`, the quoted
+**`HP_DLL_DETECTED`/`HP_NEXT_DLL`/`HP_NEXT_DLL_PATH` reach `:log`'s UNQUOTED echo AND the
+`call`-triggered second-expansion-pass hazard -- see `docs/agent-lessons-learned.md`'s ":log
+echoes UNQUOTED" entry for the full mechanism and fix history.** All three values are derived from
+PyInstaller's own build-log warning text (`_PATTERN`'s regex extracts whatever sits between quotes
+in `Library not found: could not resolve 'X.dll'`), which can legally contain any of
+`&`/`|`/`<`/`>`/`%`/`^`. Sanitized copies (`HP_DLL_DETECTED_SAFE`/`HP_NEXT_DLL_SAFE`/
+`HP_NEXT_DLL_PATH_SAFE`, computed by `tools/dll_pct_sanitize.ps1`) are used ONLY in `:log` calls --
+every functional use of the raw value (the tried-file byte-copy via `type`, the quoted
 `--add-binary` PyInstaller argument) is untouched, so this cannot desync the tried-list dedup
 matching (`next_dll_target()` re-extracts the RAW name from the log text on every loop iteration;
 sanitizing only the tried-file's stored copy would break equality comparison for any DLL name
 containing a hazardous character). `HP_NEXT_DLL_PATH_SAFE` needs the same treatment even though its
 raw value is a real, `os.walk()`-confirmed path, not warning text -- Windows filenames may legally
-contain `%`/`^`/`&` (NTFS's forbidden set is only `< > : " / \ | ? *` plus control characters), so a
-real conda-forge package path could carry any of these; `&` in particular is filesystem-legal but
-still a genuine CMD transport hazard once that path reaches an unquoted `:log` echo. See
-`docs/agent-lessons-learned.md`'s "PowerShell helpers: prefer an emitted `.ps1` file..." entry for
-why `-File` beats `-Command` here as a general rule, not just for this one call site.
+contain `%`/`^`/`&`, so a real conda-forge package path could carry any of these.
 
-**A companion CodeRabbit finding on the same review round: the loop's detected/skipped/repaired/
-unlocatable/failed outcomes previously reached only `:log`'s console text, with no
-machine-readable record.** Fixed with a new shared subroutine, `:emit_dll_bundle_row`, called from
-all 7 outcome points, emitting NDJSON id `self.dll_bundle.recover` -- see `docs/agent-ndjson.md`
-for the full state list, the `[Environment]::GetEnvironmentVariable` cmd.exe-argument-safety
-rationale, and the `HP_NDJSON`-scoping caveat (this row is not currently observed in
-`self.layered_e2e.chain`'s own artifact). Any future repair loop's outcome points need the same
-treatment: a `call`ed emitter subroutine plus a registered NDJSON row, not just a `:log` line.
+Every outcome of this loop (`skipped_nuitka`/`skipped_non_conda`/`repaired`/`unlocatable`/
+`exhausted`/`failed_rebuild`/`failed_missing_exe`) is emitted as NDJSON id `self.dll_bundle.recover`
+via `:emit_dll_bundle_row` -- see `docs/agent-ndjson.md` for the full state list and field schema.
+Any future repair loop's outcome points need the same treatment: a `call`ed emitter subroutine plus
+a registered NDJSON row, not just a `:log` line.
 
 **A NINTH real bug found via a CodeRabbit review round on PR #414 itself (CLAUDE.md Item 25,
 fixed in a dedicated follow-up loop): `:dll_bundle_loop` found the next candidate (`HP_NEXT_DLL`)

--- a/docs/agent-interconnect.md
+++ b/docs/agent-interconnect.md
@@ -23,8 +23,21 @@ Prefer terse, dense phrasing over narrative flow when editing or compressing ent
 transitional sentences, collapse restated context, prefer fragments and bullet lists over full
 paragraphs where the meaning survives. Accuracy and completeness matter far more than readability
 here -- do not sacrifice either for terseness, but don't spend words on prose polish an agent gets
-no benefit from either. See CLAUDE.md's Active Backlog for the standing "compress this file again"
-item this note exists to unblock.
+no benefit from either.
+
+**House rule: distill to the load-bearing rule; move the narrative to
+`docs/agent-closed-backlog.md`.** A sentence-level trim pass on this file (2026-08-09) only
+recovered ~0.2% of its word count -- the file's actual bulk is chronological incident-log
+narrative ("bug found via review, first fix was wrong, second fix was wrong, third fix confirmed
+via CI run N") wearing reference-doc clothes, not restated prose. When adding or editing an entry,
+write the CURRENT-STATE fact an agent needs before touching that code (the rule, the gotcha, the
+variable/subroutine relationship) as tightly as possible, and put the "how we found this out" blow-
+by-blow -- which review round caught it, which fix attempt was wrong and why, the exact commit/run
+IDs -- in `docs/agent-closed-backlog.md` instead, with a one-line pointer left here. That file is
+read on demand (not auto-loaded), which is exactly where debugging provenance belongs: valuable
+when someone is specifically re-investigating this area, not worth paying for every session
+regardless of task. See CLAUDE.md's Active Backlog Item 34 for the restructuring pass this
+principle is driving.
 
 ---
 
@@ -286,125 +299,41 @@ own accumulated flags through EVERY later rebuild command the same way, or an ea
 gets silently discarded by a later one's rebuild.
 
 **A fifth real bug found via review: `HP_DLL_DETECTED`/`HP_NEXT_DLL`/`HP_NEXT_DLL_PATH` reached
-`:log`'s UNQUOTED echo, an already-documented hazard class in this repo (see
-`docs/agent-lessons-learned.md`'s ":log echoes UNQUOTED" entry) this loop had not yet been checked
-against.** All three values are derived from PyInstaller's own build-log warning text (`_PATTERN`'s
+`:log`'s UNQUOTED echo AND the `call`-triggered second-expansion-pass hazard, both already
+documented in `docs/agent-lessons-learned.md`'s ":log echoes UNQUOTED" entry -- see that entry for
+the full mechanism (why `<`/`>`/`&`/`|` corrupt an unquoted `:log` echo, why `call` additionally
+makes `%`/`^` dangerous) and the three-rounds-of-getting-the-fix-wrong saga (a doubled-`%%`
+cmd.exe substitution silently produced empty output; the PowerShell replacement text then itself
+had an unpaired `%` corrupting an adjacent `%LOG%` reference) that ends with the current fix
+below.** All three values are derived from PyInstaller's own build-log warning text (`_PATTERN`'s
 regex extracts whatever sits between quotes in `Library not found: could not resolve 'X.dll'`),
-which can legally contain `&`/`|`/`<`/`>` on Windows -- exactly the metacharacter set that entry
-already documents as corrupting an unquoted `:log` echo. Fixed with the same DISPLAY-ONLY
-sanitization pattern the `%HP_ENTRY%` case documents as the correct fix wherever the source is
-tractable (unlike `%HP_ENTRY%` itself, which remains an accepted risk since its only real fix -- a
-global `:log` rework -- is blocked by three CI static guards): `HP_DLL_DETECTED_SAFE`/
-`HP_NEXT_DLL_SAFE`/`HP_NEXT_DLL_PATH_SAFE` are computed via chained `set "VAR_SAFE=%VAR_SAFE:&=_%"`
-substitution (repeated for `|`, `<`, `>`) immediately after each raw value is captured, and used
-ONLY in `:log` calls -- every functional use of the raw value (the tried-file byte-copy via `type`,
-the quoted `--add-binary` PyInstaller argument) is untouched, so this cannot desync the tried-list
-dedup matching (`next_dll_target()` re-extracts the RAW name from the log text on every loop
-iteration; sanitizing only the tried-file's stored copy would break equality comparison for any DLL
-name containing a hazardous character).
+which can legally contain any of `&`/`|`/`<`/`>`/`%`/`^`.
 
-**A sixth real bug found via a SECOND review pass on the fifth bug's own fix: the `_SAFE`
-sanitization above stripped `&`/`|`/`<`/`>` but left `%` and `^` untouched, missing that `call`
-performs its OWN, SECOND cmd.exe expansion pass on the command line it is calling** -- a
-well-established (if not officially documented by Microsoft) cmd.exe behavior: `call :log "...
-%HP_NEXT_DLL_SAFE% ..."` is itself an ordinary command line, so `%HP_NEXT_DLL_SAFE%` is substituted
-once during the NORMAL parse (as with any `%VAR%` reference) -- but because the command is `call`,
-cmd.exe then re-scans the ALREADY-SUBSTITUTED text a second time before actually invoking `:log`.
-If that substituted text happened to contain something shaped like `%SOME_VAR%` (a crafted "library
-not found" name from an adversarial native extension, since `_PATTERN`'s regex only excludes quote
-characters, not `%`/`^`), that second pass would expand `SOME_VAR`'s real value into what `:log`
-receives as `%~1` -- potentially leaking an unrelated environment variable (e.g. a CI secret).
-
-**First fix attempt was itself wrong, and only caught because a live-cmd.exe CI test was built to
-verify it.** The initial fix extended all three `_SAFE` chains with `set "VAR_SAFE=%VAR_SAFE:%%=_%"`
-on the theory that doubling `%` to `%%` is "the standard, long-established cmd.exe idiom" for
-matching a literal percent sign as the search token in a `:search=replace` substitution. This is
-**not actually how cmd.exe behaves** -- confirmed via `tests/harness.ps1`'s
-`batch.dll_bundle.pct_sanitizer` fixture (built specifically to settle a Blinter E021 "malformed
-string operation" flag on this construct empirically rather than trust static reasoning a fourth
-time) executed for real on Windows CI: the substitution silently produced an **empty** value
-(`echo` with no argument, `"ECHO is off."`) instead of the expected sanitized text -- an
-undocumented cmd.exe parsing quirk, not a Blinter false positive as first assumed. This broke
-`HP_DLL_DETECTED_SAFE`/`HP_NEXT_DLL_SAFE`/`HP_NEXT_DLL_PATH_SAFE` across essentially every CI lane
-(the gating `batch.dll_bundle.pct_sanitizer` NDJSON row failed the run).
-
-**Actual fix: strip `%` and `^` in PowerShell instead of cmd.exe substitution.** Each `_SAFE`
-variable's `%`/`^` stripping now happens via a `powershell -NoProfile -ExecutionPolicy Bypass
--Command` call, read back via a plain, non-`call` `for /f "usebackq delims=" %%X in
-("~dll_pct_safe*.txt") do set "VAR_SAFE=%%X"`. Reading the value via
-`[Environment]::GetEnvironmentVariable` (never substituting it into the `-Command` text itself)
-means this cannot reintroduce the same `call`-triggered second-pass hazard one layer up. `HP_NEXT_
-DLL_SAFE`/`HP_NEXT_DLL_PATH_SAFE` are sanitized in ONE PowerShell invocation writing TWO separate
-output files (`~dll_pct_safe_a.txt`/`~dll_pct_safe_b.txt`), not one combined multi-line file --
-this repo bans delayed expansion (`!VAR!`) repo-wide, which parsing multiple lines out of one file
-back into two batch variables would otherwise need. `&`/`|`/`<`/`>` stripping is unchanged (still
-plain cmd.exe `:search=replace` substitution -- that part was never wrong, only the `%%` escape
-attempt was).
-
-**A THIRD real bug, caught by this fixture's own first real Windows CI run (the fixture proved
-itself trustworthy again, not the fix): a lone, unpaired `%` inside the literal PowerShell text
-`-replace '%','_'` sits on the SAME cmd.exe logical line as `%LOG%` (or, in the fixture itself,
-`%TEMP%`).** cmd.exe pairs `%` characters via a left-to-right scan of the WHOLE line, completely
-ignoring quote boundaries -- the lone `%` paired with `%LOG%`'s own opening `%`, and cmd.exe
-treated everything between them (the entire real replace logic, dozens of characters) as one
-bogus, undefined variable name. Inside a batch file, an undefined `%VAR%` reference is silently
-removed and replaced with empty text (not left literal, the classic batch-only gotcha) -- so the
-whole PowerShell command was gutted before it ever ran, producing an empty output file and the
-identical `"ECHO is off."` failure signature as the first bug, on every single lane again. The
-`HP_NEXT_DLL_SAFE`/`HP_NEXT_DLL_PATH_SAFE` block had a variant of the same bug with an EVEN total
-`%` count (two lone `%`'s from two `-replace` calls, plus `%LOG%`'s own pair) -- even parity is
-not enough to prove correct pairing: the two lone `%`'s paired with EACH OTHER instead of each
-pairing with `%LOG%`, silently deleting the entire first `Set-Content` call as one bogus variable
-name. **Fixed by removing every literal `%` from the `-Command` text entirely**: `$pct = [char]37`
-builds the percent character inside PowerShell itself, so the only `%` remaining on any of these
-cmd.exe lines is the single, legitimate, correctly-paired `%LOG%`/`%TEMP%` reference -- verified by
-literally counting `%` occurrences per logical (continuation-joined) line after the fix (exactly 2
-in every case, the one intended pair). `tests/harness.ps1`'s `batch.dll_bundle.pct_sanitizer`
-fixture was updated with the same `[char]37` technique -- it validates the REPLACEMENT mechanism
-(still a real cmd.exe + PowerShell child-process execution, not static pattern matching) and
-additionally proves the actual security property end-to-end: a raw value shaped like `%SECRET%`,
-once sanitized, survives a real `call`-based second expansion pass without leaking the shadowed
-`SECRET` variable's true value. Order among all six substitutions
-(`&`/`|`/`<`/`>`/`%`/`^`) is commutative -- none of them can match the replacement character (`_`),
-so chaining them in any order produces the same result. `HP_NEXT_DLL_PATH_SAFE` needs the same `%`/
-`^` stripping even though its raw value is a real, `os.walk()`-confirmed path (unlike
-`HP_DLL_DETECTED`/`HP_NEXT_DLL`, which are regex-extracted from arbitrary warning text) -- Windows
-filenames may legally contain `%`, `^`, and `&` (NTFS's own forbidden set is only
-`< > : " / \ | ? *` plus control characters), so a real conda-forge package path could carry any of
-these. `&` is a valid filename character but still a genuine CMD *transport* hazard once that path
-reaches an unquoted `:log` echo -- legality on disk and safety on a cmd.exe command line are
-unrelated axes, which is why it still needs the same sanitization as `|`/`<`/`>` (those three ARE
-also filesystem-illegal, so a real path containing them would be a defect elsewhere; `&` is the one
-character in this set that's both filesystem-legal and CMD-hazardous).
-
-**Eventually converted to a real emitted `.ps1` file (`tools/dll_pct_sanitize.ps1`,
-`HP_DLL_PCT_SANITIZE`), which eliminates this entire bug class structurally rather than patching
-around it a fourth time.** All three bugs above share one root cause: literal `%` text sitting
-somewhere on a line cmd.exe itself parses. A `-File "path" arg1 arg2...` invocation has no such
-line -- cmd.exe only tokenizes the outer invocation (plain argv, no `%`-pairing hazard); the
-script's own body is read and executed entirely by PowerShell, which never sees cmd.exe's parser
-at all. Both call sites (`HP_DLL_DETECTED_SAFE`; `HP_NEXT_DLL_SAFE`/`HP_NEXT_DLL_PATH_SAFE`) now
-call this one shared helper (`(envVarName, outFile)` pairs as plain argv) instead of building
-inline `-Command` text per call site. See `docs/agent-lessons-learned.md`'s "PowerShell helpers:
-prefer an emitted `.ps1` file..." entry, extended with this as a second, independent trigger
-condition (alongside embedded `"` characters) for preferring `-File` over `-Command`.
+**Current fix: `HP_DLL_DETECTED_SAFE`/`HP_NEXT_DLL_SAFE`/`HP_NEXT_DLL_PATH_SAFE` are computed by
+`tools/dll_pct_sanitize.ps1` (`HP_DLL_PCT_SANITIZE`), an emitted `.ps1` file invoked via `-File
+"path" arg1 arg2...` rather than inline `-Command` text -- this is what finally eliminated the bug
+class structurally (a `-File` invocation's script body is never handed to cmd.exe's tokenizer at
+all, so there's no `%`-pairing hazard left to get wrong a fourth time).** Used ONLY in `:log`
+calls -- every functional use of the raw value (the tried-file byte-copy via `type`, the quoted
+`--add-binary` PyInstaller argument) is untouched, so this cannot desync the tried-list dedup
+matching (`next_dll_target()` re-extracts the RAW name from the log text on every loop iteration;
+sanitizing only the tried-file's stored copy would break equality comparison for any DLL name
+containing a hazardous character). `HP_NEXT_DLL_PATH_SAFE` needs the same treatment even though its
+raw value is a real, `os.walk()`-confirmed path, not warning text -- Windows filenames may legally
+contain `%`/`^`/`&` (NTFS's forbidden set is only `< > : " / \ | ? *` plus control characters), so a
+real conda-forge package path could carry any of these; `&` in particular is filesystem-legal but
+still a genuine CMD transport hazard once that path reaches an unquoted `:log` echo. See
+`docs/agent-lessons-learned.md`'s "PowerShell helpers: prefer an emitted `.ps1` file..." entry for
+why `-File` beats `-Command` here as a general rule, not just for this one call site.
 
 **A companion CodeRabbit finding on the same review round: the loop's detected/skipped/repaired/
 unlocatable/failed outcomes previously reached only `:log`'s console text, with no
 machine-readable record.** Fixed with a new shared subroutine, `:emit_dll_bundle_row`, called from
-all 7 outcome points (`skipped_nuitka`/`skipped_non_conda`/`repaired`/`unlocatable`/`exhausted`/
-`failed_rebuild`/`failed_missing_exe`) and emitting NDJSON id `self.dll_bundle.recover` -- see
-`docs/agent-ndjson.md` for the full field list and the `HP_NDJSON`-scoping caveat (this row is
-not currently observed in `self.layered_e2e.chain`'s own artifact, since that test's isolated
-sub-bootstrap leaves `HP_NDJSON` unset by the same established convention `selfapps_postexec_
-checkpoint.ps1` already uses; `tests/harness.ps1`'s new `batch.dll_bundle.ndjson` static check is
-the actual coverage for this row's wiring). The state name is passed as a `call` argument (safe --
-always one of the 7 literal tokens above, written directly in `run_setup.bat`, never derived from
-external content), but the DLL name/provider/iteration are pulled INSIDE the emitting PowerShell
-command via `[Environment]::GetEnvironmentVariable(...)` rather than `%VAR%` cmd.exe substitution
-into the `-Command` text -- protecting cmd.exe's OWN command-line parsing (`&`/`|` are
-metacharacters even inside a quoted `call` argument) the same way the `_SAFE` display variables
-protect `:log`'s unquoted echo, just at a different vulnerable site.
+all 7 outcome points, emitting NDJSON id `self.dll_bundle.recover` -- see `docs/agent-ndjson.md`
+for the full state list, the `[Environment]::GetEnvironmentVariable` cmd.exe-argument-safety
+rationale, and the `HP_NDJSON`-scoping caveat (this row is not currently observed in
+`self.layered_e2e.chain`'s own artifact). Any future repair loop's outcome points need the same
+treatment: a `call`ed emitter subroutine plus a registered NDJSON row, not just a `:log` line.
 
 **A NINTH real bug found via a CodeRabbit review round on PR #414 itself (CLAUDE.md Item 25,
 fixed in a dedicated follow-up loop): `:dll_bundle_loop` found the next candidate (`HP_NEXT_DLL`)

--- a/docs/agent-lessons-learned.md
+++ b/docs/agent-lessons-learned.md
@@ -19,6 +19,15 @@ shell gotchas; record those here. Record cross-component effects in the intercon
 a lesson is later disproven or fixed at the source, edit the entry to say so rather than
 leaving stale guidance.**
 
+**House rule: distill to the load-bearing rule; move the narrative to
+`docs/agent-closed-backlog.md`.** This file is auto-loaded every session (like
+`docs/agent-interconnect.md`), never read by a person browsing the repo casually -- prefer terse,
+dense phrasing over narrative flow, same as that file. When an entry accumulates multiple rounds
+of "this fix was also wrong" (several already have), keep only the CURRENT-STATE rule plus a
+one-line summary of why the obvious alternative doesn't work; move the full blow-by-blow of which
+attempt failed and how it was caught to `docs/agent-closed-backlog.md`, with a pointer left here.
+See CLAUDE.md's Active Backlog Item 34 for the restructuring pass this principle is driving.
+
 ---
 
 ## Quote a variable before piping it into `findstr`, or `&` in its value splits the command line

--- a/docs/agent-ndjson.md
+++ b/docs/agent-ndjson.md
@@ -10,6 +10,14 @@ https://mixmansoundude.github.io/Python_vs_Windows/
 update this file in the same commit. Row IDs listed here act as a registry to catch
 accidental removal or unexpected additions.**
 
+**House rule: distill to the load-bearing rule; move the narrative to
+`docs/agent-closed-backlog.md`.** This file's job is the registry itself (row id -> emitting
+test/lane/mechanism) -- keep annotations to what a row means and how it's gated, not a retelling
+of the bug that motivated adding it. If a row's own mechanism is already documented at length in
+`docs/agent-interconnect.md` or `docs/agent-lessons-learned.md`, point there instead of
+re-explaining it here. See CLAUDE.md's Active Backlog Item 34 for the restructuring pass this
+principle is driving.
+
 ---
 
 ## CI-artifacts NDJSON (selfapps tests, conda-full lane)


### PR DESCRIPTION
## Summary

- First loop of CLAUDE.md Active Backlog Item 34, the follow-up to Item 30 (PR #428). Item 30's
  compression pass found that further sentence-level trimming was a saturated lever on
  `docs/agent-interconnect.md` (~0.2% word reduction) — the file's bulk is chronological
  incident-log narrative ("bug found via review, first fix was wrong, second fix was wrong, third
  fix confirmed via CI run N") wearing reference-doc clothes, not restated prose. This loop tackles
  the cheapest, zero-information-loss slice of the structural fix.
- Adds a **"distill to the load-bearing rule; move the narrative to
  `docs/agent-closed-backlog.md`"** house rule to the top of all three auto-loaded knowledge docs
  (`agent-interconnect.md`, `agent-lessons-learned.md`, `agent-ndjson.md`).
- Dedupes the two confirmed cross-file duplications:
  - The cmd.exe `%`-pairing sanitizer saga, previously told at length in both
    `agent-interconnect.md`'s DLL-bundling section and `agent-lessons-learned.md`'s ":log echoes
    UNQUOTED" entry. Canonical home is now `agent-lessons-learned.md` (it's a standalone cmd.exe
    hazard, matching that file's own categorization principle); `agent-interconnect.md` keeps only
    the DLL-bundling-specific consequence plus a pointer.
  - The `self.dll_bundle.recover` NDJSON row's mechanism, previously fully re-explained in both
    `agent-interconnect.md` and `agent-ndjson.md`. Canonical home is now `agent-ndjson.md` (its
    whole job is documenting row semantics); `agent-interconnect.md` keeps only the
    cross-component fact (a new repair loop needs a matching emitter + registered row) plus a
    pointer.
- Net effect: `agent-interconnect.md` drops from 1981 → 1918 lines (20991 → 20224 words, ~3.7%
  reduction) — a real structural cut, not sentence-shaving. No fact was deleted, only moved to its
  single correct home with a pointer left behind.
- Adds CLAUDE.md Active Backlog Item 34 itself (this PR closes only its first of three sub-loops;
  loops 2 — relocate CLAUDE.md's "Known Findings" section to `agent-closed-backlog.md` — and 3 —
  distill CLAUDE.md's dependency-strategy essay — remain open).

## Test plan

- [x] `tools/run_sanity_sweep.sh CLAUDE.md docs/agent-interconnect.md docs/agent-lessons-learned.md docs/agent-ndjson.md` — all checks pass (compileall, pyflakes, delimiters, yamllint, actionlint, ASCII sweep, PowerShell AST parse sweep, `pytest` 515 passed / 3 skipped).
- [x] Verified no dangling references (e.g. renumbered "fifth/sixth/seventh bug" labels) were left orphaned by the interconnect.md trim.
- [x] Prose-only diff confirmed via `git diff --stat` — no code/test files touched.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01A4iE1BRSkUETwz237XeuTW

---
_Generated by [Claude Code](https://claude.ai/code/session_01A4iE1BRSkUETwz237XeuTW)_