### PR TITLE
Item 46 Bucket A slice 1: skip redundant fallback-chain retry on conda-create exhaustion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -999,19 +999,48 @@ way (no live Windows execution available here), that is noted explicitly rather 
   these (nothing useful follows a totally-exhausted provider chain with no valid interpreter at
   all), so they remain candidates for Bucket A's `HP_FATAL` mechanism instead, not this pattern.
 
-  **Bucket A (not yet started): a global `HP_FATAL` flag for the remaining, genuinely-doomed `:die`
-  sites** -- candidate fix shapes, not yet chosen between: (a) a global `HP_FATAL` flag set by
-  `:die`, checked via `if defined HP_FATAL goto :fatal_exit` after every remaining continuing call
-  site; (b) change what `:die` itself does on exit (e.g. a real process-halting `exit`, not
-  `exit /b`) for the cases where it is known to be called from the top-level call stack rather than
-  a nested subroutine -- riskier, since the top-level-vs-nested distinction is not always obvious
-  from a given call site, and a bare `exit` closes the console window immediately for a
-  double-click user with no chance to read the message first (see the existing `pause`-before-exit
-  convention this file already relies on). Given the number of remaining call sites and `:die`'s
-  central, load-bearing role throughout the file, treat this as EXTREME CAUTION on the same order
-  as the DLL-bundling/hidden-import repair loops elsewhere in this backlog -- one incremental slice
-  at a time (Bucket B above is the first proof this works), not a single sweeping change across
-  every remaining site.
+  **Bucket A slice 1 (closed 2026-08-17): `:conda_create_failed`'s own `call :die` now `goto`s
+  straight to `:after_env_mode_selection` instead of falling through into `:conda_create_done`'s
+  body.** Targeted, not a general `HP_FATAL` mechanism -- reuses a pattern the file already
+  shipped and already tests (`:hp_test_conda_fail`, the `HP_TEST_FORCE_CONDA_FAIL` bypass sibling
+  a few thousand lines below `:conda_create_failed`, has carried the identical `goto` since before
+  this fix). **The actual bug this closes is more concrete than "an extra pause": without the
+  `goto`, falling through into `:conda_create_done` unconditionally sets `HP_PY` to a path that
+  provably does not exist, and that block's own `if not exist` guard then calls
+  `:handle_conda_failure` A SECOND TIME -- not just wasted CPU, but a real user re-watching the
+  embed/venv fallback attempts and being asked the REQ-014 system-Python consent prompt again
+  right after already answering it once.** Regression test: `self.entrysmoke.no_interpreter_guard`
+  (`tests/selfapps_entrysmoke_no_interpreter.ps1`, already-gating from Item 45) extended to assert
+  the old, now-dead `:conda_create_done`-specific message ("python.exe missing from conda
+  environment") is genuinely absent, proving that block is skipped entirely.
+
+  **Important finding from implementing this slice, corrects an earlier assumption in this same
+  entry: this does NOT by itself reduce the "Consequence" chain above to a single pause.**
+  `:after_env_mode_selection`'s own `if not defined HP_PY` check (a few dozen lines below that
+  label) has the IDENTICAL non-halting `:die` shape, and is exactly what the new `goto` now
+  reaches (since `HP_PY` was never set this run) -- so a real interactive user hitting total
+  first-attempt tier exhaustion still sees two pauses today, just at a different second call site
+  than before (`:after_env_mode_selection`'s check, not `:conda_create_done`'s). That check is a
+  separate, not-yet-addressed follow-up slice -- finding a safe `goto` target for it needs its own
+  careful trace (a large block of dependency-resolution/pipreqs/heuristics code sits between it
+  and `:run_entry_smoke`, none of it needed when there's no interpreter, but not yet verified safe
+  to skip wholesale).
+
+  **Bucket A remaining scope: candidate fix shapes for a general mechanism, not yet chosen
+  between** -- (a) a global `HP_FATAL` flag set by `:die`, checked via `if defined HP_FATAL goto
+  :fatal_exit` after every remaining continuing call site; (b) change what `:die` itself does on
+  exit (e.g. a real process-halting `exit`, not `exit /b`) for the cases where it is known to be
+  called from the top-level call stack rather than a nested subroutine -- riskier, since the
+  top-level-vs-nested distinction is not always obvious from a given call site, and a bare `exit`
+  closes the console window immediately for a double-click user with no chance to read the
+  message first (see the existing `pause`-before-exit convention this file already relies on);
+  (c) continue the slice-1 approach -- individually targeted `goto`s at specific, well-understood
+  call sites, reusing already-proven patterns where one exists, rather than a single general
+  mechanism. Given the number of remaining call sites and `:die`'s central, load-bearing role
+  throughout the file, treat this as EXTREME CAUTION on the same order as the
+  DLL-bundling/hidden-import repair loops elsewhere in this backlog -- one incremental slice at a
+  time (slice 1 above is the second proof this works, after Bucket B), not a single sweeping
+  change across every remaining site.
 
 - **Item 47: no PowerShell capability preflight beyond bare presence.** The new line-ending
   self-check (Item 44's mitigation) added a `where powershell` presence guard as its own

--- a/docs/agent-interconnect.md
+++ b/docs/agent-interconnect.md
@@ -981,6 +981,44 @@ failure) -- unlike conda's solver, which fails outright on an unresolvable exact
 a real CI run ever shows this actually misbehaving for the embed tier specifically; not assumed
 from the conda case alone.
 
+### Genuine (non-cascade) conda-create exhaustion also falls through :conda_create_done -- a sibling gap to the cascade re-entry above (CLAUDE.md Item 46 Bucket A slice 1)
+
+**Distinct from "Provider cascade execution re-enters env-create" above -- that section covers a
+CASCADE re-entry (`HP_CASCADE_SAVED_PY` defined); this covers a GENUINE FIRST ATTEMPT where every
+tier (`:handle_conda_failure`'s embed/venv/system chain, called from `:conda_create_failed`) has
+already been tried and none worked.** Touch `:conda_create_failed`, must understand
+`:conda_create_done` AND `:after_env_mode_selection`'s own interpreter-missing guard -- all three
+share the same `:die`-does-not-halt hazard (see `docs/agent-lessons-learned.md`'s `:die` entry).
+
+Before this fix, `:conda_create_failed` fell through its own `call :die "[ERROR] conda env create
+failed."` straight into `:conda_create_done`, which unconditionally sets `HP_PY` to the conda
+env's expected (but never-created) `python.exe` path, immediately re-detects that via its own
+`if not exist` guard, and calls `:handle_conda_failure` A SECOND TIME -- replaying the just-failed
+embed download and venv creation attempts, and asking the REQ-014 system-Python consent prompt
+TWICE. Fixed by adding `goto :after_env_mode_selection` right after that `call :die` line (mirroring
+the already-shipped `:hp_test_conda_fail` test-bypass sibling a few thousand lines below, which has
+carried the identical goto since before this fix).
+
+**Does NOT reduce total pause count to one -- a real, more limited scope than it first appears.**
+`:after_env_mode_selection` has its OWN `if not defined HP_PY (set HP_NO_INTERPRETER=1 & call :die
+"[ERROR] Active Python interpreter not resolved.")` check a few dozen lines below its label. Since
+`HP_PY` is genuinely undefined at this point post-fix (never set, since `:conda_create_done` is now
+skipped entirely), this check fires and pauses a second time -- it did NOT fire pre-fix, because
+`:conda_create_done` used to leave `HP_PY` DEFINED (just pointing at a nonexistent file), which
+this specific check does not catch. So the fix relocates pause #2 to an already-precedented site
+(exercised by `self.embed.fallback.decline` in `tests/selfapps_ux_hardening.ps1`, via the
+`:hp_test_conda_fail` path) rather than eliminating it -- the genuine win is skipping the SECOND
+`:handle_conda_failure` call (and its embed/venv-attempt and system-consent-prompt replay), not
+cutting pause count. A further Bucket A slice targeting `:after_env_mode_selection`'s own check is
+the natural next candidate if reducing to a single pause is ever pursued.
+
+Regression test: `tests/selfapps_entrysmoke_no_interpreter.ps1` (`self.entrysmoke.no_interpreter_
+guard`, `conda-full` lane) -- asserts `[ERROR] python.exe missing from conda environment.` is
+ABSENT (proving the second `:handle_conda_failure` call is skipped) and the new
+`[ERROR] Active Python interpreter not resolved.` line IS present (proving the fall-through lands
+at `:after_env_mode_selection`'s own guard, not silently swallowed). See `docs/agent-ndjson.md`
+for the full assertion list.
+
 ### uv uses managed-only CPython (UV_PYTHON_PREFERENCE)
 
 `run_setup.bat` sets `UV_PYTHON_PREFERENCE=only-managed` at the top of the uv acquisition

--- a/docs/agent-ndjson.md
+++ b/docs/agent-ndjson.md
@@ -981,12 +981,25 @@ established convention that the `HP_TEST_FORCE_CONDA_FAIL` bypass alone is not s
 evidence for this class of gap.
 
 Asserts: both the simulated initial-attempt and retry-attempt failure signatures fired, the
-`:conda_create_done` "python.exe missing from conda environment" branch was genuinely reached,
-the honest "No Python interpreter is available" message appears, the old fabricated "syntax
+honest "No Python interpreter is available" message appears, the old fabricated "syntax
 error" message (CLAUDE.md's former Active Backlog item 14) does not, no PyInstaller build is
 ever attempted ("Building standalone executable" absent -- the key Item 45 assertion),
 `~bootstrap.status.json` reads `state=error`, and the process still exits 0 (this repo's
 established "graceful stop" contract -- see `self.conda.bothfail`'s sibling reasoning).
+
+**Updated for CLAUDE.md Active Backlog Item 46 (Bucket A slice 1, closed):**
+`:conda_create_failed`'s own `call :die` now `goto`s straight to `:after_env_mode_selection`
+instead of falling through into `:conda_create_done`'s body -- before this fix, that fall-through
+unconditionally set `HP_PY` to a nonexistent path, then its own "if not exist" guard called
+`:handle_conda_failure` a SECOND time (not just wasted CPU: a real user would have watched the
+embed/venv attempts and the REQ-014 system-Python consent prompt replay a second time right
+after already answering them once). The test now asserts the OLD "`:conda_create_done`'s
+'python.exe missing from conda environment'" message is genuinely ABSENT (proving that block is
+skipped entirely), and that the NEW site's message, "Active Python interpreter not resolved."
+(`:after_env_mode_selection`'s own "if not defined HP_PY" check, reached here since `HP_PY` was
+never set this run), appears instead. This slice does NOT reduce the bootstrap to a single pause
+for a real interactive user -- that check has the identical non-halting `:die` shape and is a
+separate, not-yet-addressed follow-up (see CLAUDE.md's Item 46 entry).
 
 Lane: `conda-full` only, gated on `steps.conda_avail.outputs.available == 'true'` (same gate 28+
 other conda-full-only self-tests already use) -- guarantees real Miniconda is already present,

--- a/run_setup.bat
+++ b/run_setup.bat
@@ -1122,7 +1122,25 @@ rem Item 23 for the full trace of why this was previously missing. On a genuine 
 rem (no earlier build to fall back to), HP_CASCADE_SAVED_PY is never defined, so this check is a
 rem no-op and the existing hard-failure behavior below is unchanged.
 if defined HP_CASCADE_SAVED_PY goto :cascade_conda_create_failed
+rem CLAUDE.md Active Backlog Item 46 (Bucket A, slice 1): :die returns via exit /b, not a
+rem process halt (see docs/agent-lessons-learned.md's ":die" entry), so without this goto,
+rem falling through here means EVERY tier (uv already failed earlier, conda create just
+rem failed, embed/venv/system all exhausted by :handle_conda_failure above) has been tried
+rem and none worked -- yet execution would still fall into :conda_create_done, which
+rem unconditionally sets HP_PY to a path that provably does not exist, immediately re-detects
+rem that via its own "if not exist" guard, and calls :handle_conda_failure A SECOND TIME.
+rem This is not just wasted CPU: :handle_conda_failure re-attempts embed download, venv
+rem creation, AND the REQ-014 system-Python consent prompt -- for a real user, this means
+rem watching the same failing embed/venv attempts a second time and being asked the same
+rem system-Python "keep going?" question again right after already answering it once. Skipping
+rem straight to :after_env_mode_selection (the same target the already-shipped :hp_test_conda_
+rem fail sibling a few thousand lines below has used since before this fix) avoids that replay
+rem -- note this does not, by itself, reduce the total pause count to one: :after_env_mode_
+rem selection's own "if not defined HP_PY" check (a few dozen lines below this label) has the
+rem identical non-halting :die shape and is reached here since HP_PY was never set this run;
+rem that is a separate, not-yet-addressed call site, tracked as a follow-up Bucket A slice.
 call :die "[ERROR] conda env create failed."
+goto :after_env_mode_selection
 :conda_create_done
 
 set "CONDA_PREFIX=%ENV_PATH%"

--- a/tests/selfapps_entrysmoke_no_interpreter.ps1
+++ b/tests/selfapps_entrysmoke_no_interpreter.ps1
@@ -7,12 +7,22 @@
 # :die uses "exit /b" (a subroutine return, not a process halt -- see docs/agent-lessons-
 # learned.md's ":die" entry), so a caller with no goto/halt after "call :die" simply continues.
 # A genuine (not HP_TEST_FORCE_CONDA_FAIL-bypassed) FIRST-ATTEMPT conda-create failure exercises
-# a path that was never directly tested before this item: :conda_create_failed falls through
-# :die into :conda_create_done, which unconditionally sets HP_PY to the conda env's expected
-# python.exe path -- even though conda create just failed and that file was never produced.
-# The very next "if not exist %HP_PY%" guard catches this and calls :handle_conda_failure a
-# SECOND time (redundant, since HP_FORCE_CONDA_ONLY already made the first call a no-op), then
-# falls through :die again before finally reaching :after_env_mode_selection.
+# a path that was never directly tested before this item.
+#
+# CLAUDE.md Active Backlog Item 46 (Bucket A, slice 1, closed): :conda_create_failed used to
+# fall through :die into :conda_create_done, which unconditionally set HP_PY to the conda env's
+# expected (but never-produced) python.exe path, then its own "if not exist %HP_PY%" guard
+# called :handle_conda_failure A SECOND TIME -- not just wasted CPU, a real user would have seen
+# the embed/venv attempts and the REQ-014 system-Python consent prompt replay a second time
+# right after already answering them once. Fixed with a goto straight to
+# :after_env_mode_selection (matching the already-shipped :hp_test_conda_fail sibling), so
+# :conda_create_done's body is skipped entirely on this path -- the old, redundant
+# "[ERROR] python.exe missing from conda environment." message this test used to assert is now
+# provably absent (see secondHandleCallAvoided below). This does NOT reduce the bootstrap to a
+# single pause for a real interactive user -- :after_env_mode_selection's own "if not defined
+# HP_PY" check has the identical non-halting shape and is what now reports the terminal failure
+# (see the honest-message assertions below), tracked as a separate, not-yet-addressed follow-up
+# slice in CLAUDE.md's Item 46 entry.
 #
 # This is a genuinely different call path than either of selfapps_cascade_conda_create_fail.
 # ps1's two scenarios (both are REQ-009 cascade RE-ENTRIES, where HP_CASCADE_SAVED_PY is
@@ -128,7 +138,15 @@ $combined  = $logText + "`n" + $setupText
 
 $initialAttemptFailed = $combined -match [regex]::Escape('CondaHTTPError: HTTP 000 CONNECTION FAILED (simulated)')
 $retryAlsoFailed      = $combined -match [regex]::Escape('conda create: retry after transient failure also failed')
-$missingPyReached     = $combined -match [regex]::Escape('[ERROR] python.exe missing from conda environment.')
+
+# Item 46 Bucket A slice 1: the old, redundant ":conda_create_done"-specific message must no
+# longer appear at all -- proving the new goto skipped that whole block, instead of merely
+# reaching it a second time. "Active Python interpreter not resolved." (from
+# :after_env_mode_selection's own "if not defined HP_PY" check) is the new site that reports the
+# terminal failure instead -- see this file's own header comment for why that site is a
+# still-open follow-up, not itself fixed by this slice.
+$secondHandleCallAvoided = -not ($combined -match [regex]::Escape('[ERROR] python.exe missing from conda environment.'))
+$reachedNewSite          = $combined -match [regex]::Escape('[ERROR] Active Python interpreter not resolved.')
 
 # The actual Item 45 guard: the honest no-interpreter message fires, the old fabricated
 # syntax-error message never fires, and -- the key assertion -- no PyInstaller build is ever
@@ -148,28 +166,29 @@ if (Test-Path -LiteralPath $statusPath) {
     } catch { }
 }
 
-$pass = $initialAttemptFailed -and $retryAlsoFailed -and $missingPyReached -and
+$pass = $initialAttemptFailed -and $retryAlsoFailed -and $secondHandleCallAvoided -and $reachedNewSite -and
         $honestNoInterpreterMsg -and $noFakeSyntaxErr -and $noBuildAttempt -and
         ($statusState -eq 'error') -and ($runExit -eq 0)
 
 Write-Host "=== self.entrysmoke.no_interpreter_guard evidence ==="
-Write-Host ("initialAttemptFailed={0} retryAlsoFailed={1} missingPyReached={2} honestNoInterpreterMsg={3} noFakeSyntaxErr={4} noBuildAttempt={5} statusState={6} statusExit={7} runExit={8} pass={9}" -f `
-    $initialAttemptFailed, $retryAlsoFailed, $missingPyReached, $honestNoInterpreterMsg, $noFakeSyntaxErr, $noBuildAttempt, $statusState, $statusExit, $runExit, $pass)
+Write-Host ("initialAttemptFailed={0} retryAlsoFailed={1} secondHandleCallAvoided={2} reachedNewSite={3} honestNoInterpreterMsg={4} noFakeSyntaxErr={5} noBuildAttempt={6} statusState={7} statusExit={8} runExit={9} pass={10}" -f `
+    $initialAttemptFailed, $retryAlsoFailed, $secondHandleCallAvoided, $reachedNewSite, $honestNoInterpreterMsg, $noFakeSyntaxErr, $noBuildAttempt, $statusState, $statusExit, $runExit, $pass)
 Write-Host "=== end self.entrysmoke.no_interpreter_guard evidence ==="
 
 Write-NdjsonRow ([ordered]@{
     id      = 'self.entrysmoke.no_interpreter_guard'
     req     = 'CLAUDE.md-Item-45'
     pass    = [bool]$pass
-    desc    = 'a genuine first-attempt conda-create failure (all fallback tiers exhausted via HP_FORCE_CONDA_ONLY) never reaches the PyInstaller build/warnfix/repair block, and reports the honest no-interpreter cause'
+    desc    = 'a genuine first-attempt conda-create failure (all fallback tiers exhausted via HP_FORCE_CONDA_ONLY) never reaches the PyInstaller build/warnfix/repair block, never redundantly retries the exhausted fallback chain a second time (Item 46 Bucket A slice 1), and reports the honest no-interpreter cause'
     details = [ordered]@{
-        initialAttemptFailed    = [bool]$initialAttemptFailed
-        retryAlsoFailed         = [bool]$retryAlsoFailed
-        missingPyReached        = [bool]$missingPyReached
-        honestNoInterpreterMsg  = [bool]$honestNoInterpreterMsg
-        noFakeSyntaxErr         = [bool]$noFakeSyntaxErr
-        noBuildAttempt          = [bool]$noBuildAttempt
-        statusState             = $statusState
+        initialAttemptFailed     = [bool]$initialAttemptFailed
+        retryAlsoFailed          = [bool]$retryAlsoFailed
+        secondHandleCallAvoided  = [bool]$secondHandleCallAvoided
+        reachedNewSite           = [bool]$reachedNewSite
+        honestNoInterpreterMsg   = [bool]$honestNoInterpreterMsg
+        noFakeSyntaxErr          = [bool]$noFakeSyntaxErr
+        noBuildAttempt           = [bool]$noBuildAttempt
+        statusState              = $statusState
         statusExit              = $statusExit
         runExit                 = $runExit
         log                     = $bootstrapLog


### PR DESCRIPTION
## Summary

- First slice of CLAUDE.md Active Backlog Item 46's "Bucket A" (the remaining genuinely-doomed `:die` call sites, tracked separately from Item 45 and Bucket B which are already merged). `:conda_create_failed`'s `call :die` previously fell through into `:conda_create_done`, which unconditionally set `HP_PY` to a path that provably does not exist, re-detected that via its own `if not exist` guard, and called `:handle_conda_failure` **a second time** -- replaying the just-failed embed download and venv creation attempts, and asking the REQ-014 system-Python consent prompt twice, for a genuine (non-cascade) total-tier-exhaustion failure.
- Fix: add `goto :after_env_mode_selection` right after that `call :die` line, mirroring the already-shipped `:hp_test_conda_fail` test-bypass sibling a few thousand lines below, which has carried the identical goto since before this change.
- **Honest scope note, caught during implementation via careful control-flow re-tracing (not by review):** this does *not* reduce total pause count to one. `:after_env_mode_selection` has its own `if not defined HP_PY` guard that now fires instead (previously masked, because `:conda_create_done` used to leave `HP_PY` defined-but-broken, which that specific check doesn't catch). The genuine win is skipping the **second** `:handle_conda_failure` call and its embed/venv-attempt + system-consent-prompt replay -- not cutting pause count to one. All updated docs (CLAUDE.md, a new `docs/agent-interconnect.md` section, the regression test header, and `docs/agent-ndjson.md`) describe this accurately rather than overclaiming.
- Regression test (`tests/selfapps_entrysmoke_no_interpreter.ps1`, `conda-full` lane) updated: asserts `[ERROR] python.exe missing from conda environment.` is now **absent** (proving the second `:handle_conda_failure` call is skipped) and the new `[ERROR] Active Python interpreter not resolved.` line **is present** (proving the fall-through lands at `:after_env_mode_selection`'s own guard rather than being silently swallowed).

## Test plan

- [x] `python tools/check_delimiters.py run_setup.bat` -- clean
- [x] `tools/run_sanity_sweep.sh` (compileall, pyflakes, delimiter check, CRLF check, markdownlint, yamllint, actionlint, ASCII sweep, PowerShell AST parse sweep, full pytest suite) -- all green, 528 passed / 3 skipped
- [x] `python tools/check_ndjson_registry.py` -- PASS, no doc/code registry mismatches
- [x] Confirmed via grep that only `tests/selfapps_entrysmoke_no_interpreter.ps1` references the two message strings this change affects; `tests/selfapps_cascade_conda_create_fail.ps1` is structurally unaffected (its scenarios always branch away via the pre-existing cascade-re-entry check before reaching the modified line)
- [ ] Full CI matrix (gated `real`/`conda-full` lanes especially) -- pending this PR's own run

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017SQ1rvJxDbE71pTXJ4QvLV


---
_Generated by [Claude Code](https://claude.ai/code/session_017SQ1rvJxDbE71pTXJ4QvLV)_