### PR TITLE
Item 47: PowerShell capability preflight beyond bare presence

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1006,25 +1006,6 @@ way (no live Windows execution available here), that is noted explicitly rather 
   elsewhere in this backlog -- one incremental slice at a time (slice 1 above is the second proof
   this works, after Bucket B), not a single sweeping change across every remaining site.
 
-- **Item 47: no PowerShell capability preflight beyond bare presence.** The new line-ending
-  self-check (Item 44's mitigation) added a `where powershell` presence guard as its own
-  precondition, but that only proves PowerShell exists on PATH, not that it can actually do the
-  things this bootstrapper needs -- `:emit_from_base64` (used to write every embedded `~*.py`/
-  `~*.ps1` helper to disk) needs `[Convert]::FromBase64String` + `[IO.File]::WriteAllBytes`, and
-  `~failfast_probe.ps1`/`~exe_smokerun.ps1` need `New-Object System.Diagnostics.ProcessStartInfo`
-  -- all of which a locked-down corporate image (AppLocker/WDAC/Constrained Language Mode) can
-  block even with PowerShell itself present and on PATH. This was the leading hypothesis in the
-  sandbox debugging session before the real root cause (Item 44) was confirmed; ruled out for THAT
-  specific sandbox (confirmed `FullLanguage`, `EMIT OK`, `PSI OK` via direct probing) but not a
-  dead concern in general -- a genuinely CLM-restricted machine would still hit this today with no
-  clear diagnostic, just the same opaque "Could not write ~x" pattern the sandbox session initially
-  (incorrectly, for that session) suspected.
-
-  **Fix**: run the FromBase64String + WriteAllBytes + `New-Object ProcessStartInfo` triple once,
-  early (after Item 44's line-ending check, before `:define_helper_payloads`), and fail with a
-  plain-language message naming Constrained Language Mode specifically if it fails, rather than
-  letting the failure surface piecemeal as five-plus separate "Could not write ~x" messages later.
-
 - **Item 59: CodeRabbit's automated review did not run on PR #435, and should be manually
   triggered on every future PR -- owner-requested standing process fix, not a code change.**
   This repo (fewer than 10 stars, Organization UI config) requires a manual trigger for

--- a/docs/agent-closed-backlog.md
+++ b/docs/agent-closed-backlog.md
@@ -2562,6 +2562,55 @@ run of the same regex logic before landing, not just reasoned about).
   commit and had to be found and fixed in two SEPARATE rounds, each confirmed only by live Windows
   CI evidence pulled from a downloaded diagnostics artifact -- local tooling caught neither one.
 
+### Item 47 (closed 2026-08-18)
+
+- **No PowerShell capability preflight beyond bare presence.** The line-ending self-check (Item
+  44's mitigation) added a `where powershell` presence guard as its own precondition, but that
+  only proves PowerShell exists on PATH, not that it can actually do what this bootstrapper
+  needs -- `:emit_from_base64` (used to write every embedded `~*.py`/`~*.ps1` helper to disk)
+  needs `[Convert]::FromBase64String` + `[IO.File]::WriteAllBytes`, and
+  `~failfast_probe.ps1`/`~exe_smokerun.ps1` need `New-Object System.Diagnostics.ProcessStartInfo`
+  -- all of which a locked-down corporate image (AppLocker/WDAC/Constrained Language Mode) can
+  block even with PowerShell itself present and on PATH. This was the leading hypothesis in the
+  original Item 44 sandbox debugging session before the real root cause was confirmed there
+  (ruled out for that specific sandbox via direct probing) but was flagged as not a dead concern
+  in general, since a genuinely CLM-restricted machine would still hit it with no clear
+  diagnostic today.
+
+  **Fix shipped**: a new preflight block in `run_setup.bat`, placed right after the CWD-writable
+  check (Item 48) -- deliberately AFTER it, not before, so a real folder-permission failure is
+  diagnosed by that check first rather than misattributed to this one -- probes all three
+  capabilities in one PowerShell command: decode a small base64 literal via
+  `[Convert]::FromBase64String`, write the decoded bytes to a probe file via
+  `[IO.File]::WriteAllBytes`, verify the file exists, delete it, then construct (not launch) a
+  `System.Diagnostics.ProcessStartInfo`. Any exception anywhere in that sequence is caught and
+  exits 1; the caller's `if errorlevel 1` branch then fails with one clear, named diagnostic
+  naming Constrained Language Mode/AppLocker/WDAC specifically, instead of letting the failure
+  surface piecemeal as five-plus separate opaque "Could not write ~x" messages later in the run.
+  Mirrors the line-ending check's own established `$env:VARNAME` indirection (never `%VAR%`
+  substituted directly into the PowerShell `-Command` text) to avoid the whole class of
+  cmd.exe/-Command interaction hazard documented in `docs/agent-lessons-learned.md`'s `:log`
+  entry -- the probe's target file path is passed via `set "HP_PS_PROBE_FILE=..."` (a plain
+  cmd.exe environment variable, inherited by the spawned `powershell.exe` child) and read inside
+  the PowerShell command as `$env:HP_PS_PROBE_FILE`, never interpolated as literal text.
+
+  **Test hook**: `HP_TEST_FORCE_PS_CAPABILITY_FAIL` redirects the probe's write target at a
+  nonexistent directory (`~nonexistent_dir_xyz\`) so the real `WriteAllBytes` call genuinely
+  throws and hits its own `catch{exit 1}` branch -- the same "exercise the real failure path
+  instead of faking an exit code externally" technique `HP_TEST_FORCE_PS_CHECK_FAIL` already
+  established for the line-ending check's own PowerShell-throws branch, rather than a purely
+  synthetic bypass. Both the success and forced-failure paths were verified directly against a
+  real PowerShell binary before being wired into `run_setup.bat`, not just reasoned about.
+
+  **Regression coverage**: `tests/selfapps_lineending_check.ps1` gained a fifth
+  `Test-PreflightScenario` call, `self.preflight.ps_capability_fail`, reusing the same
+  scratch-copy-of-run_setup.bat/env-flag/exit-code/status-json/log-substring assertion shape as
+  the file's other four scenarios. `real`/`conda-full` lanes, gating from first landing -- same
+  reasoning as `self.preflight.cwd_not_writable`'s own precedent (a cheap, provider-agnostic,
+  pure-batch preflight check with no environment/dependency work reached in any scenario, unlike
+  the Nuitka/MSVC-dependent tests elsewhere in this registry that start non-gating because they
+  could not be verified locally).
+
 ## Known Findings (diagnosed, no action warranted)
 
 - **Backlog item numbering: renumber-on-collision convention dropped, 2026-07-31 owner decision.**

--- a/docs/agent-closed-backlog.md
+++ b/docs/agent-closed-backlog.md
@@ -2611,6 +2611,34 @@ run of the same regex logic before landing, not just reasoned about).
   the Nuitka/MSVC-dependent tests elsewhere in this registry that start non-gating because they
   could not be verified locally).
 
+  **Two real bugs found via CodeRabbit's review on PR #446, both fixed in the same PR, both
+  reproduced directly (not just reasoned about) before and after the fix.** (1) The probe's
+  fixed filename (`~ps_capability_probe.tmp`) had no protection against two genuinely concurrent
+  `run_setup.bat` instances in the same folder -- this preflight runs BEFORE `:acquire_lock`
+  (REQ-024's own concurrent-instance lock, acquired much later in the file), so a second process
+  could delete or overwrite the first's probe file mid-check and produce a false capability
+  failure. Fixed by suffixing the filename with two `%RANDOM%` draws
+  (`~ps_capability_probe.%RANDOM%%RANDOM%.tmp`, computed once into `HP_PS_PROBE_NAME` before the
+  `HP_TEST_FORCE_PS_CAPABILITY_FAIL` override, so both the real and forced-failure paths share the
+  same unique suffix) -- not a full mutex, just enough entropy that a same-folder collision within
+  one preflight's brief lifetime is negligible. (2) The original PowerShell command used
+  `Test-Path`/`Remove-Item` against the probe path -- both cmdlets treat `[`/`]` as wildcard
+  syntax by default, so an app folder whose path happens to contain literal brackets (e.g. a
+  folder named `Test[1]`) made `Test-Path` report a genuinely-written file as NOT FOUND,
+  misclassifying a perfectly capable PowerShell as CLM-restricted. Reproduced directly via a real
+  `pwsh` run against a `Test[1]` directory before fixing: `[IO.File]::WriteAllBytes` wrote the
+  file successfully, but `Test-Path` on the same literal path returned `$false` while
+  `Test-Path -LiteralPath` correctly returned `$true`. Fixed by switching the whole probe to
+  `[IO.File]::Exists`/`[IO.File]::Delete` instead of `Test-Path`/`Remove-Item -LiteralPath` --
+  these two .NET methods never glob-expand at all (not even an opt-in wildcard mode to avoid),
+  consistent with the probe's existing `[IO.File]::WriteAllBytes` call, so the app folder's own
+  path can contain any legal Windows filename character without affecting the probe's outcome.
+  Also added the same file-or-directory stale-artifact pre-clear `~wtest.tmp` already uses
+  (`del /f /q` then `if exist ( rd /s /q )`) at all three cleanup sites (pre-probe, on-failure,
+  on-success), defense-in-depth against a leftover directory at the probe's path even though the
+  new per-process uniqueness makes a genuine collision with an earlier run's leftover file
+  extremely unlikely on its own.
+
 ## Known Findings (diagnosed, no action warranted)
 
 - **Backlog item numbering: renumber-on-collision convention dropped, 2026-07-31 owner decision.**

--- a/docs/agent-ndjson.md
+++ b/docs/agent-ndjson.md
@@ -55,7 +55,7 @@ self.collect.submodules,
 self.exe.hidden_import, self.exe.hidden_import.exhaust,
 self.preflight.syntax,
 self.preflight.no_powershell, self.preflight.ps_check_fail, self.preflight.lf_only,
-self.preflight.cwd_not_writable,
+self.preflight.cwd_not_writable, self.preflight.ps_capability_fail,
 self.entrysmoke.no_interpreter_guard,
 self.cascade.detect, self.cascade.consent, self.cascade.timed,
 self.cascade.exec (uv lane only -- selfapps_cascade.ps1; non-gating),
@@ -952,9 +952,26 @@ same `Test-PreflightScenario` helper. Its hook, `HP_TEST_FORCE_CWD_NOT_WRITABLE`
 `type nul > ~wtest.tmp` write attempt entirely (rather than revoking filesystem permissions on a
 shared CI runner), producing the same "not found" signal a genuine write failure would.
 
+**Extended again for CLAUDE.md Active Backlog Item 47 (`self.preflight.ps_capability_fail`).**
+Bare PowerShell presence (checked by `self.preflight.no_powershell` above) only proves
+`powershell.exe` exists on PATH, not that it can perform the operations this bootstrapper
+actually needs -- `Convert.FromBase64String` plus `IO.File.WriteAllBytes` (used by
+`:emit_from_base64` to write every embedded helper) and `System.Diagnostics.ProcessStartInfo`
+(used by the failfast-probe/exe-smokerun helpers), any of which a locked-down corporate image
+(AppLocker, WDAC, Constrained Language Mode) can block even with PowerShell itself present. The
+new preflight, sitting right after the CWD-writable check so a real folder-permission failure is
+diagnosed by that check first rather than misattributed to this one, probes all three
+capabilities together in one PowerShell command and fails with one clear, named diagnostic
+instead of five-plus later opaque "Could not write ~x" failures. Its hook,
+`HP_TEST_FORCE_PS_CAPABILITY_FAIL`, redirects the probe's write target at a nonexistent directory
+so the real `WriteAllBytes` call genuinely throws and hits its own `catch{exit 1}` branch --
+matching `HP_TEST_FORCE_PS_CHECK_FAIL`'s established real-failure technique rather than faking an
+exit code externally. Verified directly against a real PowerShell binary before being wired into
+`run_setup.bat`, not just reasoned about.
+
 ```
 self.preflight.no_powershell, self.preflight.ps_check_fail, self.preflight.lf_only,
-self.preflight.cwd_not_writable
+self.preflight.cwd_not_writable, self.preflight.ps_capability_fail
 ```
 
 ---

--- a/run_setup.bat
+++ b/run_setup.bat
@@ -213,16 +213,29 @@ rem failfast-probe/exe-smokerun helpers need System.Diagnostics.ProcessStartInfo
 rem which a locked-down corporate image, such as AppLocker, WDAC, or Constrained Language
 rem Mode, can block even with PowerShell itself present. Probing all three together here turns
 rem five-plus later opaque "Could not write ~x" failures into one clear, named diagnostic.
-set "HP_PS_PROBE_FILE=%~dp0~ps_capability_probe.tmp"
+rem derived requirement: %RANDOM% suffix (two draws) makes the probe path unique per process --
+rem this preflight runs before :acquire_lock below, so two genuinely concurrent instances in the
+rem same folder must not be able to race on (delete/overwrite) each other's probe file and
+rem misreport a capability failure that isn't real. Not a full mutex, just enough entropy that a
+rem same-folder collision within one preflight's brief lifetime is negligible.
+set "HP_PS_PROBE_NAME=~ps_capability_probe.%RANDOM%%RANDOM%.tmp"
+set "HP_PS_PROBE_FILE=%~dp0%HP_PS_PROBE_NAME%"
 if defined HP_TEST_FORCE_PS_CAPABILITY_FAIL (
   rem derived requirement: point the probe at a nonexistent directory so the real
   rem WriteAllBytes call genuinely throws and hits its own catch branch -- exercises the
   rem real failure path instead of faking an exit code externally, matching
   rem HP_TEST_FORCE_PS_CHECK_FAIL's established technique above.
-  set "HP_PS_PROBE_FILE=%~dp0~nonexistent_dir_xyz\~ps_capability_probe.tmp"
+  set "HP_PS_PROBE_FILE=%~dp0~nonexistent_dir_xyz\%HP_PS_PROBE_NAME%"
 )
 del /f /q "%HP_PS_PROBE_FILE%" >nul 2>&1
-powershell -NoProfile -Command "try{$b=[Convert]::FromBase64String('cHZ3');[IO.File]::WriteAllBytes($env:HP_PS_PROBE_FILE,$b);if(-not (Test-Path $env:HP_PS_PROBE_FILE)){exit 1};Remove-Item $env:HP_PS_PROBE_FILE -Force;$psi=New-Object System.Diagnostics.ProcessStartInfo;exit 0}catch{exit 1}" >nul 2>&1
+if exist "%HP_PS_PROBE_FILE%" rd /s /q "%HP_PS_PROBE_FILE%" >nul 2>&1
+rem derived requirement: [IO.File]::Exists/Delete, not Test-Path/Remove-Item -- the latter two
+rem PowerShell cmdlets treat "[" and "]" in a path as wildcard syntax by default, so a folder
+rem name containing literal brackets could make Test-Path report a genuinely-written file as
+rem missing, misreporting a capability failure that isn't real. The .NET IO.File methods used
+rem here never glob-expand, so the app folder's own path can contain any legal Windows filename
+rem character without affecting this probe's outcome.
+powershell -NoProfile -Command "try{$b=[Convert]::FromBase64String('cHZ3');[IO.File]::WriteAllBytes($env:HP_PS_PROBE_FILE,$b);if(-not [IO.File]::Exists($env:HP_PS_PROBE_FILE)){exit 1};[IO.File]::Delete($env:HP_PS_PROBE_FILE);$psi=New-Object System.Diagnostics.ProcessStartInfo;exit 0}catch{exit 1}" >nul 2>&1
 if errorlevel 1 (
   echo ***
   echo *** [ERROR] PowerShell on this machine cannot perform an operation this
@@ -234,10 +247,12 @@ if errorlevel 1 (
   echo ***
   echo {"state":"error","exitCode":1,"pyFiles":0}> "%HP_PREFLIGHT_STATUS%"
   del /f /q "%HP_PS_PROBE_FILE%" >nul 2>&1
+  if exist "%HP_PS_PROBE_FILE%" rd /s /q "%HP_PS_PROBE_FILE%" >nul 2>&1
   if not defined HP_CI_LANE ( pause )
   exit /b 1
 )
 del /f /q "%HP_PS_PROBE_FILE%" >nul 2>&1
+if exist "%HP_PS_PROBE_FILE%" rd /s /q "%HP_PS_PROBE_FILE%" >nul 2>&1
 set "HP_SCRIPT_ROOT=%~dp0"
 for %%R in ("%HP_SCRIPT_ROOT%") do set "HP_SCRIPT_ROOT=%%~fR"
 if not "%HP_SCRIPT_ROOT:~-1%"=="\" set "HP_SCRIPT_ROOT=%HP_SCRIPT_ROOT%\"

--- a/run_setup.bat
+++ b/run_setup.bat
@@ -203,6 +203,41 @@ if not exist "~wtest.tmp" (
   exit /b 1
 )
 del /f /q "~wtest.tmp" >nul 2>&1
+rem derived requirement: PowerShell capability preflight (CLAUDE.md Item 47) -- placed after
+rem the CWD-writable check above so a real folder-permission failure is diagnosed by that
+rem check first, not misattributed to this one. Bare PowerShell presence, checked earlier in
+rem the line-ending self-check, only proves powershell.exe exists on PATH, not that it can do
+rem what this bootstrapper actually needs: :emit_from_base64, used to write every embedded
+rem ~*.py/~*.ps1 helper, needs Convert.FromBase64String plus IO.File.WriteAllBytes, and the
+rem failfast-probe/exe-smokerun helpers need System.Diagnostics.ProcessStartInfo -- all of
+rem which a locked-down corporate image, such as AppLocker, WDAC, or Constrained Language
+rem Mode, can block even with PowerShell itself present. Probing all three together here turns
+rem five-plus later opaque "Could not write ~x" failures into one clear, named diagnostic.
+set "HP_PS_PROBE_FILE=%~dp0~ps_capability_probe.tmp"
+if defined HP_TEST_FORCE_PS_CAPABILITY_FAIL (
+  rem derived requirement: point the probe at a nonexistent directory so the real
+  rem WriteAllBytes call genuinely throws and hits its own catch branch -- exercises the
+  rem real failure path instead of faking an exit code externally, matching
+  rem HP_TEST_FORCE_PS_CHECK_FAIL's established technique above.
+  set "HP_PS_PROBE_FILE=%~dp0~nonexistent_dir_xyz\~ps_capability_probe.tmp"
+)
+del /f /q "%HP_PS_PROBE_FILE%" >nul 2>&1
+powershell -NoProfile -Command "try{$b=[Convert]::FromBase64String('cHZ3');[IO.File]::WriteAllBytes($env:HP_PS_PROBE_FILE,$b);if(-not (Test-Path $env:HP_PS_PROBE_FILE)){exit 1};Remove-Item $env:HP_PS_PROBE_FILE -Force;$psi=New-Object System.Diagnostics.ProcessStartInfo;exit 0}catch{exit 1}" >nul 2>&1
+if errorlevel 1 (
+  echo ***
+  echo *** [ERROR] PowerShell on this machine cannot perform an operation this
+  echo *** script needs -- decoding embedded data, writing files, or preparing
+  echo *** to launch a process. This is usually caused by a restrictive policy
+  echo *** such as Constrained Language Mode, AppLocker, or WDAC on a managed
+  echo *** or corporate machine. Ask an administrator to allow PowerShell Full
+  echo *** Language Mode for this script, or run it on an unrestricted machine.
+  echo ***
+  echo {"state":"error","exitCode":1,"pyFiles":0}> "%HP_PREFLIGHT_STATUS%"
+  del /f /q "%HP_PS_PROBE_FILE%" >nul 2>&1
+  if not defined HP_CI_LANE ( pause )
+  exit /b 1
+)
+del /f /q "%HP_PS_PROBE_FILE%" >nul 2>&1
 set "HP_SCRIPT_ROOT=%~dp0"
 for %%R in ("%HP_SCRIPT_ROOT%") do set "HP_SCRIPT_ROOT=%%~fR"
 if not "%HP_SCRIPT_ROOT:~-1%"=="\" set "HP_SCRIPT_ROOT=%HP_SCRIPT_ROOT%\"

--- a/tests/selfapps_lineending_check.ps1
+++ b/tests/selfapps_lineending_check.ps1
@@ -22,9 +22,18 @@
 # HP_TEST_FORCE_CWD_NOT_WRITABLE, skips the real `type nul > ~wtest.tmp` write attempt
 # entirely rather than revoking filesystem permissions on a shared CI runner.
 #
+# Extended again for CLAUDE.md Active Backlog Item 47: the PowerShell capability preflight
+# (right after the CWD-writable check above) proves PowerShell can actually decode embedded
+# data, write files, and prepare to launch a process -- not just that powershell.exe exists on
+# PATH (already covered by self.preflight.no_powershell above). Its own hook,
+# HP_TEST_FORCE_PS_CAPABILITY_FAIL, redirects the probe's write target at a nonexistent
+# directory so the real WriteAllBytes call genuinely throws, matching
+# HP_TEST_FORCE_PS_CHECK_FAIL's established real-failure technique rather than faking an exit
+# code externally.
+#
 # Lane: real and conda-full only (matches self.preflight.syntax's own precedent for a cheap,
 # provider-agnostic, pure-batch preflight check -- no environment/dependency work is ever
-# reached in any of these four scenarios, so there is no "could not verify locally" risk
+# reached in any of these five scenarios, so there is no "could not verify locally" risk
 # comparable to a real Nuitka/MSVC build; the command logic itself was verified directly
 # against a real PowerShell 7 binary before this file was written).
 param()
@@ -54,6 +63,7 @@ $rowIdReqs = [ordered]@{
     'self.preflight.ps_check_fail'   = 'CLAUDE.md-Item-44'
     'self.preflight.lf_only'         = 'CLAUDE.md-Item-44'
     'self.preflight.cwd_not_writable' = 'CLAUDE.md-Item-48'
+    'self.preflight.ps_capability_fail' = 'CLAUDE.md-Item-47'
 }
 
 # Non-Windows skip
@@ -209,6 +219,13 @@ $results += Test-PreflightScenario -Id 'self.preflight.cwd_not_writable' `
     -ExpectedExit 1 `
     -ExpectedSubstrings @('[ERROR] This folder does not appear to be writable:', '~selftest_lineending_cwd_not_writable', 'Move this script and your .py files to') `
     -Req 'CLAUDE.md-Item-48'
+
+$results += Test-PreflightScenario -Id 'self.preflight.ps_capability_fail' `
+    -WorkDirName '~selftest_lineending_ps_capability_fail' `
+    -EnvFlagName 'HP_TEST_FORCE_PS_CAPABILITY_FAIL' `
+    -ExpectedExit 1 `
+    -ExpectedSubstrings @('[ERROR] PowerShell on this machine cannot perform an operation this', 'Constrained Language Mode') `
+    -Req 'CLAUDE.md-Item-47'
 
 if ($results -contains $false) { exit 1 }
 exit 0


### PR DESCRIPTION
## Summary

- The line-ending self-check (Item 44's mitigation) added a `where powershell` presence guard,
  but that only proves `powershell.exe` exists on PATH -- not that it can actually do what this
  bootstrapper needs. `:emit_from_base64` (used to write every embedded `~*.py`/`~*.ps1` helper
  to disk) needs `[Convert]::FromBase64String` + `[IO.File]::WriteAllBytes`, and
  `~failfast_probe.ps1`/`~exe_smokerun.ps1` need `New-Object System.Diagnostics.ProcessStartInfo`
  -- all of which a locked-down corporate image (AppLocker/WDAC/Constrained Language Mode) can
  block even with PowerShell itself present and on PATH.
- New preflight block in `run_setup.bat`, placed right after the CWD-writable check (Item 48) --
  deliberately after it, not before, so a real folder-permission failure is diagnosed by that
  check first rather than misattributed to this one. Probes all three capabilities together in
  one PowerShell command (decode a small base64 literal, write the bytes to a probe file, verify
  and delete it, then construct a `ProcessStartInfo`). Any exception anywhere in that sequence
  fails with one clear, named diagnostic naming Constrained Language Mode/AppLocker/WDAC
  specifically, instead of letting the failure surface piecemeal as several later opaque
  "Could not write ~x" messages.
- Uses the same `$env:VARNAME` indirection the line-ending check already established (never
  `%VAR%` substituted directly into the PowerShell `-Command` text), avoiding the cmd.exe/
  `-Command` interaction hazard documented in `docs/agent-lessons-learned.md`.

## Test plan

- [x] New `HP_TEST_FORCE_PS_CAPABILITY_FAIL` hook redirects the probe's write target at a
      nonexistent directory so the real `WriteAllBytes` call genuinely throws and hits its own
      `catch{exit 1}` branch -- same "exercise the real failure path" technique
      `HP_TEST_FORCE_PS_CHECK_FAIL` already established, not a faked exit code.
- [x] New `tests/selfapps_lineending_check.ps1` scenario, `self.preflight.ps_capability_fail`,
      reusing the file's existing `Test-PreflightScenario` helper -- wired into `real`/
      `conda-full` lanes, gating from first landing (same reasoning as
      `self.preflight.cwd_not_writable`'s own precedent: cheap, provider-agnostic, no
      environment/dependency work reached).
- [x] Both the success and forced-failure paths of the new PowerShell command verified directly
      against a real PowerShell binary before being wired into `run_setup.bat`.
- [x] `docs/agent-ndjson.md` and `docs/agent-closed-backlog.md` updated with the new row and a
      full Item 47 closure entry; removed from CLAUDE.md's Active Backlog.
- [x] `python tools/check_delimiters.py run_setup.bat` -- clean (no literal parens introduced in
      any echo/rem text, per the lessons from Item 52's own PR).
- [x] Full local sanity sweep (`tools/run_sanity_sweep.sh`): compileall, pyflakes, delimiter
      check, CRLF check, markdownlint, yamllint, actionlint, ASCII sweep, PowerShell AST parse
      sweep, and the full pytest suite (530 passed, 3 skipped) -- all green.
- [x] `python tools/check_ndjson_registry.py` -- PASS, no doc/code registry mismatches.
- [ ] Full CI matrix (`real`/`conda-full` gating lanes) to confirm on real Windows runners.

Co-Authored-By: Claude Sonnet 5

https://claude.ai/code/session_017SQ1rvJxDbE71pTXJ4QvLV

---
_Generated by [Claude Code](https://claude.ai/code/session_017SQ1rvJxDbE71pTXJ4QvLV)_