### PR TITLE
Fix two stale post-#435 messages; close Item 51; file Item 59

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1123,6 +1123,34 @@ way (no live Windows execution available here), that is noted explicitly rather 
   lockstep. Both fixes verified via the full sanity sweep (delimiters, CRLF, ASCII, PS parse,
   pytest) before landing.
 
+- **Item 60: `:merge_git_config` (REQ-015) does not migrate an EXISTING `.gitattributes` that
+  already has the old `*.bat eol=crlf`/`*.cmd eol=crlf` rules to `-text`.** Found by CodeRabbit's
+  first manually-triggered review on this repo (PR #436, rated "Major, Heavy lift" -- item 59's
+  own motivating request), the same day item 59 fixed the FORWARD-facing half of this same gap
+  (what a fresh run writes). The idempotency guard (`findstr /C:"%HP_GA_SIG%" ".gitattributes"`,
+  gating on the SIGNATURE comment line, unchanged by item 59's fix) means a user who already ran
+  an OLDER `run_setup.bat` has that signature present, so re-running a NEWER copy skips the whole
+  append block and never upgrades their file -- their `.gitattributes` stays on the disproven
+  `eol=crlf` rule indefinitely, with no path to the fix. Narrow real-world exposure (only affects
+  OTHER users' own unrelated projects that already ran an old copy, have `.bat`/`.cmd` files, and
+  publish to GitHub), but real and permanent without a fix -- there is currently no self-healing
+  mechanism.
+
+  **Deliberately not attempted as a quick fix**: a correct migration needs a genuine
+  read-modify-write against a user's own, arbitrary `.gitattributes` content (not just an append),
+  which raises real design questions this item does not pre-answer: detect the OLD lines
+  specifically (not just the presence of the shared signature) and REPLACE them in place, versus
+  appending new superseding lines below the old ones and relying on git's own last-match-wins
+  attribute resolution (messier file, no cleanup, but avoids ever rewriting content that might not
+  be exactly what this bootstrapper wrote -- e.g. a user who hand-edited that section). Whichever
+  shape is chosen, prefer the established `.NET` file-IO safe-write pattern this repo already uses
+  elsewhere (see `docs/agent-lessons-learned.md`'s "never open a real source file in Python 'w'
+  mode" entry for the general principle, and the PowerShell-side equivalent already used for the
+  DLL-bundling sanitizers) over a naive in-place text substitution, and add a new regression
+  scenario in `tests/selfapps_ux_hardening.ps1` that pre-seeds a scratch `.gitattributes` with the
+  OLD rules before running the bootstrapper, asserting the file ends up with `-text` and no
+  leftover `eol=crlf` line for `*.bat`/`*.cmd`.
+
 ## Cold Storage (promising ideas, deliberately shelved -- revisit only if a named trigger fires)
 
 Moved to `docs/agent-cold-storage.md` (2026-07-31, to reduce this file's per-session context

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1070,37 +1070,6 @@ way (no live Windows execution available here), that is noted explicitly rather 
   this file's other consent gates already use, defaulting to whichever of retry/offline is safer
   unattended (offline, matching the existing empty-input default two lines below).
 
-- **Item 51: `HP_PIPREQS_RC`'s errorlevel capture, in the direct (non-staging) pipreqs path, has
-  an intervening `set` command between the pipreqs invocation and the `%errorlevel%` read --
-  PLAUSIBLE, NOT CONFIRMED, needs a live-cmd.exe check before acting.** Current source, right after
-  the direct pipreqs invocation, at the `:pipreqs_direct_done` label:
-
-  ```
-  "%HP_PY%" -m pipreqs.pipreqs ... > "%HP_PIPREQS_DIRECT_LOG%" 2>&1
-  :pipreqs_direct_done
-  set "HP_PIPREQS_LAST_LOG=%HP_PIPREQS_DIRECT_LOG%"
-  set "HP_PIPREQS_RC=%errorlevel%"
-  ```
-
-  If a plain successful `set` resets `%errorlevel%` to 0 (contested even in general cmd.exe
-  folklore, and this repo's own `docs/agent-lessons-learned.md` explicitly warns against trusting
-  static reasoning about cmd.exe semantics without a live test -- three separate past incidents in
-  this exact file were each "fixed" wrong before a live-cmd.exe fixture caught the real behavior),
-  `HP_PIPREQS_RC` would always read "0" regardless of pipreqs's real exit code, silently
-  misclassifying a genuine pipreqs crash. Notably, the SIBLING staging-path capture, a little
-  further down in the same block right after the staging pipreqs invocation, captures
-  `%errorlevel%` on the very next line with no intervening command --
-  suggesting this might already be a known-avoided hazard elsewhere in the same file, making the
-  direct-path instance look like an inconsistency worth resolving even before the exact mechanism
-  is confirmed.
-
-  **Fix, low-risk regardless of the exact mechanism**: move the `HP_PIPREQS_RC` capture to
-  immediately follow the pipreqs invocation (before the `HP_PIPREQS_LAST_LOG` set), matching the
-  already-used safe pattern at the staging call site. Costs nothing even if the hazard turns out
-  not to be real. **Verification needed before or alongside the fix**: a small live-Windows-CI
-  fixture confirming whether `set "VAR=literal"` does or does not reset `%errorlevel%`, following
-  this repo's own established "trust the live test over reasoning" methodology.
-
 - **Item 52: `tools/pyproj_deps.py`'s exit code 1 is overloaded between its intentional
   "no `[project].dependencies` found" contract and a catch-all for any genuinely unexpected
   exception, making a real bug in that script indistinguishable from the normal case.** CONFIRMED
@@ -1121,6 +1090,38 @@ way (no live Windows execution available here), that is noted explicitly rather 
   either a distinct exit code for the top-level catch-all (e.g. 3), or an unconditional low-tier
   log line (not a WARN) on any errorlevel 1 so the fact is at least visible in `~setup.log` for a
   future debugging session, without changing user-facing behavior.
+
+- **Item 59: CodeRabbit's automated review did not run on PR #435, and should be manually
+  triggered on every future PR -- owner-requested standing process fix, not a code change.**
+  This repo (fewer than 10 stars, Organization UI config) requires a manual trigger for
+  CodeRabbit review; it posts a "Review available on request" gate comment instead of reviewing
+  automatically, and that comment was left untouched on PR #435. The owner explicitly wants
+  CodeRabbit's review going forward -- it likely would have caught at least one of the two
+  stale-message findings below (a high-confidence external review caught them instead, working
+  from the repo alone with no CI-log visibility).
+
+  **Standing directive for every future PR this agent opens**: when CodeRabbit posts its
+  "Review available on request" gate comment, reply with `@coderabbitai review` (or `@coderabbitai
+  full review` for a deeper pass) to actually trigger it, rather than leaving the gate comment
+  unanswered. Apply this on PR open, not just when reminded.
+
+  **Two concrete findings this pass caught, both fixed same-day (2026-08-15), that motivated
+  filing this item**: (1) `run_setup.bat`'s own line-ending self-check panel (`docs/agent-
+  closed-backlog.md`'s Item 44) still told a user to "re-download using git clone, not the Raw
+  button" -- true before the CRLF distribution fix (Item 44's own "Raw-download CRLF
+  distribution fix" entry above), false and actively bad advice after it (steers a confused,
+  git-less Prime Directive user toward a tool they do not have, instead of just re-downloading
+  via the now-fixed Raw link). Fixed: the panel and its header comment now describe the check as
+  defense-in-depth against a stale/re-saved copy, not as a workaround for a still-broken
+  distribution channel; `tests/selfapps_lineending_check.ps1`'s matching assertion updated in
+  lockstep. (2) `:merge_git_config` (REQ-015) was still writing `*.bat eol=crlf`/`*.cmd eol=crlf`
+  into every bootstrapped user's OWN `.gitattributes` -- the exact pattern this repo just spent
+  the whole CRLF distribution fix proving insufficient for itself, propagated into every user's
+  project that happens to contain `.bat` files and gets published to GitHub. Fixed to `*.bat
+  -text`/`*.cmd -text`, matching this repo's own `.gitattributes`; `tests/selfapps_ux_hardening.
+  ps1`'s `self.ux.gitattributes.merge` assertion, and the REQ-015 spec in README.md, updated in
+  lockstep. Both fixes verified via the full sanity sweep (delimiters, CRLF, ASCII, PS parse,
+  pytest) before landing.
 
 ## Cold Storage (promising ideas, deliberately shelved -- revisit only if a named trigger fires)
 

--- a/README.md
+++ b/README.md
@@ -533,7 +533,7 @@ blip or a temporary outage.
 - At bootstrap time, the bootstrapper appends standard `.gitignore` and `.gitattributes` entries to the working directory.
 - Uses a sentinel comment line to detect existing entries; never duplicates content already present.
 - `.gitignore` additions: tilde-prefix work files (`~*`), env directories (`.venv/`, `.uv/`, `.*_env/`, `.cache/`, `.conda/`), build artifacts (`dist/`, `build/`).
-- `.gitattributes` additions: `*.bat eol=crlf`, `*.cmd eol=crlf`, `*.exe binary`.
+- `.gitattributes` additions: `*.bat -text`, `*.cmd -text`, `*.exe binary`. (`-text`, not `eol=crlf`: `eol=crlf` only affects `git checkout`, never what a raw/GitHub-served download returns -- see this repo's own CRLF distribution fix.)
 - Silent if no changes needed; logs when appending.
 - Log contract:
   - `[INFO] REQ-015: Appending standard ignores to .gitignore.`

--- a/docs/agent-closed-backlog.md
+++ b/docs/agent-closed-backlog.md
@@ -2093,6 +2093,22 @@ the full mechanism (`HP_DLL_HINT_STATE`'s reset/capture contract, the `:pfb_dll_
 static check (verified locally against the real `run_setup.bat` content via a standalone `pwsh`
 run of the same regex logic before landing, not just reasoned about).
 
+### Item 51 (closed 2026-08-15)
+
+- **`HP_PIPREQS_RC`'s errorlevel capture in the direct (non-staging) pipreqs path had an
+  intervening `set` command between the pipreqs invocation and the `%errorlevel%` read, unlike
+  the sibling staging-path capture a few dozen lines below (no intervening command there).**
+  Filed as "PLAUSIBLE, NOT CONFIRMED, needs a live-cmd.exe check" -- a high-confidence external
+  review settled the underlying cmd.exe semantics question without needing a live Windows
+  fixture: a successful plain `set "VAR=literal"` does NOT itself modify `%errorlevel%` in real
+  cmd.exe (only a FAILED `set`/`set /a`/`set /p` does), so `HP_PIPREQS_RC` almost certainly was
+  already capturing pipreqs's real exit code correctly -- this was very likely never a live bug.
+  **Fixed anyway, exactly as the item's own "low-risk regardless of the exact mechanism" note
+  recommended**: reordered the two `set` lines at `:pipreqs_direct_done` so `HP_PIPREQS_RC` is
+  captured immediately after the pipreqs invocation, before `HP_PIPREQS_LAST_LOG`, matching the
+  staging path's own pattern. Zero-risk, closes the cross-call-site inconsistency that made this
+  worth filing in the first place, regardless of which side of the semantics question is right.
+
 ## Known Findings (diagnosed, no action warranted)
 
 - **Backlog item numbering: renumber-on-collision convention dropped, 2026-07-31 owner decision.**

--- a/docs/demo-bootstrapper-output.md
+++ b/docs/demo-bootstrapper-output.md
@@ -1614,8 +1614,8 @@ and `.gitattributes`:
 
 ```
 # Automated Python Bootstrapper Attributes
-*.bat eol=crlf
-*.cmd eol=crlf
+*.bat -text
+*.cmd -text
 *.exe binary
 ```
 

--- a/run_setup.bat
+++ b/run_setup.bat
@@ -42,16 +42,19 @@
 setlocal DisableDelayedExpansion
 rem ============================================================
 rem LINE-ENDING SELF-CHECK -- keep this first, before any goto/call in
-rem this file. A raw/blob download ^(GitHub's "Raw" button, or a
-rem raw.githubusercontent.com link^) serves this file with Unix ^(LF^)
-rem line endings instead of the Windows ^(CRLF^) endings a real git
-rem checkout produces ^(see .gitattributes^). cmd.exe's goto/call label
-rem lookup can silently misbehave on an LF-only copy of a file this
-rem size -- wrong-label errors, skipped blocks, corrupted commands --
-rem producing a confusing partial run instead of a clear failure. This
-rem check must therefore be self-reliant ^(no goto/call anywhere in
-rem this file, since that is exactly what an LF-only copy breaks^) and
-rem must run before anything else.
+rem this file. Defense-in-depth, not a fix for a known-broken distribution
+rem channel: this file's line endings are Windows ^(CRLF^) by construction
+rem and enforced in CI ^(.gitattributes' "-text" for *.bat/*.cmd plus
+rem tools/check_crlf.py -- a raw/blob download via GitHub's "Raw" button or
+rem a raw.githubusercontent.com link is expected to serve genuine CRLF^),
+rem but an old cached download from before that fix, or a copy re-saved by
+rem an editor that does not preserve CRLF, can still corrupt a user's copy.
+rem cmd.exe's goto/call label lookup can silently misbehave on an LF-only
+rem copy of a file this size -- wrong-label errors, skipped blocks,
+rem corrupted commands -- producing a confusing partial run instead of a
+rem clear failure. This check must therefore be self-reliant ^(no goto/call
+rem anywhere in this file, since that is exactly what an LF-only copy
+rem breaks^) and must run before anything else.
 rem ============================================================
 rem HP_PREFLIGHT_STATUS is script-rooted via %~dp0 (not CWD-relative, and not the
 rem later %STATUS_FILE%/:write_status machinery -- neither exists yet at this point
@@ -110,11 +113,11 @@ if errorlevel 1 (
   echo *** Every line ending in this file must be Windows-style ^(CRLF^); at
   echo *** least one is not, and the file will fail with confusing, partial,
   echo *** hard-to-diagnose errors if run as-is.
-  echo *** This usually happens when downloading via the GitHub "Raw" button
-  echo *** or a raw.githubusercontent.com link, neither of which preserves
-  echo *** Windows line endings.
   echo ***
-  echo ***   Easiest fix: re-download using "git clone", not the Raw button.
+  echo ***   Easiest fix: delete this copy and download run_setup.bat again --
+  echo ***   the GitHub "Raw" link and the download page are both fine now.
+  echo ***   This is usually an old cached copy, or one re-saved by an editor
+  echo ***   that does not preserve Windows line endings.
   echo ***
   echo ***   Or open this file in an editor that shows line endings
   echo ***   ^(e.g. Notepad++, VS Code^) and convert it to Windows ^(CRLF^)
@@ -1416,8 +1419,15 @@ rem pipreqs flags are locked by CI (pipreqs.flags gate).
 rem Rationale: compat mode for deterministic output; force overwrite; write to requirements.auto.txt (separate from committed requirements).
 "%HP_PY%" -m pipreqs.pipreqs . --force --mode compat --savepath "%HP_PIPREQS_TARGET%" --ignore "%HP_PIPREQS_IGNORE%" > "%HP_PIPREQS_DIRECT_LOG%" 2>&1
 :pipreqs_direct_done
-set "HP_PIPREQS_LAST_LOG=%HP_PIPREQS_DIRECT_LOG%"
+rem CLAUDE.md Item 51: capture %errorlevel% on the line immediately after the pipreqs
+rem invocation, before any intervening "set", matching the staging path's own already-safe
+rem pattern a few dozen lines below (which never had an intervening command). A successful
+rem plain "set VAR=literal" does not itself modify ERRORLEVEL in real cmd.exe, so this was
+rem very likely never a live bug -- but the two call sites disagreeing on ordering, for no
+rem reason, is what made this worth a live-cmd.exe check in the first place. Zero-risk either
+rem way; closes the inconsistency for good.
 set "HP_PIPREQS_RC=%errorlevel%"
+set "HP_PIPREQS_LAST_LOG=%HP_PIPREQS_DIRECT_LOG%"
 if "%HP_PIPREQS_RC%"=="0" if exist "%HP_PIPREQS_TARGET_WORK%" (
   rem Zero imports are valid: pipreqs exits 0 and may intentionally leave requirements.auto.txt empty.
   set "HP_PIPREQS_PHASE_RESULT=ok"
@@ -5344,10 +5354,15 @@ call :log "[INFO] REQ-015: Appending standard ignores to .gitignore."
 findstr /C:"%HP_GA_SIG%" ".gitattributes" >nul 2>&1
 if not errorlevel 1 goto :mgc_ga_done
 call :log "[INFO] REQ-015: Appending standard attributes to .gitattributes."
+rem derived requirement: "-text" (not "eol=crlf") for *.bat/*.cmd -- eol=crlf only affects
+rem checkout, never the blob a raw/GitHub-served download returns, so a user's own .bat files
+rem would still be corrupted for anyone downloading them raw from THEIR repo. This repo's own
+rem docs/agent-lessons-learned.md ".bat files: -text, not eol=crlf" entry is the full writeup
+rem of why; propagate the fix this bootstrapper itself needed, not the pattern proven insufficient.
 >> ".gitattributes" echo.
 >> ".gitattributes" echo %HP_GA_SIG%
->> ".gitattributes" echo *.bat eol=crlf
->> ".gitattributes" echo *.cmd eol=crlf
+>> ".gitattributes" echo *.bat -text
+>> ".gitattributes" echo *.cmd -text
 >> ".gitattributes" echo *.exe binary
 :mgc_ga_done
 set "HP_GI_SIG="

--- a/tests/selfapps_lineending_check.ps1
+++ b/tests/selfapps_lineending_check.ps1
@@ -182,7 +182,7 @@ $results += Test-PreflightScenario -Id 'self.preflight.lf_only' `
     -WorkDirName '~selftest_lineending_lf_only' `
     -EnvFlagName 'HP_TEST_FORCE_LF_ONLY' `
     -ExpectedExit 1 `
-    -ExpectedSubstrings @('[ERROR] This copy of run_setup.bat has invalid line endings.', 'Easiest fix: re-download using') `
+    -ExpectedSubstrings @('[ERROR] This copy of run_setup.bat has invalid line endings.', 'Easiest fix: delete this copy and download run_setup.bat again') `
     -WriteLfOnlySentinel
 
 if ($results -contains $false) { exit 1 }

--- a/tests/selfapps_ux_hardening.ps1
+++ b/tests/selfapps_ux_hardening.ps1
@@ -171,19 +171,22 @@ Write-NdjsonRow ([ordered]@{
     details = [ordered]@{ sigCount = $sigCount1 }
 })
 
-# Test 4: .gitattributes created with signature and *.bat eol=crlf
+# Test 4: .gitattributes created with signature and *.bat -text (not eol=crlf -- see
+# docs/agent-lessons-learned.md's ".bat files: -text, not eol=crlf" entry; eol=crlf only
+# affects checkout, never what a raw download serves, so this bootstrapper must not teach a
+# user's own project the exact pattern it just proved insufficient for itself).
 $gaText = ''
 if (Test-Path -LiteralPath $gaPath) {
     $gaText = Get-Content -LiteralPath $gaPath -Raw -Encoding Ascii
 }
 $gaMerged   = $gaText -match [regex]::Escape($sigGa)
-$gaBatCrlf  = $gaText -match [regex]::Escape('*.bat eol=crlf')
+$gaBatText  = $gaText -match [regex]::Escape('*.bat -text')
 Write-NdjsonRow ([ordered]@{
     id      = 'self.ux.gitattributes.merge'
     req     = 'REQ-015'
-    pass    = ($gaMerged -and $gaBatCrlf)
+    pass    = ($gaMerged -and $gaBatText)
     desc    = 'Standard attributes signature appended to .gitattributes'
-    details = [ordered]@{ sigFound = $gaMerged; batCrlfFound = $gaBatCrlf }
+    details = [ordered]@{ sigFound = $gaMerged; batTextFound = $gaBatText }
 })
 
 # Test 5: .gitattributes idempotent (signature once after two runs)

--- a/tests/selfapps_ux_hardening.ps1
+++ b/tests/selfapps_ux_hardening.ps1
@@ -176,22 +176,23 @@ Write-NdjsonRow ([ordered]@{
     details = [ordered]@{ sigCount = $sigCount1 }
 })
 
-# Test 4: .gitattributes created with signature and *.bat -text (not eol=crlf -- see
-# docs/agent-lessons-learned.md's ".bat files: -text, not eol=crlf" entry; eol=crlf only
-# affects checkout, never what a raw download serves, so this bootstrapper must not teach a
-# user's own project the exact pattern it just proved insufficient for itself).
+# Test 4: .gitattributes created with signature and *.bat/*.cmd -text (not eol=crlf).
+# derived requirement: docs/agent-lessons-learned.md's ".bat files: -text, not eol=crlf" entry
+# -- eol=crlf only affects checkout, never what a raw download serves, so this bootstrapper
+# must not teach a user's own project the exact pattern it just proved insufficient for itself.
 $gaText = ''
 if (Test-Path -LiteralPath $gaPath) {
     $gaText = Get-Content -LiteralPath $gaPath -Raw -Encoding Ascii
 }
 $gaMerged   = $gaText -match [regex]::Escape($sigGa)
 $gaBatText  = $gaText -match [regex]::Escape('*.bat -text')
+$gaCmdText  = $gaText -match [regex]::Escape('*.cmd -text')
 Write-NdjsonRow ([ordered]@{
     id      = 'self.ux.gitattributes.merge'
     req     = 'REQ-015'
-    pass    = ($gaMerged -and $gaBatText)
+    pass    = ($gaMerged -and $gaBatText -and $gaCmdText)
     desc    = 'Standard attributes signature appended to .gitattributes'
-    details = [ordered]@{ sigFound = $gaMerged; batTextFound = $gaBatText }
+    details = [ordered]@{ sigFound = $gaMerged; batTextFound = $gaBatText; cmdTextFound = $gaCmdText }
 })
 
 # Test 5: .gitattributes idempotent (signature once after two runs)
@@ -1186,6 +1187,6 @@ if ($env:HP_FORCE_CONDA_ONLY -eq '1') {
     })
 }
 
-$allPass = $giMerged -and $giPreserved -and $giIdem -and ($gaMerged -and $gaBatText) -and $gaIdem -and $pfFound -and ($connPromptFound -and $connOfflineLog) -and $connPromptFound -and $uvOfflinePass -and $condaOfflinePass -and $connReachableFound -and $connRetryFound -and ($sysPromptFound -and $sysDeclineLog) -and $sysPromptFound -and $sysRealPass -and $sysAcceptPass -and $venvFbPass -and $venvCanaryPass -and $venvNoPipPass -and $embedDeclinePass -and $embedRealPass -and $entryOvPass
+$allPass = $giMerged -and $giPreserved -and $giIdem -and ($gaMerged -and $gaBatText -and $gaCmdText) -and $gaIdem -and $pfFound -and ($connPromptFound -and $connOfflineLog) -and $connPromptFound -and $uvOfflinePass -and $condaOfflinePass -and $connReachableFound -and $connRetryFound -and ($sysPromptFound -and $sysDeclineLog) -and $sysPromptFound -and $sysRealPass -and $sysAcceptPass -and $venvFbPass -and $venvCanaryPass -and $venvNoPipPass -and $embedDeclinePass -and $embedRealPass -and $entryOvPass
 if (-not $allPass) { exit 1 }
 exit 0

--- a/tests/selfapps_ux_hardening.ps1
+++ b/tests/selfapps_ux_hardening.ps1
@@ -46,8 +46,13 @@ function Invoke-WithEnvOverrides {
 }
 
 # Non-Windows skip
-if (-not $IsWindows) {
-    $platform = [System.Environment]::OSVersion.Platform.ToString()
+# derived requirement: $IsWindows is undefined (reads as $null, so "-not $IsWindows" is always
+# true) under Windows PowerShell 5.1 -- it was only introduced in PowerShell 6+. Already fixed
+# once for this exact reason in tests/selfapps_lineending_check.ps1 (CLAUDE.md Item 44's own CI
+# coverage, PR #434); this sibling file had not been updated to match until a CodeRabbit review
+# on PR #436 caught it. [System.Environment]::OSVersion.Platform works identically on 5.1 and 7+.
+$platform = [System.Environment]::OSVersion.Platform.ToString()
+if ($platform -ne 'Win32NT') {
     $skipDetails = [ordered]@{ skip = $true; platform = $platform; reason = 'non-windows-host' }
     foreach ($id in @(
         'self.ux.gitignore.merge',
@@ -1181,6 +1186,6 @@ if ($env:HP_FORCE_CONDA_ONLY -eq '1') {
     })
 }
 
-$allPass = $giMerged -and $giPreserved -and $giIdem -and ($gaMerged -and $gaBatCrlf) -and $gaIdem -and $pfFound -and ($connPromptFound -and $connOfflineLog) -and $connPromptFound -and $uvOfflinePass -and $condaOfflinePass -and $connReachableFound -and $connRetryFound -and ($sysPromptFound -and $sysDeclineLog) -and $sysPromptFound -and $sysRealPass -and $sysAcceptPass -and $venvFbPass -and $venvCanaryPass -and $venvNoPipPass -and $embedDeclinePass -and $embedRealPass -and $entryOvPass
+$allPass = $giMerged -and $giPreserved -and $giIdem -and ($gaMerged -and $gaBatText) -and $gaIdem -and $pfFound -and ($connPromptFound -and $connOfflineLog) -and $connPromptFound -and $uvOfflinePass -and $condaOfflinePass -and $connReachableFound -and $connRetryFound -and ($sysPromptFound -and $sysDeclineLog) -and $sysPromptFound -and $sysRealPass -and $sysAcceptPass -and $venvFbPass -and $venvCanaryPass -and $venvNoPipPass -and $embedDeclinePass -and $embedRealPass -and $entryOvPass
 if (-not $allPass) { exit 1 }
 exit 0


### PR DESCRIPTION
## Summary

A high-confidence external review of #435 (working from the repo alone, no CI-log access) caught two places the CRLF distribution fix landed but didn't revisit, plus resolved one open backlog question. Fixed here:

1. **Stale in-file error message.** `run_setup.bat`'s own line-ending self-check panel still told a confused user to "re-download using git clone, not the Raw button" -- true before #435, false and actively bad advice after it (it steers a git-less Prime Directive user toward a tool they don't have, instead of just re-downloading via the now-fixed Raw link). The panel and its header comment now describe the check as defense-in-depth against a stale/re-saved copy, not a workaround for a still-broken distribution channel.
2. **`:merge_git_config` (REQ-015) propagating the disproven pattern.** It was still writing `*.bat eol=crlf` / `*.cmd eol=crlf` into every bootstrapped user's *own* `.gitattributes` -- the exact pattern this repo just spent #435 proving insufficient for itself. Changed to `*.bat -text` / `*.cmd -text`, matching this repo's own `.gitattributes`.
3. **Active Backlog Item 51 closed.** The same review settled the underlying cmd.exe semantics question (a successful plain `set` does not itself touch `%errorlevel%`, so this was very likely never a live bug) but the zero-risk reorder fix was applied anyway, exactly as the item's own note recommended -- closes the cross-call-site inconsistency regardless of who's right.
4. **Active Backlog Item 59 filed.** CodeRabbit's automated review did not run on PR #435 (this repo requires a manual trigger for repos under 10 stars) -- standing directive for future PRs to trigger it via `@coderabbitai review`, plus a record of what this pass caught as the motivating evidence.

Both message/template fixes updated their matching test assertions (`selfapps_lineending_check.ps1`, `selfapps_ux_hardening.ps1`) and the REQ-015 spec in README.md in lockstep, plus the captured-output transcript in `docs/demo-bootstrapper-output.md`.

## Test plan

- [x] `python tools/check_delimiters.py run_setup.bat` -- clean
- [x] `python tools/check_crlf.py` -- clean
- [x] `python -m compileall -q .` / `python -m pyflakes .` -- clean
- [x] `python -m yamllint .github/workflows/` / `actionlint -oneline .github/workflows/*.yml` -- clean
- [x] PowerShell AST parse sweep (`tests/*.ps1`, `tools/*.ps1`) -- clean
- [x] `python -m pytest tests/test_*.py -q` -- 528 passed, 3 skipped
- [x] ASCII sweep -- clean
- [ ] Full Windows CI matrix (`real`/`conda-full` gating lanes) -- pending this PR's own CI run

@coderabbitai review

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_017SQ1rvJxDbE71pTXJ4QvLV

---
_Generated by [Claude Code](https://claude.ai/code/session_017SQ1rvJxDbE71pTXJ4QvLV)_