### PR TITLE
Close Item 45: gate build/warnfix/repair block on HP_PY existing

### DIFF
--- a/.github/workflows/batch-check.yml
+++ b/.github/workflows/batch-check.yml
@@ -998,6 +998,18 @@ jobs:
         run: |
           & tests\selfapps_cascade_timed.ps1
 
+      # CLAUDE.md Active Backlog Item 45: a genuine first-attempt conda-create failure (all
+      # fallback tiers exhausted via the test's own HP_FORCE_CONDA_ONLY=1) must never reach the
+      # PyInstaller build/warnfix/repair block against a nonexistent HP_PY. Self-contained
+      # (own HP_FORCE_CONDA_ONLY=1 override, matching selfapps_pipgap.ps1's pattern) and
+      # deterministic (HP_TEST_FORCE_CONDA_CREATE_BOTH_FAIL=1, no real network dependency for
+      # the failure itself) -- gating from first landing.
+      - name: "Self-test: entry-smoke no-interpreter guard (conda-full only)"
+        if: ${{ !cancelled() && matrix.mode == 'conda-full' && steps.conda_avail.outputs.available == 'true' }}
+        shell: pwsh
+        run: |
+          & tests\selfapps_entrysmoke_no_interpreter.ps1
+
       - name: "Test pandas/openpyxl heuristic (conda-full only)"
         if: ${{ !cancelled() && matrix.mode == 'conda-full' && steps.conda_avail.outputs.available == 'true' }}
         shell: pwsh

--- a/.github/workflows/batch-check.yml
+++ b/.github/workflows/batch-check.yml
@@ -2137,6 +2137,12 @@ jobs:
             tests\~selftest_lineending_lf_only\~lineending_bootstrap.log
             tests/~selftest_lineending_lf_only/~bootstrap.status.json
             tests\~selftest_lineending_lf_only\~bootstrap.status.json
+            tests/~selftest_entrysmoke_no_interpreter/~entrysmoke_no_interpreter_bootstrap.log
+            tests\~selftest_entrysmoke_no_interpreter\~entrysmoke_no_interpreter_bootstrap.log
+            tests/~selftest_entrysmoke_no_interpreter/~setup.log
+            tests\~selftest_entrysmoke_no_interpreter\~setup.log
+            tests/~selftest_entrysmoke_no_interpreter/~bootstrap.status.json
+            tests\~selftest_entrysmoke_no_interpreter\~bootstrap.status.json
             tests/extracted/**
           if-no-files-found: ignore
           include-hidden-files: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -961,26 +961,6 @@ the same session, no new information, not re-filed). Each item below was checked
 source directly, not taken on the reviews' word alone; where a claim could not be confirmed this
 way (no live Windows execution available here), that is noted explicitly rather than stated as fact.
 
-- **Item 45: gate the build/warnfix/repair block on `HP_PY` actually existing, so a failed
-  env-create cannot cascade into a doomed PyInstaller build plus multiple repair-loop attempts with
-  no interpreter behind any of them.** Deliberately scoped narrow -- this is the small, isolated
-  first bite; Item 46 below is the larger, NOT-small structural issue this is a partial mitigation
-  for, and the two should not be conflated into one change.
-
-  **Mechanism**: `:die` returns via `exit /b` rather than halting the process (see
-  `docs/agent-lessons-learned.md`'s `:die` entry), so a genuine env-create failure can fall through
-  into `:run_entry_smoke` and attempt a full PyInstaller build, warnfix repair round, DLL-bundle
-  recovery, and hidden-import recovery (each with their own iteration budgets) against an `HP_PY`
-  that points at a python.exe that does not exist. Every one of those steps is guaranteed to fail
-  or no-op uselessly in this state; none of it does the user any good, and each failure inside the
-  loop is itself a `call :die` site that may pause again.
-
-  **Fix**: a single `if not exist "%HP_PY%" (...)` guard at the top of the build/warnfix/repair
-  block, skipping straight to whatever the existing no-interpreter failure path already is (or a
-  new one, if none currently exists cleanly for this exact state) instead of attempting any of it.
-  Small, isolated, and directly kills the "PyInstaller loops while no env/dep work happened"
-  symptom without touching `:die`'s own 24+ call sites.
-
 - **Item 46: `:die`'s `exit /b` lets most of its ~31 call sites continue executing afterward,
   producing repeated `pause` prompts and further doomed work instead of a single clear stop. NOT a
   small slice -- needs its own careful, dedicated scoping pass before touching it.** Matches this

--- a/docs/agent-closed-backlog.md
+++ b/docs/agent-closed-backlog.md
@@ -2109,6 +2109,60 @@ run of the same regex logic before landing, not just reasoned about).
   staging path's own pattern. Zero-risk, closes the cross-call-site inconsistency that made this
   worth filing in the first place, regardless of which side of the semantics question is right.
 
+### Item 45 (closed 2026-08-17)
+
+- **Gate the build/warnfix/repair block on `HP_PY` actually existing, so a failed env-create
+  cannot cascade into a doomed PyInstaller build against no real interpreter.** Filed as a real,
+  reasoned-from-source concern: `:die` returns via `exit /b`, not a process halt, so a genuine
+  env-create failure can fall through into `:run_entry_smoke` with `HP_PY` pointing at a
+  python.exe that was never produced.
+
+  **Deep tracing before implementing found the concern was already substantially mitigated by
+  prior work, not a live open hole.** `:after_env_mode_selection`'s own interpreter smoke test
+  (`"%HP_PY%" -c "print('py_ok')" ... || set "HP_NO_INTERPRETER=1"`, added for CLAUDE.md's former
+  Active Backlog item 14) already catches every traced instance of a broken/nonexistent `HP_PY`
+  reaching that point -- both the "HP_PY completely undefined" case AND the "HP_PY defined but
+  the file does not exist" case (a plain, nonexistent-executable invocation fails with a nonzero
+  errorlevel either way) -- and `:preflight_compile` already bails out on `HP_NO_INTERPRETER`
+  before `:run_entry_smoke` ever reaches the PyInstaller build call. Traced every reachable path
+  into `:run_entry_smoke` (the sole call site, reached only via `:after_env_bootstrap`, itself
+  reached only via natural fall-through after `:after_env_mode_selection` for every real,
+  non-`HP_CI_SKIP_ENV` user run) and confirmed none of them bypass this smoke test.
+
+  **Genuine gap found: no direct, self-contained regression test existed for the specific call
+  path that reaches `:conda_create_done` with a nonexistent `HP_PY`.** `:conda_create_failed`
+  can fall through `:die` into `:conda_create_done`, which unconditionally sets
+  `HP_PY=%CONDA_PREFIX%\python.exe` even though conda create just failed -- the exact "points at
+  a python.exe that does not exist" scenario the item describes. Item 14's own regression test
+  (`self.embed.fallback.decline`) uses the `HP_TEST_FORCE_CONDA_FAIL` bypass, which routes
+  straight to `:handle_conda_failure` and never touches `:conda_create_done`'s `HP_PY`-setting
+  line at all; `self.cascade.conda_create_fail`'s two scenarios are both REQ-009 cascade
+  RE-ENTRIES (`HP_CASCADE_SAVED_PY` defined), which route through `:cascade_conda_create_failed`
+  instead, also never reaching that line. No existing test reached it via a genuine, first-attempt
+  (non-cascade), non-bypassed conda-create failure.
+
+  **Fix shipped**: a direct, explicit guard at the very top of `:run_entry_smoke`
+  (`if not exist "%HP_PY%" set "HP_NO_INTERPRETER=1"`, before `:preflight_compile` is even
+  called) -- a backstop at the actual point of use, not a fix for a previously-unmitigated hole.
+  Value beyond pure redundancy: it also fixes a latent message-framing bug -- without it, a
+  broken `HP_PY` that somehow bypassed the upstream smoke test would instead fail
+  `:preflight_compile`'s own `py_compile` call and get misreported as a syntax error in the
+  user's own code, rather than the honest "no Python interpreter is available" message.
+
+  **New regression test**: `tests/selfapps_entrysmoke_no_interpreter.ps1` (`conda-full` lane,
+  gated on `steps.conda_avail.outputs.available == 'true'`, GATING from first landing --
+  deterministic and self-contained via `HP_FORCE_CONDA_ONLY=1` + `HP_TEST_FORCE_CONDA_CREATE_
+  BOTH_FAIL=1`, no real network dependency for the failure itself, matching
+  `selfapps_pipgap.ps1`'s own established self-contained-conda-only pattern). Exercises the exact
+  previously-untested path: reaches `:conda_create_done` with a nonexistent `HP_PY`, asserts no
+  PyInstaller build is ever attempted, the honest no-interpreter message appears, the old
+  fabricated syntax-error message does not, and `~bootstrap.status.json` reads `state=error` with
+  a graceful `exit 0`. New static check `batch.entrysmoke.no_interpreter_guard`
+  (`tests/harness.ps1`) confirms the guard line exists between the `:run_entry_smoke` label and
+  its first `call :preflight_compile`, verified via a standalone `pwsh` probe (including a
+  negative control) before landing. See `docs/agent-ndjson.md`'s own entry for the full row
+  schema and reasoning.
+
 ## Known Findings (diagnosed, no action warranted)
 
 - **Backlog item numbering: renumber-on-collision convention dropped, 2026-07-31 owner decision.**

--- a/docs/agent-cold-storage.md
+++ b/docs/agent-cold-storage.md
@@ -28,10 +28,11 @@ its own named trigger genuinely fires -- do not speculatively build any of these
 
 - **Total build-attempt budget cap across nested repair loops** (hidden-import recovery x
   DLL-bundle recovery x REQ-009 provider-cascade tiers, each with its own iteration cap that
-  compounds with the others -- see CLAUDE.md's former Active Backlog Item 45/46 discussion for the
-  no-`HP_PY` case this overlaps with). Raised during a 2026-08-14 real Windows Sandbox debugging
-  session as a theoretical concern (many PyInstaller invocations possible in the worst case with no
-  single circuit breaker), not a confirmed problem -- the individual loops are each already capped
+  compounds with the others -- see CLAUDE.md's closed Active Backlog Item 45 and still-open Item 46
+  discussion for the no-`HP_PY` case this overlaps with). Raised during a 2026-08-14 real Windows
+  Sandbox debugging session as a theoretical concern (many PyInstaller invocations possible in the
+  worst case with no single circuit breaker), not a confirmed problem -- the individual loops are
+  each already capped
   and this repo's own history with them (CLAUDE.md's DLL-bundling/hidden-import interconnect
   entries) shows real, hard-won caution about touching them without strong justification. **Trigger
   to thaw**: a real CI run or user report showing the repair-loop product actually causing a

--- a/docs/agent-ndjson.md
+++ b/docs/agent-ndjson.md
@@ -55,6 +55,7 @@ self.collect.submodules,
 self.exe.hidden_import, self.exe.hidden_import.exhaust,
 self.preflight.syntax,
 self.preflight.no_powershell, self.preflight.ps_check_fail, self.preflight.lf_only,
+self.entrysmoke.no_interpreter_guard,
 self.cascade.detect, self.cascade.consent, self.cascade.timed,
 self.cascade.exec (uv lane only -- selfapps_cascade.ps1; non-gating),
 self.cascade.conda_create_fail (uv lane only -- selfapps_cascade_conda_create_fail.ps1; non-gating),
@@ -182,6 +183,7 @@ version.metadata,
 host.env.os, host.env.ps, host.env.python,
 batch.req009.venv_unconditional, batch.req009.provider_logs, batch.req009.cascade_detect, batch.req009.cascade_consent, batch.req009.cascade_exec,
 batch.req010.isolation, batch.req011.dircheck, batch.req012.skiphooks,
+batch.entrysmoke.no_interpreter_guard,
 batch.req002.findentry_cli, batch.req002.findentry_run, batch.req002.entry_log, batch.req002.findentry_payload,
 batch.req002.picker,
 batch.ux.pause.gated,
@@ -939,6 +941,61 @@ verified locally).
 
 ```
 self.preflight.no_powershell, self.preflight.ps_check_fail, self.preflight.lf_only
+```
+
+---
+
+## selfapps-entrysmoke-no-interpreter NDJSON rows (selfapps_entrysmoke_no_interpreter.ps1, conda-full lane only, GATING)
+
+CLAUDE.md Active Backlog Item 45: `:die` uses `exit /b` (a subroutine return, not a process halt),
+so a genuine first-attempt conda-create failure can fall through into `:conda_create_done`, which
+unconditionally sets `HP_PY` to the conda env's expected `python.exe` path even though conda
+create just failed and that file was never produced. Deep tracing while implementing this item
+found the build/warnfix/repair block was already structurally protected in every reachable
+scenario -- `:after_env_mode_selection`'s own interpreter smoke test (added for CLAUDE.md's
+former Active Backlog item 14, closed) already sets `HP_NO_INTERPRETER` whenever `HP_PY` fails to
+execute, and `:preflight_compile` already bails out on that flag before `:run_entry_smoke` ever
+reaches the PyInstaller build call -- but this exact call path (a genuine, non-cascade,
+non-`HP_TEST_FORCE_CONDA_FAIL`-bypassed first-attempt exhaustion reaching `:conda_create_done`
+with a nonexistent `HP_PY`) had no direct regression test of its own; item 14's own regression
+test (`self.embed.fallback.decline`, `selfapps_ux_hardening.ps1`) uses the `HP_TEST_FORCE_
+CONDA_FAIL` bypass, which never reaches `:conda_create_done`'s `HP_PY`-setting line at all, and
+`self.cascade.conda_create_fail`'s two scenarios are both REQ-009 cascade RE-ENTRIES (`HP_CASCADE_
+SAVED_PY` defined), which route through `:cascade_conda_create_failed` instead, also never
+touching this line. The fix itself is a direct, explicit guard at the top of `:run_entry_smoke`
+(`if not exist "%HP_PY%" set "HP_NO_INTERPRETER=1"`, before `:preflight_compile` is even called)
+-- a backstop at the actual point of use, not a fix for a previously-unmitigated hole, so the
+build/warnfix/repair block cannot be reached against a nonexistent `HP_PY` even if some future
+change removes or bypasses the upstream smoke test; it also fixes a latent message-framing bug
+(without it, a broken `HP_PY` bypassing the upstream smoke test would instead fail
+`:preflight_compile`'s own `py_compile` call and get misreported as a syntax error in the user's
+code, not a missing interpreter).
+
+`HP_FORCE_CONDA_ONLY=1` (self-contained, matching `selfapps_pipgap.ps1`'s own established
+pattern) makes both `:handle_conda_failure` calls in this path a no-op (embed/venv/system
+fallback attempts are skipped by design for this lane), so total tier exhaustion is reached
+deterministically without needing embed/venv/system-specific forced-failure hooks.
+`HP_TEST_FORCE_CONDA_CREATE_BOTH_FAIL=1` forces the REAL conda create/retry code path to fail
+both attempts deterministically, matching CLAUDE.md's former Active Backlog item 23's own
+established convention that the `HP_TEST_FORCE_CONDA_FAIL` bypass alone is not sufficient
+evidence for this class of gap.
+
+Asserts: both the simulated initial-attempt and retry-attempt failure signatures fired, the
+`:conda_create_done` "python.exe missing from conda environment" branch was genuinely reached,
+the honest "No Python interpreter is available" message appears, the old fabricated "syntax
+error" message (CLAUDE.md's former Active Backlog item 14) does not, no PyInstaller build is
+ever attempted ("Building standalone executable" absent -- the key Item 45 assertion),
+`~bootstrap.status.json` reads `state=error`, and the process still exits 0 (this repo's
+established "graceful stop" contract -- see `self.conda.bothfail`'s sibling reasoning).
+
+Lane: `conda-full` only, gated on `steps.conda_avail.outputs.available == 'true'` (same gate 28+
+other conda-full-only self-tests already use) -- guarantees real Miniconda is already present,
+since `HP_FORCE_CONDA_ONLY=1` makes this test's own conda-create attempt the first thing reached
+rather than triggering a fresh Miniconda download itself. Deterministic and self-contained, so
+gating from first landing (same reasoning as `self.preflight.lf_only`'s own precedent).
+
+```
+self.entrysmoke.no_interpreter_guard
 ```
 
 ---

--- a/run_setup.bat
+++ b/run_setup.bat
@@ -3397,6 +3397,18 @@ if not "%HP_SMOKE_RC%"=="0" if not defined HP_PROBE_EXCEEDED (
 exit /b 0
 :run_entry_smoke
 call :record_chosen_entry "%HP_ENTRY%"
+rem CLAUDE.md Active Backlog Item 45: a failed env-create can fall through :die (exit /b
+rem returns from the call frame, it does not halt the process -- see docs/agent-lessons-
+rem learned.md's ":die uses exit /b" entry) with HP_PY left pointing at a python.exe that
+rem was never produced. :after_env_mode_selection's own interpreter smoke test already sets
+rem HP_NO_INTERPRETER for this case today, but that protection is 800+ lines upstream and
+rem indirect; this is a direct, explicit backstop at the actual point of use, so the
+rem build/warnfix/repair block below can never be reached against a nonexistent HP_PY even
+rem if some future change removes or bypasses the upstream smoke test. Setting
+rem HP_NO_INTERPRETER here (instead of a bespoke message) also fixes a latent message-framing
+rem bug: without it, a broken HP_PY would instead fail :preflight_compile's own py_compile
+rem call and get misreported as a syntax error in the user's code, not a missing interpreter.
+if not exist "%HP_PY%" set "HP_NO_INTERPRETER=1"
 rem REQ-021: static pre-flight syntax check of the entry (no user code executed). A SyntaxError
 rem makes the program unrunnable under the interpreter AND unbuildable by PyInstaller, so report it
 rem clearly and stop here instead of failing later inside the doomed PyInstaller build.

--- a/tests/harness.ps1
+++ b/tests/harness.ps1
@@ -296,7 +296,7 @@ Write-Result "batch.req012.skiphooks" "REQ-012: HP_SKIP_ENTRY_SMOKE and HP_SKIP_
 # whole-file match) to the text between the :run_entry_smoke label and its first
 # "call :preflight_compile" -- both the guard's presence AND its ordering before the call are
 # proven together, since a guard placed anywhere after the call would fall outside this window.
-$item45Scope = [regex]::Match($AllText, '(?s):run_entry_smoke\r?\n.*?call :preflight_compile')
+$item45Scope = [regex]::Match($AllText, '(?ms)^:run_entry_smoke\r?\n.*?call :preflight_compile')
 $hasItem45Guard = $item45Scope.Success -and ($item45Scope.Value -match [regex]::Escape('if not exist "%HP_PY%" set "HP_NO_INTERPRETER=1"'))
 Write-Result "batch.entrysmoke.no_interpreter_guard" "CLAUDE.md Item 45: :run_entry_smoke gates HP_PY existence before :preflight_compile is called" $hasItem45Guard @{}
 $req009Patterns = @('\[BOOT\] REQ-009.*Selected.*UV', '\[BOOT\] REQ-009.*Selected.*Conda', '\[BOOT\] REQ-009.*Selected.*Embedded Python', '\[BOOT\] REQ-009.*Selected.*Local venv', '\[BOOT\] REQ-009.*Selected.*System Python')

--- a/tests/harness.ps1
+++ b/tests/harness.ps1
@@ -290,6 +290,15 @@ Write-Result "batch.req011.dircheck" "REQ-011: directory integrity check present
 $req012Patterns = @('HP_SKIP_ENTRY_SMOKE set; skipping entry-script smoke', 'HP_SKIP_EXE_SMOKERUN set; skipping EXE verification')
 $hasReq012 = ($req012Patterns | Where-Object { -not ($AllText -match $_) }).Count -eq 0
 Write-Result "batch.req012.skiphooks" "REQ-012: HP_SKIP_ENTRY_SMOKE and HP_SKIP_EXE_SMOKERUN execution-skip log lines present in run_setup.bat" $hasReq012 @{}
+# CLAUDE.md Active Backlog Item 45: :run_entry_smoke must gate on HP_PY actually existing
+# BEFORE :preflight_compile is ever called, so a failed env-create that fell through :die with
+# a broken HP_PY can never reach the PyInstaller build/warnfix/repair block. Scoped (not a
+# whole-file match) to the text between the :run_entry_smoke label and its first
+# "call :preflight_compile" -- both the guard's presence AND its ordering before the call are
+# proven together, since a guard placed anywhere after the call would fall outside this window.
+$item45Scope = [regex]::Match($AllText, '(?s):run_entry_smoke\r?\n.*?call :preflight_compile')
+$hasItem45Guard = $item45Scope.Success -and ($item45Scope.Value -match [regex]::Escape('if not exist "%HP_PY%" set "HP_NO_INTERPRETER=1"'))
+Write-Result "batch.entrysmoke.no_interpreter_guard" "CLAUDE.md Item 45: :run_entry_smoke gates HP_PY existence before :preflight_compile is called" $hasItem45Guard @{}
 $req009Patterns = @('\[BOOT\] REQ-009.*Selected.*UV', '\[BOOT\] REQ-009.*Selected.*Conda', '\[BOOT\] REQ-009.*Selected.*Embedded Python', '\[BOOT\] REQ-009.*Selected.*Local venv', '\[BOOT\] REQ-009.*Selected.*System Python')
 $hasReq009 = ($req009Patterns | Where-Object { -not ($AllText -match $_) }).Count -eq 0
 Write-Result "batch.req009.provider_logs" "REQ-009: all five provider log lines present in run_setup.bat" $hasReq009 @{}

--- a/tests/selfapps_entrysmoke_no_interpreter.ps1
+++ b/tests/selfapps_entrysmoke_no_interpreter.ps1
@@ -1,0 +1,180 @@
+# ASCII only
+# selfapps_entrysmoke_no_interpreter.ps1 - Regression coverage for CLAUDE.md Active Backlog
+# Item 45: gate the build/warnfix/repair block on HP_PY actually existing, so a failed
+# env-create cannot cascade into a doomed PyInstaller build (plus warnfix/DLL-bundle/hidden-
+# import repair attempts) with no real interpreter behind any of it.
+#
+# :die uses "exit /b" (a subroutine return, not a process halt -- see docs/agent-lessons-
+# learned.md's ":die" entry), so a caller with no goto/halt after "call :die" simply continues.
+# A genuine (not HP_TEST_FORCE_CONDA_FAIL-bypassed) FIRST-ATTEMPT conda-create failure exercises
+# a path that was never directly tested before this item: :conda_create_failed falls through
+# :die into :conda_create_done, which unconditionally sets HP_PY to the conda env's expected
+# python.exe path -- even though conda create just failed and that file was never produced.
+# The very next "if not exist %HP_PY%" guard catches this and calls :handle_conda_failure a
+# SECOND time (redundant, since HP_FORCE_CONDA_ONLY already made the first call a no-op), then
+# falls through :die again before finally reaching :after_env_mode_selection.
+#
+# This is a genuinely different call path than either of selfapps_cascade_conda_create_fail.
+# ps1's two scenarios (both are REQ-009 cascade RE-ENTRIES, where HP_CASCADE_SAVED_PY is
+# defined and routes through :cascade_conda_create_failed instead -- HP_PY is never touched by
+# :conda_create_done on that path at all) and self.embed.fallback.decline in
+# selfapps_ux_hardening.ps1 (which forces conda to fail via the HP_TEST_FORCE_CONDA_FAIL bypass,
+# never reaching :conda_create_done's own HP_PY-setting line either). This is the one scenario
+# that reaches :conda_create_done with a HP_PY that is defined but does not exist on disk.
+#
+# HP_FORCE_CONDA_ONLY=1 makes :handle_conda_failure a no-op on both calls (embed/venv/system
+# fallback attempts are all skipped for this lane by design), so total tier exhaustion is
+# reached deterministically without needing embed/venv/system-specific forced-failure hooks.
+# HP_TEST_FORCE_CONDA_CREATE_BOTH_FAIL=1 forces the REAL conda create/retry code path to fail
+# both attempts deterministically (matching Item 23's own established convention that the
+# HP_TEST_FORCE_CONDA_FAIL bypass is not sufficient evidence for this class of gap -- see
+# selfapps_cascade_conda_create_fail.ps1's own header comment).
+#
+# Asserts the actual Item 45 guard: no PyInstaller build is ever attempted ("Building standalone
+# executable" absent), the honest "No Python interpreter is available" message appears (proving
+# HP_NO_INTERPRETER was set -- either by :after_env_mode_selection's own interpreter smoke test,
+# or by this item's new direct guard at the top of :run_entry_smoke, whichever fires first), the
+# old fabricated "syntax error" message is absent (CLAUDE.md former Active Backlog item 14's own
+# regression -- see selfapps_ux_hardening.ps1's self.embed.fallback.decline for the sibling
+# assertion), and ~bootstrap.status.json reads state=error with a graceful (exit 0) process exit
+# (this repo's established "graceful stop" contract -- see selfapps_conda_bothfail.ps1's sibling
+# reasoning).
+#
+# Lane: conda-full only, gated on steps.conda_avail.outputs.available == 'true' (same gate 28+
+# other conda-full-only self-tests already use) -- guarantees real Miniconda is already present
+# (HP_FORCE_CONDA_ONLY=1 makes this test's own conda create attempt the FIRST thing reached, so
+# it needs CONDA_BAT to already exist rather than triggering a fresh Miniconda download itself).
+# Deterministic (no real network dependency for the create failure itself) and self-contained
+# (own HP_FORCE_CONDA_ONLY=1 override, matching selfapps_pipgap.ps1's own established pattern),
+# so gating from first landing.
+param()
+$ErrorActionPreference = 'Continue'
+$here = $PSScriptRoot
+$repo = Split-Path -Path $here -Parent
+$nd   = Join-Path $here '~test-results.ndjson'
+$ciNd = Join-Path $repo 'ci_test_results.ndjson'
+if (-not (Test-Path $nd))   { New-Item -ItemType File -Path $nd   -Force | Out-Null }
+if (-not (Test-Path $ciNd)) { New-Item -ItemType File -Path $ciNd -Force | Out-Null }
+
+function Write-NdjsonRow {
+    param([hashtable]$Row)
+    $lane = [Environment]::GetEnvironmentVariable('HP_CI_LANE')
+    if ($lane -and -not $Row.ContainsKey('lane')) { $Row['lane'] = $lane }
+    $json = $Row | ConvertTo-Json -Compress -Depth 8
+    Add-Content -LiteralPath $nd   -Value $json -Encoding Ascii
+    Add-Content -LiteralPath $ciNd -Value $json -Encoding Ascii
+}
+
+# derived requirement: $IsWindows is undefined (reads as $null) under Windows PowerShell 5.1 --
+# only introduced in PowerShell 6+. [System.Environment]::OSVersion.Platform works on both.
+$platform = [System.Environment]::OSVersion.Platform.ToString()
+if ($platform -ne 'Win32NT') {
+    Write-NdjsonRow ([ordered]@{
+        id      = 'self.entrysmoke.no_interpreter_guard'
+        req     = 'CLAUDE.md-Item-45'
+        pass    = $true
+        desc    = 'Entry-smoke no-interpreter guard (skipped on non-Windows)'
+        details = [ordered]@{ skip = $true; platform = $platform; reason = 'non-windows-host' }
+    })
+    exit 0
+}
+
+$batchPath = Join-Path $repo 'run_setup.bat'
+if (-not (Test-Path $batchPath)) {
+    Write-NdjsonRow ([ordered]@{
+        id      = 'self.entrysmoke.no_interpreter_guard'
+        req     = 'CLAUDE.md-Item-45'
+        pass    = $false
+        desc    = 'Entry-smoke no-interpreter guard: run_setup.bat not found'
+        details = [ordered]@{ error = 'run_setup.bat not found at ' + $batchPath }
+    })
+    exit 1
+}
+
+$workDir = Join-Path $here '~selftest_entrysmoke_no_interpreter'
+if (Test-Path $workDir) { Remove-Item -Recurse -Force $workDir }
+New-Item -ItemType Directory -Force -Path $workDir | Out-Null
+Copy-Item -Path $batchPath -Destination $workDir -Force
+Set-Content -Path (Join-Path $workDir 'app.py') -Value 'print("should-not-run")' -Encoding ASCII
+
+$bootstrapLog = '~entrysmoke_no_interpreter_bootstrap.log'
+
+$prevForceCondaOnly = if (Test-Path Env:HP_FORCE_CONDA_ONLY) { $env:HP_FORCE_CONDA_ONLY } else { $null }
+$prevCcBothFail     = if (Test-Path Env:HP_TEST_FORCE_CONDA_CREATE_BOTH_FAIL) { $env:HP_TEST_FORCE_CONDA_CREATE_BOTH_FAIL } else { $null }
+$prevSkipPipreqs    = if (Test-Path Env:HP_SKIP_PIPREQS) { $env:HP_SKIP_PIPREQS } else { $null }
+$env:HP_FORCE_CONDA_ONLY = '1'
+$env:HP_TEST_FORCE_CONDA_CREATE_BOTH_FAIL = '1'
+$env:HP_SKIP_PIPREQS = '1'
+
+try {
+    Push-Location $workDir
+    try {
+        cmd /c "call run_setup.bat > $bootstrapLog 2>&1"
+        $runExit = $LASTEXITCODE
+    } finally {
+        Pop-Location
+    }
+} finally {
+    if ($null -eq $prevForceCondaOnly) { Remove-Item Env:HP_FORCE_CONDA_ONLY -ErrorAction SilentlyContinue } else { $env:HP_FORCE_CONDA_ONLY = $prevForceCondaOnly }
+    if ($null -eq $prevCcBothFail)     { Remove-Item Env:HP_TEST_FORCE_CONDA_CREATE_BOTH_FAIL -ErrorAction SilentlyContinue } else { $env:HP_TEST_FORCE_CONDA_CREATE_BOTH_FAIL = $prevCcBothFail }
+    if ($null -eq $prevSkipPipreqs)    { Remove-Item Env:HP_SKIP_PIPREQS -ErrorAction SilentlyContinue } else { $env:HP_SKIP_PIPREQS = $prevSkipPipreqs }
+}
+
+$logPath   = Join-Path $workDir $bootstrapLog
+$setupLog  = Join-Path $workDir '~setup.log'
+$logText   = if (Test-Path -LiteralPath $logPath)  { Get-Content -LiteralPath $logPath  -Raw -Encoding ASCII } else { '' }
+$setupText = if (Test-Path -LiteralPath $setupLog) { Get-Content -LiteralPath $setupLog -Raw -Encoding ASCII } else { '' }
+$combined  = $logText + "`n" + $setupText
+
+$initialAttemptFailed = $combined -match [regex]::Escape('CondaHTTPError: HTTP 000 CONNECTION FAILED (simulated)')
+$retryAlsoFailed      = $combined -match [regex]::Escape('conda create: retry after transient failure also failed')
+$missingPyReached     = $combined -match [regex]::Escape('[ERROR] python.exe missing from conda environment.')
+
+# The actual Item 45 guard: the honest no-interpreter message fires, the old fabricated
+# syntax-error message never fires, and -- the key assertion -- no PyInstaller build is ever
+# attempted against the broken interpreter.
+$honestNoInterpreterMsg = $combined -match [regex]::Escape('No Python interpreter is available')
+$noFakeSyntaxErr        = -not ($combined -match [regex]::Escape('Your Python program has a syntax error'))
+$noBuildAttempt         = -not ($combined -match [regex]::Escape('Building standalone executable'))
+
+$statusPath = Join-Path $workDir '~bootstrap.status.json'
+$statusState = $null
+$statusExit  = $null
+if (Test-Path -LiteralPath $statusPath) {
+    try {
+        $status = Get-Content -LiteralPath $statusPath -Raw -Encoding ASCII | ConvertFrom-Json
+        $statusState = $status.state
+        $statusExit  = $status.exitCode
+    } catch { }
+}
+
+$pass = $initialAttemptFailed -and $retryAlsoFailed -and $missingPyReached -and
+        $honestNoInterpreterMsg -and $noFakeSyntaxErr -and $noBuildAttempt -and
+        ($statusState -eq 'error') -and ($runExit -eq 0)
+
+Write-Host "=== self.entrysmoke.no_interpreter_guard evidence ==="
+Write-Host ("initialAttemptFailed={0} retryAlsoFailed={1} missingPyReached={2} honestNoInterpreterMsg={3} noFakeSyntaxErr={4} noBuildAttempt={5} statusState={6} statusExit={7} runExit={8} pass={9}" -f `
+    $initialAttemptFailed, $retryAlsoFailed, $missingPyReached, $honestNoInterpreterMsg, $noFakeSyntaxErr, $noBuildAttempt, $statusState, $statusExit, $runExit, $pass)
+Write-Host "=== end self.entrysmoke.no_interpreter_guard evidence ==="
+
+Write-NdjsonRow ([ordered]@{
+    id      = 'self.entrysmoke.no_interpreter_guard'
+    req     = 'CLAUDE.md-Item-45'
+    pass    = [bool]$pass
+    desc    = 'a genuine first-attempt conda-create failure (all fallback tiers exhausted via HP_FORCE_CONDA_ONLY) never reaches the PyInstaller build/warnfix/repair block, and reports the honest no-interpreter cause'
+    details = [ordered]@{
+        initialAttemptFailed    = [bool]$initialAttemptFailed
+        retryAlsoFailed         = [bool]$retryAlsoFailed
+        missingPyReached        = [bool]$missingPyReached
+        honestNoInterpreterMsg  = [bool]$honestNoInterpreterMsg
+        noFakeSyntaxErr         = [bool]$noFakeSyntaxErr
+        noBuildAttempt          = [bool]$noBuildAttempt
+        statusState             = $statusState
+        statusExit              = $statusExit
+        runExit                 = $runExit
+        log                     = $bootstrapLog
+    }
+})
+
+if (-not $pass) { exit 1 }
+exit 0


### PR DESCRIPTION
## Summary

Implements CLAUDE.md Active Backlog Item 45: `:die` returns via `exit /b` (not a process halt), so a genuine env-create failure can fall through into `:run_entry_smoke` with `HP_PY` pointing at a python.exe that was never produced.

**Deep tracing before implementing found the concern was already substantially mitigated by prior work (CLAUDE.md's former Item 14), not a live open hole.** `:after_env_mode_selection`'s own interpreter smoke test already sets `HP_NO_INTERPRETER` whenever `HP_PY` fails to execute, and `:preflight_compile` already bails out on that flag before the PyInstaller build call is ever reached. Every path into `:run_entry_smoke` was traced and confirmed to pass through that smoke test first.

**Genuine gap found**: no regression test directly covered the specific call path that reaches `:conda_create_done` with a nonexistent `HP_PY` (a genuine, non-cascade, non-test-bypassed first-attempt conda-create failure). Neither existing sibling test reaches this exact line.

**Fix**: a direct, explicit guard at the top of `:run_entry_smoke` (`if not exist "%HP_PY%" set "HP_NO_INTERPRETER=1"`, before `:preflight_compile` is even called) — a backstop at the actual point of use, not a fix for a previously-unmitigated hole. It also fixes a latent message-framing bug: without it, a broken `HP_PY` that somehow bypassed the upstream smoke test would instead fail `:preflight_compile`'s own `py_compile` call and get misreported as a syntax error in the user's own code, rather than the honest "no Python interpreter is available" message.

1. `run_setup.bat`: new guard at the top of `:run_entry_smoke`.
2. `tests/selfapps_entrysmoke_no_interpreter.ps1` (new): regression test exercising the exact previously-untested path (`conda-full` lane, gated on Miniconda availability, gating from first landing — deterministic and self-contained via `HP_FORCE_CONDA_ONLY=1` + `HP_TEST_FORCE_CONDA_CREATE_BOTH_FAIL=1`).
3. `tests/harness.ps1`: new static check `batch.entrysmoke.no_interpreter_guard` confirming the guard's presence and ordering (scoped regex, not a whole-file match — verified against a negative control before landing).
4. `.github/workflows/batch-check.yml`: wires the new test into the `conda-full` lane.
5. `docs/agent-ndjson.md`: registers both new NDJSON row ids.
6. `CLAUDE.md` / `docs/agent-closed-backlog.md`: Item 45 moved from Active Backlog to Closed, with the full tracing/reasoning preserved.
7. `docs/agent-cold-storage.md`: small wording fix (a cross-reference to "former Active Backlog Item 45/46" was inaccurate now that only 45 is closed).

## Test plan

- [x] `python tools/check_delimiters.py run_setup.bat` -- clean
- [x] `python tools/check_crlf.py` -- clean
- [x] `python -m compileall -q .` / `python -m pyflakes .` -- clean
- [x] `python -m yamllint .github/workflows/` / `actionlint -oneline .github/workflows/*.yml` -- clean
- [x] PowerShell AST parse sweep (`tests/*.ps1`, `tools/*.ps1`) -- clean
- [x] `python -m pytest tests/test_*.py -q` -- 528 passed, 3 skipped
- [x] `python tools/check_ndjson_registry.py` -- PASS, no doc/code mismatches
- [x] New harness static check verified against a real `pwsh` probe, including a negative control (guard removed -> check correctly flips to fail)
- [x] ASCII sweep -- clean
- [ ] Full Windows CI matrix (`real`/`conda-full` gating lanes) -- pending this PR's own CI run

@coderabbitai review

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_017SQ1rvJxDbE71pTXJ4QvLV

---
_Generated by [Claude Code](https://claude.ai/code/session_017SQ1rvJxDbE71pTXJ4QvLV)_