### PR TITLE
Close Item 44's CI-coverage gap: test hooks for line-ending preflight branches

### DIFF
--- a/.github/workflows/batch-check.yml
+++ b/.github/workflows/batch-check.yml
@@ -944,6 +944,12 @@ jobs:
         run: |
           & tests\selfapps_preflight.ps1
 
+      - name: "Self-test: line-ending self-check preflight branches (real/conda-full only)"
+        if: ${{ !cancelled() && (matrix.mode == 'real' || (matrix.mode == 'conda-full' && steps.conda_avail.outputs.available == 'true')) }}
+        shell: pwsh
+        run: |
+          & tests\selfapps_lineending_check.ps1
+
       - name: "Self-test: EXE smokerun XFAIL missing data file (real/conda-full only)"
         if: ${{ !cancelled() && (matrix.mode == 'real' || (matrix.mode == 'conda-full' && steps.conda_avail.outputs.available == 'true')) }}
         shell: pwsh

--- a/.github/workflows/batch-check.yml
+++ b/.github/workflows/batch-check.yml
@@ -2113,6 +2113,18 @@ jobs:
             tests/~test-summary.txt
             tests/~test-results.ndjson
             tests\~test-results.ndjson
+            tests/~selftest_lineending_no_ps/~lineending_bootstrap.log
+            tests\~selftest_lineending_no_ps\~lineending_bootstrap.log
+            tests/~selftest_lineending_no_ps/~bootstrap.status.json
+            tests\~selftest_lineending_no_ps\~bootstrap.status.json
+            tests/~selftest_lineending_ps_fail/~lineending_bootstrap.log
+            tests\~selftest_lineending_ps_fail\~lineending_bootstrap.log
+            tests/~selftest_lineending_ps_fail/~bootstrap.status.json
+            tests\~selftest_lineending_ps_fail\~bootstrap.status.json
+            tests/~selftest_lineending_lf_only/~lineending_bootstrap.log
+            tests\~selftest_lineending_lf_only\~lineending_bootstrap.log
+            tests/~selftest_lineending_lf_only/~bootstrap.status.json
+            tests\~selftest_lineending_lf_only\~bootstrap.status.json
             tests/extracted/**
           if-no-files-found: ignore
           include-hidden-files: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -958,55 +958,6 @@ the same session, no new information, not re-filed). Each item below was checked
 source directly, not taken on the reviews' word alone; where a claim could not be confirmed this
 way (no live Windows execution available here), that is noted explicitly rather than stated as fact.
 
-- **Item 44: the Prime-Directive download path serves `run_setup.bat` with broken (LF-only) line
-  endings, and cmd.exe's goto/call silently misbehaves on the result.** Confirmed directly: a raw
-  download (GitHub's "Raw" button, or a `raw.githubusercontent.com` link) is 447,375 bytes with
-  zero CRLF pairs; the same file via a real `git clone` checkout is 452,917 bytes with 5,542 CRLF
-  pairs -- a delta of exactly one byte per line, matching `.gitattributes`'s own model exactly:
-  `* text=auto eol=lf` normalizes the STORED blob to LF regardless of the `*.bat text eol=crlf`
-  override, and that override only affects checkout-time conversion, never the blob GitHub serves
-  raw. Every natural "just get me the file" path a beginner would take (the Raw button, a
-  raw.githubusercontent.com link found via search) hands them a corrupted copy; only `git clone`
-  (or any path that performs a real checkout) gets it right today.
-
-  **Consequence, confirmed against the real symptom triad from the sandbox session**: cmd.exe
-  resolves `goto`/`call` by relocating to a byte offset associated with the target label; an
-  LF-only copy of a ~4700-line file with 129 labels drifts that offset by one byte per line
-  crossed, compounding with each jump. This produces exactly what was observed: a `goto`/`call`
-  landing on the wrong spot ("the system cannot find the batch label specified" for a label that
-  genuinely exists), a `%HP_PY%`-dependent line executing before `HP_PY` was ever assigned because
-  an earlier gating block was skipped by the drift (`'""' is not recognized as an internal or
-  external command`), and a run that partially completes -- early, purely-sequential code runs
-  fine, everything past the first mis-resolved jump does not. No CI lane can catch this: every CI
-  checkout goes through `actions/checkout`, which always applies `.gitattributes`'s `eol=crlf`
-  conversion, so the broken artifact only ever exists in what a real user downloads, never in what
-  CI tests.
-
-  **Mitigated this session, not fully fixed**: `run_setup.bat` now self-checks its own line endings
-  as literally the first thing it does (before any other `goto`/`call` in the file, so the check
-  itself stays reliable even on a corrupted copy -- see the new block right after `setlocal` at the
-  top of the file), and fails fast with a clear, actionable message instead of a silent, partial,
-  undiagnosable run. This does not fix the distribution channel itself -- a user can still land on
-  a raw link and get the broken file; the check only turns that into a loud, fixable failure instead
-  of the multi-hour debugging session that surfaced this item. See `docs/open-questions.md` for the
-  maintainer decision on whether/how to fix distribution itself (pro/con on the `.gitattributes`
-  options), and README.md's new TL;DR bullet recommending `git clone` in the meantime.
-
-  **Known gap, deliberately not closed in the same slice: the new self-check has no CI coverage of
-  its own, in explicit tension with AGENTS.md's stated rule that every branch added to
-  `run_setup.bat` must have a CI test.** Flagged by both external reviews on the PR that shipped
-  this item (Codex, citing AGENTS.md directly) -- a normal Actions checkout only ever exercises the
-  CRLF happy path (`actions/checkout` always applies `.gitattributes`'s `eol=crlf` conversion, same
-  reason no CI lane could catch the original bug), so a future quoting/errorlevel regression in any
-  of its three branches -- PowerShell absent from PATH entirely, PowerShell present but the check's
-  own invocation fails (`errorlevel 2`), or a genuine LF-only copy of the file -- could silently
-  break or remove the check with nothing in CI to notice. Needs a dedicated `HP_TEST_*` hook
-  (matching this repo's established pattern, e.g. `HP_TEST_FORCE_UV_FAIL`) that deterministically
-  forces each of the three, plus an NDJSON row asserting the emitted message and exit code for each.
-  Deliberately
-  deferred rather than built inline: real test-authoring scope (a new selfapps scenario, workflow
-  wiring, NDJSON registry update), not a small slice on top of the fix that was already in flight.
-
 - **Item 45: gate the build/warnfix/repair block on `HP_PY` actually existing, so a failed
   env-create cannot cascade into a doomed PyInstaller build plus multiple repair-loop attempts with
   no interpreter behind any of them.** Deliberately scoped narrow -- this is the small, isolated

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -947,7 +947,7 @@ but several represent real gaps worth closing before calling the path fully rele
   `run_setup.bat` next to your scripts, or move your scripts up into this folder" instead of (or
   alongside) the generic zero-files message.
 
-Items 44-52 below stem from a 2026-08-14 real Windows Sandbox debugging session (two independent
+Items 45-52 below stem from a 2026-08-14 real Windows Sandbox debugging session (two independent
 external AI reviews plus direct verification against current source by the acting agent) chasing a
 garbled first run (repeated pauses, a PyInstaller build loop with no environment behind it, some
 files written and others not). The root cause (Item 44) turned out to be file corruption from the

--- a/docs/agent-closed-backlog.md
+++ b/docs/agent-closed-backlog.md
@@ -1946,6 +1946,87 @@ this belongs to).
   enough of a track record to be trusted as the sole delivery mechanism. Revisit whether it can
   move out once that track record exists.
 
+### Item 44 (closed 2026-08-14)
+
+- **The Prime-Directive download path serves `run_setup.bat` with broken (LF-only) line endings,
+  and cmd.exe's goto/call silently misbehaves on the result.** Confirmed directly: a raw download
+  (GitHub's "Raw" button, or a `raw.githubusercontent.com` link) is 447,375 bytes with zero CRLF
+  pairs; the same file via a real `git clone` checkout is 452,917 bytes with 5,542 CRLF pairs --
+  a delta of exactly one byte per line, matching `.gitattributes`'s own model exactly: `* text=auto
+  eol=lf` normalizes the STORED blob to LF regardless of the `*.bat text eol=crlf` override, and
+  that override only affects checkout-time conversion, never the blob GitHub serves raw. Every
+  natural "just get me the file" path a beginner would take (the Raw button, a
+  raw.githubusercontent.com link found via search) hands them a corrupted copy; only `git clone`
+  (or any path that performs a real checkout) gets it right.
+
+  **Consequence, confirmed against a real symptom triad from a Windows Sandbox debugging
+  session**: cmd.exe resolves `goto`/`call` by relocating to a byte offset associated with the
+  target label; an LF-only copy of a ~4700-line file with 129 labels drifts that offset by one
+  byte per line crossed, compounding with each jump. This produced exactly what was observed: a
+  `goto`/`call` landing on the wrong spot ("the system cannot find the batch label specified" for
+  a label that genuinely exists), a `%HP_PY%`-dependent line executing before `HP_PY` was ever
+  assigned because an earlier gating block was skipped by the drift (`'""' is not recognized as an
+  internal or external command`), and a run that partially completes -- early, purely-sequential
+  code runs fine, everything past the first mis-resolved jump does not. No CI lane could catch
+  this: every CI checkout goes through `actions/checkout`, which always applies `.gitattributes`'s
+  `eol=crlf` conversion, so the broken artifact only ever existed in what a real user downloaded,
+  never in what CI tested -- exactly the gap the fix below (and its own regression test) closes.
+
+  **Fix: `run_setup.bat` self-checks its own line endings as literally the first thing it does**
+  (before any other `goto`/`call` in the file, so the check itself stays reliable even on a
+  corrupted copy -- see the block right after `setlocal` at the top of the file), and fails fast
+  with a clear, actionable message instead of a silent, partial, undiagnosable run. This does not
+  fix the distribution channel itself -- a user can still land on a raw link and get the broken
+  file, they just now get told clearly instead of hitting the multi-hour debugging session that
+  surfaced this item. See `docs/open-questions.md`'s open item 2 for the maintainer decision on
+  whether/how to fix distribution itself (pro/con on the `.gitattributes` options -- a genuinely
+  separate, still-open question, not a precondition for this item's own closure), and README.md's
+  TL;DR bullet recommending `git clone` in the meantime.
+
+  **CI coverage for the self-check's own three failure branches, closed in the same overall item
+  (a second loop, after the mitigation above had already shipped and soaked one review round).**
+  Flagged by external review (Codex, citing AGENTS.md's rule that every branch added to
+  `run_setup.bat` must have a CI test) as a real gap: a normal Actions checkout only ever exercises
+  the CRLF happy path, so a future quoting/errorlevel regression in any of the check's three
+  branches -- PowerShell absent from PATH entirely, PowerShell present but the check's own
+  invocation fails (`errorlevel 2`), or a genuine LF-only copy of the file -- could have silently
+  broken or removed the check with nothing in CI to notice. Closed via three new `HP_TEST_FORCE_*`
+  hooks plus `tests/selfapps_lineending_check.ps1` (wired gating into `real`/`conda-full`,
+  matching `self.preflight.syntax`'s own precedent for a cheap, provider-agnostic, pure-batch
+  preflight test -- see `docs/agent-ndjson.md`'s own section for the row ids and mechanism).
+  `HP_TEST_FORCE_NO_POWERSHELL` forces a synthetic nonzero errorlevel right after the real `where
+  powershell` call, with no PATH tampering (spawning and hiding a real `powershell.exe` from PATH
+  on a shared CI runner was considered and rejected as needlessly risky for zero extra coverage
+  value). `HP_TEST_FORCE_LF_ONLY` and `HP_TEST_FORCE_PS_CHECK_FAIL` both redirect `HP_SELF_PATH`
+  at something other than the running copy of `run_setup.bat` itself (a synthetic pure-LF sentinel
+  file, or a path that does not exist) rather than corrupting the file actually executing -- the
+  running copy must stay healthy CRLF to reliably reach and execute the hook logic at all. Pointing
+  at a nonexistent path makes the real, unmodified PowerShell command genuinely throw
+  (`FileNotFoundException`) and hit its own `catch{exit 2}` branch, exercising the real failure
+  path rather than a simulated one. All three hooks and the underlying PowerShell command's exact
+  behavior for each case were verified directly against a real PowerShell 7 binary before being
+  wired in, not just reasoned about -- this also caught a genuine bug in the test script itself
+  before it ever reached CI: an initial draft used PowerShell's `-like "*...*"` for substring
+  assertions, which silently mis-evaluates any expected string containing `[`/`]` (its wildcard
+  syntax treats brackets as a character class, not literal text) -- exactly the shape of the
+  `[ERROR]`-prefixed messages this check emits. Fixed to a plain `.Contains()` before landing.
+
+  **A raw-download-from-the-PR's-own-branch test (fetching the real corrupted bytes via
+  `raw.githubusercontent.com` instead of synthesizing them locally) was considered and rejected**
+  for the CI-gating test specifically: it would add a real network dependency and fork-branch-
+  resolution complexity for no additional coverage, since the corruption mechanism was already
+  triangulated at the byte level above -- a locally-synthesized pure-LF file exercises the exact
+  same detection logic and the exact same cmd.exe byte-offset-drift hazard as a genuine raw
+  download, because what matters to the detection algorithm is the byte content, not the transport
+  that produced it. This also keeps the new test deterministic and gating-lane-appropriate,
+  matching this repo's general preference (`self.dl.uv.fallback`/`self.dl.conda.fallback` are the
+  only tests in this repo that deliberately hit real external download endpoints, and both are
+  non-gating specifically because of that). A periodic, informational, non-gating confirmation
+  that `raw.githubusercontent.com` still serves LF-only content (i.e., the general premise behind
+  this whole item still holds) would be a legitimate "next-pin probe"-style addition to CLAUDE.md's
+  Periodic Maintenance Checks section if ever wanted -- not built here, since nothing about it is
+  urgent or was explicitly requested.
+
 ## Known Findings (diagnosed, no action warranted)
 
 - **Backlog item numbering: renumber-on-collision convention dropped, 2026-07-31 owner decision.**

--- a/docs/agent-closed-backlog.md
+++ b/docs/agent-closed-backlog.md
@@ -1972,8 +1972,8 @@ this belongs to).
   `eol=crlf` conversion, so the broken artifact only ever existed in what a real user downloaded,
   never in what CI tested -- exactly the gap the fix below (and its own regression test) closes.
 
-  **Fix: `run_setup.bat` self-checks its own line endings as literally the first thing it does**
-  (before any other `goto`/`call` in the file, so the check itself stays reliable even on a
+  **Fix: `run_setup.bat` runs its "LINE-ENDING SELF-CHECK" block before any `goto`/`call`**
+  (so the check itself stays reliable even on a
   corrupted copy -- see the file's own "LINE-ENDING SELF-CHECK" header banner; this block
   deliberately predates every `:label` in the file, so no subroutine name exists to cite instead),
   and fails fast

--- a/docs/agent-closed-backlog.md
+++ b/docs/agent-closed-backlog.md
@@ -2014,11 +2014,16 @@ this belongs to).
   **A raw-download-from-the-PR's-own-branch test (fetching the real corrupted bytes via
   `raw.githubusercontent.com` instead of synthesizing them locally) was considered and rejected**
   for the CI-gating test specifically: it would add a real network dependency and fork-branch-
-  resolution complexity for no additional coverage, since the corruption mechanism was already
-  triangulated at the byte level above -- a locally-synthesized pure-LF file exercises the exact
-  same detection logic and the exact same cmd.exe byte-offset-drift hazard as a genuine raw
-  download, because what matters to the detection algorithm is the byte content, not the transport
-  that produced it. This also keeps the new test deterministic and gating-lane-appropriate,
+  resolution complexity for no additional coverage on the axis this test actually covers -- the
+  DETECTION logic (does the check's own PowerShell command correctly classify pure-LF content as
+  invalid), which a locally-synthesized pure-LF file exercises identically to a genuine raw
+  download, since what matters to that algorithm is the byte content, not the transport that
+  produced it. **This test does not itself execute an LF-only copy of `run_setup.bat` or observe
+  real cmd.exe goto/call byte-offset-drift misbehavior** -- the running copy stays healthy CRLF
+  throughout every scenario, only `HP_SELF_PATH` (what the check reads) is redirected; that
+  separate hazard was established independently, via the original sandbox debugging session's own
+  symptom triad (see above), not by this test. This also keeps the new test deterministic and
+  gating-lane-appropriate,
   matching this repo's general preference (`self.dl.uv.fallback`/`self.dl.conda.fallback` are the
   only tests in this repo that deliberately hit real external download endpoints, and both are
   non-gating specifically because of that). A periodic, informational, non-gating confirmation

--- a/docs/agent-closed-backlog.md
+++ b/docs/agent-closed-backlog.md
@@ -1974,7 +1974,9 @@ this belongs to).
 
   **Fix: `run_setup.bat` self-checks its own line endings as literally the first thing it does**
   (before any other `goto`/`call` in the file, so the check itself stays reliable even on a
-  corrupted copy -- see the block right after `setlocal` at the top of the file), and fails fast
+  corrupted copy -- see the file's own "LINE-ENDING SELF-CHECK" header banner; this block
+  deliberately predates every `:label` in the file, so no subroutine name exists to cite instead),
+  and fails fast
   with a clear, actionable message instead of a silent, partial, undiagnosable run. This does not
   fix the distribution channel itself -- a user can still land on a raw link and get the broken
   file, they just now get told clearly instead of hitting the multi-hour debugging session that

--- a/docs/agent-ndjson.md
+++ b/docs/agent-ndjson.md
@@ -54,6 +54,7 @@ self.exe.warnfix.real_warnfix_delayed,
 self.collect.submodules,
 self.exe.hidden_import, self.exe.hidden_import.exhaust,
 self.preflight.syntax,
+self.preflight.no_powershell, self.preflight.ps_check_fail, self.preflight.lf_only,
 self.cascade.detect, self.cascade.consent, self.cascade.timed,
 self.cascade.exec (uv lane only -- selfapps_cascade.ps1; non-gating),
 self.cascade.conda_create_fail (uv lane only -- selfapps_cascade_conda_create_fail.ps1; non-gating),
@@ -898,6 +899,36 @@ restore-keys prefix match, and records whether that real self-heal attempt actua
 (`details.healed`). Always `pass:true` (informational, matching `self.cache.corrupted`'s own
 convention) -- its purpose is to make an organic occurrence queryable on the diagnostics site
 over time instead of requiring a raw-log dig to notice it happened at all, not to gate.
+
+---
+
+## selfapps-lineending-check NDJSON rows (selfapps_lineending_check.ps1, real/conda-full lanes, GATING)
+
+CLAUDE.md Active Backlog Item 44's own "Known gap": the line-ending self-check at the top of
+`run_setup.bat` (before any goto/call in the file -- see the file's own header comment) had zero
+CI coverage of its three failure branches, since a normal `actions/checkout` always normalizes to
+CRLF, so CI could exercise only the happy path on real cmd.exe, never the failure branches. Three
+new `HP_TEST_FORCE_*` hooks close this: `HP_TEST_FORCE_NO_POWERSHELL` forces a synthetic nonzero
+errorlevel right after the real `where powershell` call (no PATH tampering); `HP_TEST_FORCE_LF_
+ONLY` and `HP_TEST_FORCE_PS_CHECK_FAIL` both redirect `HP_SELF_PATH` at something other than the
+running copy of `run_setup.bat` (a synthetic pure-LF sentinel file, or a path that does not exist)
+rather than corrupting the file actually executing -- the running copy must stay healthy CRLF to
+reliably reach and execute the hook logic at all. Pointing at a nonexistent path makes the real,
+unmodified PowerShell command genuinely throw (`FileNotFoundException`) and hit its own
+`catch{exit 2}` branch, exercising the real failure path rather than a simulated one. All three
+hooks and the underlying PowerShell command's exact behavior for each case (nonexistent path ->
+exit 2; pure-LF file -> exit 1; genuine CRLF file -> exit 0) were verified directly against a real
+PowerShell 7 binary before being wired into `run_setup.bat`, not just reasoned about.
+
+Lane: `real` and `conda-full` only, gating from first landing -- matches `self.preflight.syntax`'s
+own precedent for a cheap, provider-agnostic, pure-batch preflight check (no environment or
+dependency work is ever reached in any of these three scenarios, unlike the Nuitka/MSVC-dependent
+tests elsewhere in this registry that start non-gating specifically because they could not be
+verified locally).
+
+```
+self.preflight.no_powershell, self.preflight.ps_check_fail, self.preflight.lf_only
+```
 
 ---
 

--- a/docs/open-questions.md
+++ b/docs/open-questions.md
@@ -50,17 +50,17 @@ or leave the caveat panel purely generic indefinitely and close this question as
 
 ## 2. Should the distribution channel itself be fixed so a raw download of `run_setup.bat` gets correct (CRLF) line endings, and if so, how?
 
-**Status: OPEN, raised 2026-08-14.** Background and full mechanism in CLAUDE.md's former Active
-Backlog Item 44 (now closed/mitigated -- see `docs/agent-closed-backlog.md` once archived): a raw
-download (GitHub's "Raw" button, or a `raw.githubusercontent.com` link) serves `run_setup.bat`
+**Status: OPEN, raised 2026-08-14.** Background and full mechanism in `docs/agent-closed-backlog.md`'s
+Item 44 (closed 2026-08-14, including CI coverage for the self-check's own three failure branches):
+a raw download (GitHub's "Raw" button, or a `raw.githubusercontent.com` link) serves `run_setup.bat`
 with Unix (LF-only) line endings instead of the Windows (CRLF) endings a real `git clone` checkout
 produces, because `.gitattributes`'s `* text=auto eol=lf` normalizes the STORED blob to LF and the
 `*.bat text eol=crlf` override only affects checkout-time conversion, never what GitHub serves raw.
 cmd.exe's goto/call label-seeking silently misbehaves on the LF-only copy, producing a confusing,
-partial, undiagnosable run. A same-session mitigation now makes `run_setup.bat` self-detect this
-and fail with a clear message (see the top of the file) -- but the distribution channel itself is
-unchanged: a user can still land on a raw link and get the broken file, they just now get told
-clearly instead of being left confused.
+partial, undiagnosable run. A mitigation now makes `run_setup.bat` self-detect this and fail with a
+clear message (see the top of the file), with CI coverage of its own for all three failure branches
+-- but the distribution channel itself is unchanged: a user can still land on a raw link and get the
+broken file, they just now get told clearly instead of being left confused.
 
 **The maintainer explicitly wants**: diffs to stay clean (no line-ending noise from
 cross-platform edits), and ideally for a raw download to just work. These two preferences are in

--- a/run_setup.bat
+++ b/run_setup.bat
@@ -52,6 +52,12 @@ rem same folder can never be misread as this run's result if this run's copy of
 rem the file cannot even get past its own preflight.
 set "HP_PREFLIGHT_STATUS=%~dp0~bootstrap.status.json"
 where powershell >nul 2>&1
+if defined HP_TEST_FORCE_NO_POWERSHELL (
+  rem derived requirement: force a nonzero errorlevel here without touching PATH,
+  rem so CI can deterministically exercise the branch below on a shared runner
+  rem with no risk of actually breaking PowerShell resolution for it.
+  cmd /c "exit /b 1"
+)
 if errorlevel 1 (
   echo ***
   echo *** [ERROR] PowerShell was not found on this machine.
@@ -62,7 +68,20 @@ if errorlevel 1 (
   if not defined HP_CI_LANE ( pause )
   exit /b 1
 )
-set "HP_SELF_PATH=%~f0"
+if defined HP_TEST_FORCE_LF_ONLY (
+  rem derived requirement: point the check at a synthetic LF-only file instead
+  rem of this running copy, so CI can exercise the invalid-line-endings branch
+  rem below without corrupting the file that is actually executing right now.
+  set "HP_SELF_PATH=%~dp0~test_lf_only.bat"
+) else if defined HP_TEST_FORCE_PS_CHECK_FAIL (
+  rem derived requirement: point at a path that does not exist, so the real
+  rem PowerShell command below genuinely throws and hits its own catch branch
+  rem -- exercises the real failure path instead of faking an exit code
+  rem externally.
+  set "HP_SELF_PATH=%~dp0~test_missing_for_ps_check.bat"
+) else (
+  set "HP_SELF_PATH=%~f0"
+)
 powershell -NoProfile -Command "try{$c=[System.IO.File]::ReadAllText($env:HP_SELF_PATH);$crlf=-join @([char]13,[char]10);$lf=[string][char]10;$cr=[string][char]13;$norm=$c.Replace($crlf,'');if($c.Contains($crlf) -and -not $norm.Contains($lf) -and -not $norm.Contains($cr)){exit 0}else{exit 1}}catch{exit 2}" >nul 2>&1
 if errorlevel 2 (
   echo ***

--- a/tests/selfapps_lineending_check.ps1
+++ b/tests/selfapps_lineending_check.ps1
@@ -1,0 +1,181 @@
+# ASCII only
+# selfapps_lineending_check.ps1 - CLAUDE.md Active Backlog Item 44's own "Known gap": the
+# line-ending self-check at the very top of run_setup.bat (before any goto/call in the file)
+# had zero CI coverage of its own three failure branches. A normal actions/checkout always
+# normalizes to CRLF per .gitattributes, so CI exercises the happy path on real cmd.exe every
+# run but can never organically produce a broken copy to test the failure branches against --
+# hence the three HP_TEST_FORCE_* hooks this file drives.
+#
+# Each scenario redirects the check at something OTHER than the file actually executing right
+# now (a synthetic LF-only sentinel file, or a path that does not exist) rather than corrupting
+# the running copy of run_setup.bat itself -- the running copy must stay healthy CRLF so it can
+# reliably reach and execute the hook logic in the first place. The PS-check-fail scenario
+# deliberately does not fake an exit code either: pointing at a nonexistent path makes the real,
+# unmodified PowerShell command genuinely throw (FileNotFoundException) and hit its own
+# catch{exit 2} branch, exercising the real failure path rather than a simulated one.
+#
+# Lane: real and conda-full only (matches self.preflight.syntax's own precedent for a cheap,
+# provider-agnostic, pure-batch preflight check -- no environment/dependency work is ever
+# reached in any of these three scenarios, so there is no "could not verify locally" risk
+# comparable to a real Nuitka/MSVC build; the command logic itself was verified directly
+# against a real PowerShell 7 binary before this file was written).
+param()
+$ErrorActionPreference = 'Continue'
+$here = $PSScriptRoot
+$repo = Split-Path -Path $here -Parent
+$nd   = Join-Path $here '~test-results.ndjson'
+$ciNd = Join-Path $repo 'ci_test_results.ndjson'
+if (-not (Test-Path $nd))   { New-Item -ItemType File -Path $nd   -Force | Out-Null }
+if (-not (Test-Path $ciNd)) { New-Item -ItemType File -Path $ciNd -Force | Out-Null }
+
+function Write-NdjsonRow {
+    param([hashtable]$Row)
+    $lane = [Environment]::GetEnvironmentVariable('HP_CI_LANE')
+    if ($lane -and -not $Row.ContainsKey('lane')) { $Row['lane'] = $lane }
+    $json = $Row | ConvertTo-Json -Compress -Depth 8
+    Add-Content -LiteralPath $nd   -Value $json -Encoding Ascii
+    Add-Content -LiteralPath $ciNd -Value $json -Encoding Ascii
+}
+
+$rowIds = @('self.preflight.no_powershell', 'self.preflight.ps_check_fail', 'self.preflight.lf_only')
+
+# Non-Windows skip
+if (-not $IsWindows) {
+    $platform = [System.Environment]::OSVersion.Platform.ToString()
+    foreach ($id in $rowIds) {
+        Write-NdjsonRow ([ordered]@{
+            id      = $id
+            req     = 'CLAUDE.md-Item-44'
+            pass    = $true
+            desc    = 'Line-ending self-check preflight branch (skipped on non-Windows)'
+            details = [ordered]@{ skip = $true; platform = $platform; reason = 'non-windows-host' }
+        })
+    }
+    exit 0
+}
+
+$batchPath = Join-Path $repo 'run_setup.bat'
+if (-not (Test-Path $batchPath)) {
+    foreach ($id in $rowIds) {
+        Write-NdjsonRow ([ordered]@{
+            id      = $id
+            req     = 'CLAUDE.md-Item-44'
+            pass    = $false
+            desc    = 'Line-ending self-check preflight branch: run_setup.bat not found'
+            details = [ordered]@{ error = 'run_setup.bat not found at ' + $batchPath }
+        })
+    }
+    exit 1
+}
+
+function Test-PreflightScenario {
+    param(
+        [string]$Id,
+        [string]$WorkDirName,
+        [string]$EnvFlagName,
+        [int]$ExpectedExit,
+        [string[]]$ExpectedSubstrings,
+        [switch]$WriteLfOnlySentinel
+    )
+
+    $workDir = Join-Path $here $WorkDirName
+    if (Test-Path $workDir) { Remove-Item -Recurse -Force $workDir }
+    New-Item -ItemType Directory -Force -Path $workDir | Out-Null
+    Copy-Item -Path $batchPath -Destination $workDir -Force
+
+    if ($WriteLfOnlySentinel) {
+        # derived requirement: pure LF, no CR anywhere, no BOM -- WriteAllText with an
+        # explicit no-BOM UTF8Encoding is used instead of Set-Content, since Set-Content's
+        # array-join would use the OS newline convention (CRLF on Windows) and defeat the
+        # whole point of this sentinel file.
+        $sentinelPath = Join-Path $workDir '~test_lf_only.bat'
+        $sentinelBody = "@echo off`n:: synthetic LF-only content for HP_TEST_FORCE_LF_ONLY`n:: no CRLF anywhere in this file`n"
+        [System.IO.File]::WriteAllText($sentinelPath, $sentinelBody, (New-Object System.Text.UTF8Encoding($false)))
+    }
+
+    $bootstrapLog = '~lineending_bootstrap.log'
+    $prev = if (Test-Path "Env:$EnvFlagName") { (Get-Item "Env:$EnvFlagName").Value } else { $null }
+    Set-Item -Path "Env:$EnvFlagName" -Value '1'
+
+    Push-Location $workDir
+    try {
+        cmd /c "call run_setup.bat > $bootstrapLog 2>&1"
+        $runExit = $LASTEXITCODE
+    } finally {
+        if ($null -eq $prev) {
+            Remove-Item -Path "Env:$EnvFlagName" -ErrorAction SilentlyContinue
+        } else {
+            Set-Item -Path "Env:$EnvFlagName" -Value $prev
+        }
+        Pop-Location
+    }
+
+    $logPath = Join-Path $workDir $bootstrapLog
+    $statusF = Join-Path $workDir '~bootstrap.status.json'
+    $logTxt  = if (Test-Path $logPath) { Get-Content -LiteralPath $logPath -Raw -Encoding ASCII } else { '' }
+
+    # derived requirement: plain .Contains(), not -like -- these expected substrings contain
+    # literal [ and ] (e.g. "[ERROR]"), which -like's wildcard syntax treats as a character
+    # class rather than literal brackets, silently making a genuine match report as absent.
+    $allSubstringsFound = $true
+    foreach ($s in $ExpectedSubstrings) {
+        if (-not $logTxt.Contains($s)) { $allSubstringsFound = $false }
+    }
+
+    $state = ''
+    $exitCodeInStatus = -1
+    if (Test-Path $statusF) {
+        try {
+            $parsed = Get-Content -LiteralPath $statusF -Raw -Encoding ASCII | ConvertFrom-Json
+            $state = $parsed.state
+            $exitCodeInStatus = $parsed.exitCode
+        } catch { $state = 'unparseable' }
+    }
+
+    $exitMatches = ($runExit -eq $ExpectedExit)
+    $statusMatches = ($state -eq 'error') -and ($exitCodeInStatus -eq $ExpectedExit)
+    $pass = $exitMatches -and $statusMatches -and $allSubstringsFound
+
+    Write-NdjsonRow ([ordered]@{
+        id      = $Id
+        req     = 'CLAUDE.md-Item-44'
+        pass    = $pass
+        desc    = "Line-ending self-check preflight branch: $EnvFlagName"
+        details = [ordered]@{
+            bootstrapExit       = $runExit
+            expectedExit        = $ExpectedExit
+            exitMatches         = $exitMatches
+            statusState         = $state
+            statusExitCode      = $exitCodeInStatus
+            statusMatches       = $statusMatches
+            allSubstringsFound  = $allSubstringsFound
+            log                 = $bootstrapLog
+        }
+    })
+
+    return $pass
+}
+
+$results = @()
+
+$results += Test-PreflightScenario -Id 'self.preflight.no_powershell' `
+    -WorkDirName '~selftest_lineending_no_ps' `
+    -EnvFlagName 'HP_TEST_FORCE_NO_POWERSHELL' `
+    -ExpectedExit 1 `
+    -ExpectedSubstrings @('[ERROR] PowerShell was not found on this machine.')
+
+$results += Test-PreflightScenario -Id 'self.preflight.ps_check_fail' `
+    -WorkDirName '~selftest_lineending_ps_fail' `
+    -EnvFlagName 'HP_TEST_FORCE_PS_CHECK_FAIL' `
+    -ExpectedExit 2 `
+    -ExpectedSubstrings @('[ERROR] PowerShell could not check the line endings of this file.')
+
+$results += Test-PreflightScenario -Id 'self.preflight.lf_only' `
+    -WorkDirName '~selftest_lineending_lf_only' `
+    -EnvFlagName 'HP_TEST_FORCE_LF_ONLY' `
+    -ExpectedExit 1 `
+    -ExpectedSubstrings @('[ERROR] This copy of run_setup.bat has invalid line endings.', 'Easiest fix: re-download using') `
+    -WriteLfOnlySentinel
+
+if ($results -contains $false) { exit 1 }
+exit 0

--- a/tests/selfapps_lineending_check.ps1
+++ b/tests/selfapps_lineending_check.ps1
@@ -99,7 +99,12 @@ function Test-PreflightScenario {
 
     Push-Location $workDir
     try {
-        cmd /c "call run_setup.bat > $bootstrapLog 2>&1"
+        # derived requirement: redirect stdin from nul -- all three scenarios reach a
+        # preflight-failure branch that calls `pause` when HP_CI_LANE is not defined; in CI
+        # that branch is always skipped (HP_CI_LANE is set at the job level), but a local run
+        # of this script without it set would otherwise hang on a real keypress despite
+        # stdout/stderr already being redirected.
+        cmd /c "call run_setup.bat > $bootstrapLog 2>&1 < nul"
         $runExit = $LASTEXITCODE
     } finally {
         if ($null -eq $prev) {

--- a/tests/selfapps_lineending_check.ps1
+++ b/tests/selfapps_lineending_check.ps1
@@ -40,8 +40,11 @@ function Write-NdjsonRow {
 $rowIds = @('self.preflight.no_powershell', 'self.preflight.ps_check_fail', 'self.preflight.lf_only')
 
 # Non-Windows skip
-if (-not $IsWindows) {
-    $platform = [System.Environment]::OSVersion.Platform.ToString()
+# derived requirement: $IsWindows is undefined (reads as $null, so "-not $IsWindows" is
+# always true) under Windows PowerShell 5.1 -- it was only introduced in PowerShell 6+.
+# [System.Environment]::OSVersion.Platform works identically on 5.1 and 7+.
+$platform = [System.Environment]::OSVersion.Platform.ToString()
+if ($platform -ne 'Win32NT') {
     foreach ($id in $rowIds) {
         Write-NdjsonRow ([ordered]@{
             id      = $id


### PR DESCRIPTION
## Summary

- Adds three deterministic test hooks (`HP_TEST_FORCE_NO_POWERSHELL`, `HP_TEST_FORCE_LF_ONLY`, `HP_TEST_FORCE_PS_CHECK_FAIL`) to the line-ending self-check at the very top of `run_setup.bat`, so CI can exercise all three of its failure branches -- PowerShell absent, PowerShell present but the check itself fails, and a genuine LF-only copy of the file. Previously none of these had any CI coverage, since a normal `actions/checkout` always normalizes to CRLF and can never organically produce a broken file to test against (this was flagged by review as a real gap against AGENTS.md's "every branch needs a CI test" rule, and tracked as CLAUDE.md's Active Backlog Item 44's own "Known gap").
- Adds `tests/selfapps_lineending_check.ps1`, wired gating into the `real`/`conda-full` lanes (matching the existing `self.preflight.syntax` precedent for a cheap, provider-agnostic, pure-batch preflight test).
- The LF-only and PS-check-fail hooks redirect `HP_SELF_PATH` at a synthetic file rather than faking an exit code externally, so the real, unmodified PowerShell command's own logic is what actually gets exercised. Both this design and the underlying PowerShell command's exact behavior for each case were verified directly against a real PowerShell 7 binary before landing -- which also caught a real bug in the test script itself pre-CI: an initial draft used `-like "*...*"` for substring assertions, which silently mis-evaluates any string containing `[`/`]` (its wildcard syntax treats brackets as a character class). Fixed to `.Contains()`.
- Archives Item 44 (root cause, mitigation, and this closure) to `docs/agent-closed-backlog.md` and removes it from CLAUDE.md's Active Backlog per the repo's own "closed items move out entirely" convention. `docs/open-questions.md`'s item 2 (whether to fix the distribution channel itself) stays open as a separate, unrelated maintainer decision -- not a precondition for this item's closure.
- A raw-download-from-branch test (fetching the real corrupted bytes via `raw.githubusercontent.com` instead of synthesizing them locally) was considered and rejected for the CI-gating test: it would add network/fork-branch-resolution complexity for no additional coverage, since the corruption mechanism is already fully triangulated at the byte level, and it would break this repo's convention of keeping gating tests deterministic.

## Test plan

- [x] `python tools/check_delimiters.py run_setup.bat`
- [x] PowerShell command logic (all three branch conditions) verified directly against a real PowerShell 7 binary, not just reasoned about
- [x] New selfapps test script AST-parsed clean via `[System.Management.Automation.Language.Parser]::ParseFile`
- [x] `tools/run_sanity_sweep.sh` -- compileall, pyflakes, delimiter check, yamllint, actionlint, ASCII sweep, PowerShell AST parse sweep all clean
- [x] `python -m pytest tests/test_*.py -q` -- 464 passed, 54 skipped (pre-existing Windows-only skips)
- [x] `python tools/check_ndjson_registry.py` -- PASS, no doc/code registry mismatches (confirms the 3 new row ids are correctly wired in both the doc and the emission sites)
- [ ] Real Windows CI (`real`/`conda-full` lanes) -- pending, this PR's own first run

---
_Generated by [Claude Code](https://claude.ai/code/session_018ZziZDLZLHPqY4N7kCMTBi)_