### PR TITLE
Item 36: fix warnfix repair-install silent no-op under venv/embed

### DIFF
--- a/.github/workflows/batch-check.yml
+++ b/.github/workflows/batch-check.yml
@@ -1817,6 +1817,14 @@ jobs:
             tests\~selftest_warnfix_real_warnfix_delayed\dist\~warnfix_exe.log
             tests/~selftest_warnfix_real_warnfix_delayed/~warnfile.txt
             tests\~selftest_warnfix_real_warnfix_delayed\~warnfile.txt
+            tests/~selftest_warnfix_venv_repair/~warnfix_venv_repair_bootstrap.log
+            tests\~selftest_warnfix_venv_repair\~warnfix_venv_repair_bootstrap.log
+            tests/~selftest_warnfix_venv_repair/~setup.log
+            tests\~selftest_warnfix_venv_repair\~setup.log
+            tests/~selftest_warnfix_venv_repair/dist/~warnfix_venv_repair_exe.log
+            tests\~selftest_warnfix_venv_repair\dist\~warnfix_venv_repair_exe.log
+            tests/~selftest_warnfix_venv_repair/dist/~warnfix_venv_token.txt
+            tests\~selftest_warnfix_venv_repair\dist\~warnfix_venv_token.txt
             tests/~selftest_collect/~collect_bootstrap.log
             tests\~selftest_collect\~collect_bootstrap.log
             tests/~selftest_collect/~setup.log

--- a/.github/workflows/batch-check.yml
+++ b/.github/workflows/batch-check.yml
@@ -600,6 +600,21 @@ jobs:
         run: |
           & tests\selfapps_warnfix.ps1
 
+      # CLAUDE.md Active Backlog Item 36: the warnfix repair-install dispatch previously had
+      # ONLY uv/conda branches, so it silently no-opped under venv/embed/system while still
+      # logging as if the repair succeeded. Now that venv/embed branches exist, this proves
+      # the venv branch genuinely installs the missing module, not just that the EXE builds.
+      # uv lane only (non-gating for first landing, matches this repo's established graduation
+      # pattern for a new PowerShell scenario not yet proven stable across several real runs) --
+      # forces venv mode via HP_OFFLINE_MODE=1 + HP_TEST_FORCE_CONDA_FAIL=1 in a fresh scratch
+      # dir (see selfapps_warnfix_venv_repair.ps1's own header comment for the mechanism).
+      - name: "Self-test: warnfix repair-install under venv mode (uv lane only)"
+        if: ${{ matrix.mode == 'uv' }}
+        continue-on-error: true
+        shell: pwsh
+        run: |
+          & tests\selfapps_warnfix_venv_repair.ps1
+
       # REQ-005.11: PEP 723 header write-back (uv add --script). v1-scoped to HP_ENV_MODE=uv,
       # so wired to the dedicated uv lane only (non-gating) for this first CI pass rather than
       # the gating real lane -- lets these brand-new scenarios prove out in real Windows CI

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -668,46 +668,6 @@ but several represent real gaps worth closing before calling the path fully rele
      self-healing) is relevant prior art specifically for the `cache` lane's own non-gating
      history.
 
-- **Item 36: warnfix repair install is a silent no-op under venv/embed/system, and reports false
-  success.** Confirmed via direct source read and matches an already-flagged-but-never-filed gap
-  in `docs/agent-interconnect.md` ("Standalone Python-download tier" section): *"the warnfix
-  REPAIR-install branch only has two cases -- `if "%HP_ENV_MODE%"=="uv"` and `else if defined
-  CONDA_BAT` -- with NO plain-pip fallback for any other mode... Worth a dedicated future fix...
-  its own backlog item."* That backlog item was never actually created until now -- a real defect
-  sat fully diagnosed and un-tracked for weeks.
-
-  **Mechanism**: the warnfix repair-install dispatch inside `:run_entry_smoke`'s
-  `HP_WARNFIX_NEEDED` block has exactly two branches and no catch-all. Under venv, embed, or
-  system mode, `HP_ENV_MODE` isn't `uv` and `CONDA_BAT` is undefined, so neither branch matches --
-  yet the loop still logs `[REPAIR] missing modules detected; installing and rebuilding.`,
-  installs nothing, rebuilds an unchanged EXE, and logs `[REPAIR] rebuild complete after
-  warnfix.` as if it worked. Worse: since no module install was even attempted,
-  `~warnfix_repair_failed.flag` is never created, so `:warnfix_cascade_detect`'s own recovery gate
-  (`if exist flag AND unresolved`) never fires either -- the ONE mechanism designed to recover
-  from exactly this situation (cascading to the next provider tier) is silently defeated by the
-  same gap.
-
-  **Realistic scenario**: a locked-down corporate machine reaches the embed tier (uv venv fails,
-  conda download fails, cascades to embed). The user's script needs `openpyxl` via
-  `pandas.read_excel` -- precisely the runtime-only import pipreqs can't see and warnfix exists to
-  catch. Warnfix "installs" nothing, claims success, the EXE builds, the smoke run fails with
-  `ModuleNotFoundError: openpyxl`, and the user sees "SETUP COMPLETE -- WITH A CAVEAT" with no hint
-  that a repair step silently did nothing.
-
-  **High-level fix**: add a plain-pip catch-all branch (`else ("%HP_PY%" -m pip install %%M)`) to
-  the repair-install dispatch, mirroring the SAME three-mode pip pathway (`venv`/`embed`/`system`
-  all already use `"%HP_PY%" -m pip install -r requirements.txt` in the main, non-repair
-  dependency-install dispatch a few hundred lines earlier) -- both venv and embed have a working
-  pip already; this is not a new capability, just wiring an existing one into a second call site
-  that was missed. Also verify `~warnfix_repair_failed.flag` is set correctly on a genuine failure
-  in this new branch, so the cascade-recovery gate becomes reachable for this failure class too.
-
-  **Coverage gap to close in the same slice**: all five `selfapps_warnfix.ps1` scenarios run on
-  `real`/`conda-full`, both of which land in the `uv` or `CONDA_BAT` branch -- the broken branch is
-  unreachable from every existing warnfix test. Add a scenario that forces venv or embed mode with
-  a warnfix-triggering missing import, asserting the module actually gets installed (not just that
-  the EXE eventually builds).
-
 - **Item 37: `:dll_bundle_recover`'s own regression coverage is entirely non-gating, on the
   newest code on the golden path.** Confirmed against `.github/workflows/batch-check.yml`,
   `tests/harness.ps1`, and `docs/agent-ndjson.md`. This is a specific, concrete instance of Item

--- a/docs/agent-closed-backlog.md
+++ b/docs/agent-closed-backlog.md
@@ -2716,9 +2716,13 @@ run of the same regex logic before landing, not just reasoned about).
   `"%HP_PY%" -m pip install %%M` per missing module, mirroring the SAME three-mode pip pathway
   `venv`/`embed`/`system` already use in the main, non-repair dependency-install dispatch a few
   hundred lines earlier) plus a final `system`-mode catch-all that deliberately stays a no-op
-  (system is a shared, uncontrolled interpreter; REQ-009 avoids installing into it) but now logs
-  `[WARN] System fallback: skipping warnfix repair installation.` instead of silently claiming
-  success. Both new branches set `~warnfix_repair_failed.flag` on a genuine per-module install
+  (system is a shared, uncontrolled interpreter; REQ-009 avoids installing into it) but now ALSO
+  logs `[WARN] System fallback: skipping warnfix repair installation.` -- in addition to, not
+  instead of, the surrounding `[REPAIR] missing modules detected; installing and rebuilding.` /
+  `[REPAIR] rebuild complete after warnfix.` markers, which still fire unconditionally regardless
+  of mode (the rebuild always runs after the install dispatch, whether or not anything was
+  actually installed); the new line stops the install step itself from being silent about doing
+  nothing. Both new branches set `~warnfix_repair_failed.flag` on a genuine per-module install
   failure, identical to the pre-existing uv/conda branches, so the cascade-recovery gate is
   reachable for this failure class too. Verified via `tools/check_delimiters.py run_setup.bat`
   (count unchanged at the pre-existing 26-finding baseline -- see CLAUDE.md Item 61's own follow-up

--- a/docs/agent-closed-backlog.md
+++ b/docs/agent-closed-backlog.md
@@ -2684,6 +2684,72 @@ run of the same regex logic before landing, not just reasoned about).
   `HP_SMOKERUN_KILL_MS` against a real PyInstaller-frozen EXE's own cold-start behavior for the
   first time, which could not be verified against real Windows locally.
 
+### Item 36 (closed 2026-08-22)
+
+- **Warnfix repair install was a silent no-op under venv/embed/system, and reported false
+  success.** Confirmed via direct source read and matched an already-flagged-but-never-filed gap
+  in `docs/agent-interconnect.md` ("Standalone Python-download tier" section): *"the warnfix
+  REPAIR-install branch only has two cases -- `if "%HP_ENV_MODE%"=="uv"` and `else if defined
+  CONDA_BAT` -- with NO plain-pip fallback for any other mode... Worth a dedicated future fix...
+  its own backlog item."* That backlog item sat fully diagnosed and un-tracked for weeks before
+  finally being filed and closed in the same pass.
+
+  **Mechanism**: the warnfix repair-install dispatch inside `:run_entry_smoke`'s
+  `HP_WARNFIX_NEEDED` block had exactly two branches and no catch-all. Under venv, embed, or
+  system mode, `HP_ENV_MODE` isn't `uv` and `CONDA_BAT` is undefined, so neither branch matched --
+  yet the loop still logged `[REPAIR] missing modules detected; installing and rebuilding.`,
+  installed nothing, rebuilt an unchanged EXE, and logged `[REPAIR] rebuild complete after
+  warnfix.` as if it worked. Worse: since no module install was even attempted,
+  `~warnfix_repair_failed.flag` was never created, so `:warnfix_cascade_detect`'s own recovery gate
+  (`if exist flag AND unresolved`) never fired either -- the ONE mechanism designed to recover
+  from exactly this situation (cascading to the next provider tier) was silently defeated by the
+  same gap.
+
+  **Realistic scenario this closes**: a locked-down corporate machine reaches the embed tier (uv
+  venv fails, conda download fails, cascades to embed). The user's script needs `openpyxl` via
+  `pandas.read_excel` -- precisely the runtime-only import pipreqs can't see and warnfix exists to
+  catch. Before this fix, warnfix "installed" nothing, claimed success, the EXE built, the smoke
+  run failed with `ModuleNotFoundError: openpyxl`, and the user saw "SETUP COMPLETE -- WITH A
+  CAVEAT" with no hint that a repair step silently did nothing.
+
+  **Fix shipped**: added `venv` and `embed` branches to the repair-install dispatch (each a plain
+  `"%HP_PY%" -m pip install %%M` per missing module, mirroring the SAME three-mode pip pathway
+  `venv`/`embed`/`system` already use in the main, non-repair dependency-install dispatch a few
+  hundred lines earlier) plus a final `system`-mode catch-all that deliberately stays a no-op
+  (system is a shared, uncontrolled interpreter; REQ-009 avoids installing into it) but now logs
+  `[WARN] System fallback: skipping warnfix repair installation.` instead of silently claiming
+  success. Both new branches set `~warnfix_repair_failed.flag` on a genuine per-module install
+  failure, identical to the pre-existing uv/conda branches, so the cascade-recovery gate is
+  reachable for this failure class too. Verified via `tools/check_delimiters.py run_setup.bat`
+  (count unchanged at the pre-existing 26-finding baseline -- see CLAUDE.md Item 61's own follow-up
+  scope for that unrelated, already-tracked number) and `tools/check_crlf.py` (clean).
+
+  **Coverage gap closed in the same slice**: all five `selfapps_warnfix.ps1` scenarios run on
+  `real`/`conda-full`, both of which land in the `uv` or `CONDA_BAT` branch -- the broken branch
+  was unreachable from every existing warnfix test. New file `tests/selfapps_warnfix_venv_repair.ps1`
+  (`uv` lane, non-gating for its first landing, matching this repo's established graduation
+  pattern) forces venv mode via `HP_OFFLINE_MODE=1` + `HP_TEST_FORCE_CONDA_FAIL=1` in a fresh
+  scratch directory -- the same established technique `self.venv.fallback`
+  (`tests/selfapps_ux_hardening.ps1`) already uses, per `docs/agent-interconnect.md`'s "HP_UV_BIN
+  locality" section: a fresh directory has no cached `~uv_bin` so uv is unavailable,
+  `HP_OFFLINE_MODE` blocks a fresh uv download, and `HP_TEST_FORCE_CONDA_FAIL` forces conda to
+  fail too, so the provider chain falls through uv -> conda -> embed -> venv and lands on venv
+  (embed is not forced, so it's never reachable here). Uses the same `xlrd`-importing stub app as
+  `selfapps_warnfix.ps1`'s own `real_warnfix` scenario (xlrd is not covered by any heuristic, so
+  warnfix is the only repair path), with the same `HP_SKIP_PIPREQS=1` +
+  `HP_SKIP_AUTOPEP_DISCOVERY=1` isolation flags to keep warnfix the sole install mechanism.
+  Asserts the `[BOOT] REQ-009: Selected Python provider: Local venv (fallback).` line (proving
+  venv mode was genuinely selected, not conda/embed unexpectedly succeeding instead), both warnfix
+  phase-marker lines, and -- the actual Item 36 assertion -- `[INFO] Installed: xlrd` (the line
+  that was NEVER emitted under venv mode before this fix, even though the "rebuild complete" line
+  fired unconditionally regardless), plus the absence of `[WARN] Repair failed:` and a clean EXE
+  run with its token file written. Wired into `batch-check.yml` immediately after
+  `selfapps_warnfix.ps1`'s 5 existing scenario steps, with its own `continue-on-error: true` (per
+  this repo's own established rule: job-level `continue-on-error` alone does not protect sibling
+  steps in the same job from an earlier step's failure skipping everything after it -- confirmed
+  via a real CI run, see the PEP 723 write-back block's own header comment a few steps below this
+  one in `batch-check.yml`).
+
 ## Known Findings (diagnosed, no action warranted)
 
 - **Backlog item numbering: renumber-on-collision convention dropped, 2026-07-31 owner decision.**

--- a/docs/agent-interconnect.md
+++ b/docs/agent-interconnect.md
@@ -821,13 +821,25 @@ lines; `:conda_base_update`'s conda-only guard. Dep-check's fast-path gate (`if 
 still excludes embed too, matching venv's scope -- a design choice for MVP parity, not an
 oversight; could extend to embed later if desired.
 
-**Pre-existing gap found during this audit, unrelated to embed, flagged not fixed:** the warnfix
-REPAIR-install branch (~line 2661) only has two cases -- `if "%HP_ENV_MODE%"=="uv"` and
-`else if defined CONDA_BAT` -- with NO plain-pip fallback for any other mode. venv and system
-ALREADY had this blind spot (warnfix-detected missing modules under either mode match neither
-branch, so the repair loop is a no-op). Confirmed unchanged after shipping embed (this branch
-wasn't touched) -- embed inherits the identical gap. Worth a dedicated future fix (a plain
-`%HP_PY% -m pip install` catch-all covering venv/system/embed) -- its own backlog item.
+**Pre-existing gap found during this audit, unrelated to embed -- fixed (CLAUDE.md's former Item
+36, closed; see `docs/agent-closed-backlog.md`).** The warnfix REPAIR-install dispatch used to
+have only two cases -- `if "%HP_ENV_MODE%"=="uv"` and `else if defined CONDA_BAT` -- with NO
+plain-pip fallback for any other mode, so venv/embed/system all silently no-opped while still
+logging as if the repair succeeded. Now has explicit `venv` and `embed` branches (each a plain
+`"%HP_PY%" -m pip install %%M` per missing module, mirroring the three-mode pip pathway the MAIN,
+non-repair dependency-install dispatch already used) plus a `system`-mode catch-all that stays a
+no-op (system is a shared, uncontrolled interpreter; REQ-009 avoids installing into it) but now
+logs `[WARN] System fallback: skipping warnfix repair installation.` instead of the old, silently
+misleading "installing and rebuilding... rebuild complete" pair. `~warnfix_repair_failed.flag` is
+set correctly on a genuine failure in both new branches, so `:warnfix_cascade_detect`'s own
+recovery gate is reachable for this failure class too. Regression coverage:
+`tests/selfapps_warnfix_venv_repair.ps1` (new file, `uv` lane, non-gating) forces venv mode via
+the same `HP_OFFLINE_MODE=1` + `HP_TEST_FORCE_CONDA_FAIL=1` technique as `self.venv.fallback`
+(see "HP_UV_BIN locality" above) with an `xlrd`-importing stub app, and asserts the module is
+GENUINELY installed (`[INFO] Installed: xlrd`), not just that the EXE eventually builds -- the
+exact coverage gap the original finding called out (every existing warnfix scenario runs on
+`real`/`conda-full`, both of which land in the `uv` or `CONDA_BAT` branch, so the broken branch
+was unreachable from any prior test).
 
 ---
 

--- a/docs/agent-interconnect.md
+++ b/docs/agent-interconnect.md
@@ -829,8 +829,12 @@ logging as if the repair succeeded. Now has explicit `venv` and `embed` branches
 `"%HP_PY%" -m pip install %%M` per missing module, mirroring the three-mode pip pathway the MAIN,
 non-repair dependency-install dispatch already used) plus a `system`-mode catch-all that stays a
 no-op (system is a shared, uncontrolled interpreter; REQ-009 avoids installing into it) but now
-logs `[WARN] System fallback: skipping warnfix repair installation.` instead of the old, silently
-misleading "installing and rebuilding... rebuild complete" pair. `~warnfix_repair_failed.flag` is
+ALSO logs `[WARN] System fallback: skipping warnfix repair installation.` -- IN ADDITION TO, not
+instead of, the surrounding `[REPAIR] missing modules detected; installing and rebuilding.` /
+`[REPAIR] rebuild complete after warnfix.` markers, which still fire unconditionally regardless of
+mode (the rebuild always runs after the install dispatch, whether or not anything was actually
+installed) -- the new line clarifies that nothing was actually attempted under system mode, it
+does not suppress or replace those surrounding markers. `~warnfix_repair_failed.flag` is
 set correctly on a genuine failure in both new branches, so `:warnfix_cascade_detect`'s own
 recovery gate is reachable for this failure class too. Regression coverage:
 `tests/selfapps_warnfix_venv_repair.ps1` (new file, `uv` lane, non-gating) forces venv mode via

--- a/docs/agent-ndjson.md
+++ b/docs/agent-ndjson.md
@@ -929,6 +929,43 @@ gating maturity" periodic check).
 self.exe.timeout_gui_hint
 ```
 
+## selfapps-warnfix-venv-repair NDJSON rows (selfapps_warnfix_venv_repair.ps1, uv lane only, non-gating)
+
+CLAUDE.md's former Active Backlog Item 36 (closed, see `docs/agent-closed-backlog.md`): the
+warnfix repair-install dispatch used to have only `uv`/`CONDA_BAT` branches, silently no-opping
+under venv/embed/system while still logging as if the repair succeeded -- see
+`docs/agent-interconnect.md`'s "Standalone Python-download tier" section for the full mechanism
+and fix. This test proves the new `venv`-mode branch genuinely installs the missing module, not
+just that the EXE eventually builds -- the exact coverage gap the original finding called out
+(every existing `self.exe.warnfix.*` scenario runs on `real`/`conda-full`, both of which land in
+the `uv` or `CONDA_BAT` branch, so the broken branch was unreachable from any prior test).
+
+Forces venv mode via `HP_OFFLINE_MODE=1` + `HP_TEST_FORCE_CONDA_FAIL=1` in a fresh scratch
+directory -- the same established technique `self.venv.fallback` (`selfapps_ux_hardening.ps1`)
+already uses (see `docs/agent-interconnect.md`'s "HP_UV_BIN locality" section): a fresh directory
+has no cached `~uv_bin` so uv is unavailable, `HP_OFFLINE_MODE` blocks a fresh uv download, and
+`HP_TEST_FORCE_CONDA_FAIL` forces conda to fail too, so the provider chain falls through
+uv -> conda -> embed -> venv and lands on venv (embed is not forced real, so it's never reachable
+here). Uses the same `xlrd`-importing stub app as `selfapps_warnfix.ps1`'s own `real_warnfix`
+scenario (xlrd is not covered by any heuristic, so warnfix is the only repair path), with the
+same `HP_SKIP_PIPREQS=1` + `HP_SKIP_AUTOPEP_DISCOVERY=1` isolation flags to keep warnfix the sole
+install mechanism.
+
+Asserts: the `[BOOT] REQ-009: Selected Python provider: Local venv (fallback).` line (proving
+venv mode was genuinely selected, not conda/embed unexpectedly succeeding instead), both warnfix
+phase-marker lines (`[REPAIR] missing modules detected; installing and rebuilding.` /
+`[REPAIR] rebuild complete after warnfix.`), and -- the core Item 36 assertion -- `[INFO]
+Installed: xlrd` (the line that was NEVER emitted under venv mode before the fix, even though the
+rebuild-complete line fired unconditionally regardless), plus the absence of `[WARN] Repair
+failed:`, no infra-error signature, and a clean EXE run with its token file written. Skips with
+`skip=true` on non-Windows and in the conda-full lane (`HP_FORCE_CONDA_ONLY=1` blocks all
+non-conda fallbacks unconditionally there, matching `self.venv.fallback`'s own skip reasoning).
+Non-gating for its first landing, matching this repo's established graduation pattern.
+
+```
+self.exe.warnfix.venv_repair
+```
+
 ## selfapps-cache-selfheal NDJSON rows (test_ci_cache_selfheal.ps1, `real` lane only, GATING)
 
 Item 19 follow-on (docs/agent-closed-backlog.md): the cache-lane self-heal logic

--- a/run_setup.bat
+++ b/run_setup.bat
@@ -3841,7 +3841,14 @@ if not defined HP_BUILD_OK (
             call :log "[INFO] Installed: %%M"
           )
         )
-      ) else if defined CONDA_BAT (
+      ) else if "%HP_ENV_MODE%"=="conda" if defined CONDA_BAT (
+        rem derived requirement (CodeRabbit finding on Item 36's own PR): :select_conda_bat
+        rem sets CONDA_BAT purely from Miniconda binary presence on disk, never clears it once
+        rem set -- so a genuine venv/embed fallback (conda env CREATE failed, cascaded past conda)
+        rem can still leave CONDA_BAT defined if Miniconda itself was already on disk.
+        rem Gating on HP_ENV_MODE=="conda" too (not just "defined CONDA_BAT") stops that stale
+        rem definedness from routing a real venv/embed repair into a conda-install command
+        rem targeting an environment that was never created.
         for /f "usebackq delims=" %%M in ("~missing_modules.txt") do (
           call :log "[INFO] Attempting to install: %%M"
           call "%CONDA_BAT%" install -y -n "%ENVNAME%" --override-channels -c conda-forge %%M >> "%LOG%" 2>&1

--- a/run_setup.bat
+++ b/run_setup.bat
@@ -3852,6 +3852,39 @@ if not defined HP_BUILD_OK (
             call :log "[INFO] Installed: %%M"
           )
         )
+      ) else if "%HP_ENV_MODE%"=="venv" (
+        rem derived requirement (CLAUDE.md Item 36): the repair-install dispatch above only had
+        rem uv/conda branches, silently no-opping under venv/embed/system while still logging
+        rem "installing and rebuilding" and "rebuild complete" as if it worked -- both a private,
+        rem bootstrapper-owned interpreter -- venv/embed, same as the MAIN non-repair
+        rem dependency-install dispatch a few hundred lines above -- already have a working pip;
+        rem this just wires that existing capability into the second call site that was missed.
+        for /f "usebackq delims=" %%M in ("~missing_modules.txt") do (
+          call :log "[INFO] Attempting to install: %%M"
+          "%HP_PY%" -m pip install %%M >> "%LOG%" 2>&1
+          if errorlevel 1 (
+            call :log "[WARN] Repair failed: %%M"
+            copy nul "~warnfix_repair_failed.flag" >nul 2>&1
+          ) else (
+            call :log "[INFO] Installed: %%M"
+          )
+        )
+      ) else if "%HP_ENV_MODE%"=="embed" (
+        for /f "usebackq delims=" %%M in ("~missing_modules.txt") do (
+          call :log "[INFO] Attempting to install: %%M"
+          "%HP_PY%" -m pip install %%M >> "%LOG%" 2>&1
+          if errorlevel 1 (
+            call :log "[WARN] Repair failed: %%M"
+            copy nul "~warnfix_repair_failed.flag" >nul 2>&1
+          ) else (
+            call :log "[INFO] Installed: %%M"
+          )
+        )
+      ) else (
+        rem system mode deliberately stays a no-op here too, matching the MAIN dependency-install
+        rem dispatch's own "System fallback: skipping requirement installation." convention --
+        rem system is a shared, uncontrolled interpreter; REQ-009 avoids installing into it.
+        call :log "[WARN] System fallback: skipping warnfix repair installation."
       )
       if exist "~warnfix_repair_failed.flag" call :log "[WARN] One or more repair attempts failed"
       call :log "[INFO] Rebuilding standalone executable after warnfix -- this may take a minute or two..."

--- a/tests/selfapps_warnfix_venv_repair.ps1
+++ b/tests/selfapps_warnfix_venv_repair.ps1
@@ -1,0 +1,210 @@
+# ASCII only
+# selfapps_warnfix_venv_repair.ps1 - Regression test for CLAUDE.md Active Backlog Item 36:
+# the warnfix repair-install dispatch previously had ONLY uv/conda branches, so under
+# venv/embed/system it silently no-opped -- installed nothing -- while still logging
+# "[REPAIR] missing modules detected; installing and rebuilding." and "[REPAIR] rebuild
+# complete after warnfix." as if it had worked. run_setup.bat now has venv/embed branches
+# (plain "%HP_PY%" -m pip install %%M, mirroring the MAIN dependency-install dispatch's
+# own venv/embed pip pathway) plus a system-mode no-op with an honest log line. This test
+# forces venv mode specifically (embed is exercised only via a real python.org download,
+# too network-heavy for a dedicated regression test here) and asserts the missing module
+# is GENUINELY installed, not just that the EXE eventually builds.
+#
+# derived requirement: HP_OFFLINE_MODE=1 + HP_TEST_FORCE_CONDA_FAIL=1 in a FRESH scratch
+# directory is the established technique (see self.venv.fallback in
+# selfapps_ux_hardening.ps1, and docs/agent-interconnect.md's "HP_UV_BIN locality"
+# section) for deterministically forcing venv-mode fallback: a fresh directory has no
+# cached ~uv_bin so uv is unavailable, HP_OFFLINE_MODE blocks a fresh uv download, and
+# HP_TEST_FORCE_CONDA_FAIL forces conda to fail too -- the provider chain falls through
+# uv -> conda -> embed -> venv, and embed is a private, checksummed python.org download
+# this test does not force (HP_TEST_FORCE_EMBED_REAL is not set), so venv is the first
+# tier actually reachable.
+#
+# Lane: uv (non-gating for first landing -- matches this repo's established graduation
+# pattern for a new PowerShell scenario not yet proven stable across several real runs).
+# Skips in conda-full (HP_FORCE_CONDA_ONLY=1 blocks all non-conda fallbacks unconditionally).
+#
+# Emits: self.exe.warnfix.venv_repair
+param()
+$ErrorActionPreference = 'Continue'
+$here = $PSScriptRoot
+$repo = Split-Path -Path $here -Parent
+$nd   = Join-Path $here '~test-results.ndjson'
+$ciNd = Join-Path $repo 'ci_test_results.ndjson'
+if (-not (Test-Path $nd))   { New-Item -ItemType File -Path $nd   -Force | Out-Null }
+if (-not (Test-Path $ciNd)) { New-Item -ItemType File -Path $ciNd -Force | Out-Null }
+
+function Write-NdjsonRow {
+    param([hashtable]$Row)
+    $lane = [Environment]::GetEnvironmentVariable('HP_CI_LANE')
+    if ($lane -and -not $Row.ContainsKey('lane')) { $Row['lane'] = $lane }
+    $json = $Row | ConvertTo-Json -Compress -Depth 8
+    Add-Content -LiteralPath $nd   -Value $json -Encoding Ascii
+    Add-Content -LiteralPath $ciNd -Value $json -Encoding Ascii
+}
+
+$rowId = 'self.exe.warnfix.venv_repair'
+
+# Non-Windows skip
+if (-not $IsWindows) {
+    $platform = [System.Environment]::OSVersion.Platform.ToString()
+    Write-NdjsonRow ([ordered]@{
+        id      = $rowId
+        req     = 'REQ-007'
+        pass    = $true
+        desc    = 'Warnfix repair-install under venv mode genuinely installs the missing module (skipped on non-Windows)'
+        details = [ordered]@{ skip = $true; platform = $platform; reason = 'non-windows-host' }
+    })
+    exit 0
+}
+
+# conda-full lane skip: HP_FORCE_CONDA_ONLY=1 blocks embed/venv/system fallback
+# unconditionally, so venv mode is unreachable there regardless of what this test forces.
+if ($env:HP_FORCE_CONDA_ONLY -eq '1') {
+    Write-NdjsonRow ([ordered]@{
+        id      = $rowId
+        req     = 'REQ-007'
+        pass    = $true
+        desc    = 'Warnfix repair-install under venv mode genuinely installs the missing module (skipped: HP_FORCE_CONDA_ONLY blocks venv fallback)'
+        details = [ordered]@{ skip = $true; reason = 'HP_FORCE_CONDA_ONLY-prohibits-venv-fallback' }
+    })
+    exit 0
+}
+
+$batchPath = Join-Path $repo 'run_setup.bat'
+if (-not (Test-Path $batchPath)) {
+    Write-NdjsonRow ([ordered]@{
+        id      = $rowId
+        req     = 'REQ-007'
+        pass    = $false
+        desc    = 'Warnfix venv-repair: run_setup.bat not found'
+        details = [ordered]@{ error = 'run_setup.bat not found at ' + $batchPath }
+    })
+    exit 1
+}
+
+$workDir = Join-Path $here '~selftest_warnfix_venv_repair'
+if (Test-Path $workDir) { Remove-Item -Recurse -Force $workDir }
+New-Item -ItemType Directory -Force -Path $workDir | Out-Null
+Copy-Item -Path $batchPath -Destination $workDir -Force
+
+# derived requirement: xlrd is not covered by any heuristic (same choice as
+# selfapps_warnfix.ps1's own real_warnfix scenario) -- no requirements.txt is created,
+# so there is nothing for prep_requirements to pre-install. warnfix must fire to install
+# xlrd, and it must do so via the new venv-mode branch, not silently no-op.
+$appCode = @'
+import xlrd
+import os as _os
+import sys as _sys
+_ = xlrd.__version__
+assert callable(xlrd.open_workbook), 'xlrd.open_workbook not accessible'
+_here = _os.path.dirname(_os.path.abspath(_sys.argv[0]))
+with open(_os.path.join(_here, '~warnfix_venv_token.txt'), 'w') as _f:
+    _f.write('warnfix-venv-repair-ok\n')
+print('xlrd ok')
+'@
+Set-Content -Path (Join-Path $workDir 'app.py') -Value $appCode -Encoding ASCII
+
+$savedCondaFail = $env:HP_TEST_FORCE_CONDA_FAIL
+$savedOffline   = $env:HP_OFFLINE_MODE
+$savedSkipPR    = $env:HP_SKIP_PIPREQS
+$savedSkipAP    = $env:HP_SKIP_AUTOPEP_DISCOVERY
+$savedLane      = $env:HP_CI_LANE
+$env:HP_TEST_FORCE_CONDA_FAIL   = '1'
+$env:HP_OFFLINE_MODE            = '1'
+$env:HP_SKIP_PIPREQS            = '1'
+# derived requirement: HP_SKIP_AUTOPEP_DISCOVERY=1 for the same reason
+# selfapps_warnfix.ps1 sets it -- without it, REQ-005.12's autopep723-check discovery
+# (uv lane, default-on) would statically discover xlrd from the stub app's own import
+# and merge it into requirements.txt before warnfix ever gets a chance to fire, defeating
+# this test's whole "isolate the warnfix repair path" premise.
+$env:HP_SKIP_AUTOPEP_DISCOVERY  = '1'
+$env:HP_CI_LANE                 = 'test'
+
+$bootstrapLog = '~warnfix_venv_repair_bootstrap.log'
+Push-Location -LiteralPath $workDir
+try {
+    cmd /c "call run_setup.bat > $bootstrapLog 2>&1"
+    $runExit = $LASTEXITCODE
+} finally {
+    $env:HP_TEST_FORCE_CONDA_FAIL   = $savedCondaFail
+    $env:HP_OFFLINE_MODE            = $savedOffline
+    $env:HP_SKIP_PIPREQS            = $savedSkipPR
+    $env:HP_SKIP_AUTOPEP_DISCOVERY  = $savedSkipAP
+    $env:HP_CI_LANE                 = $savedLane
+    Pop-Location
+}
+
+$logPath   = Join-Path $workDir $bootstrapLog
+$setupLog  = Join-Path $workDir '~setup.log'
+$logLines  = if (Test-Path $logPath)  { Get-Content -LiteralPath $logPath  -Encoding ASCII } else { @() }
+$setupText = if (Test-Path $setupLog) { Get-Content -LiteralPath $setupLog -Raw -Encoding ASCII } else { '' }
+$combined  = ($logLines -join "`n") + "`n" + $setupText
+
+# derived requirement: confirm venv mode was GENUINELY selected -- without this, a false
+# pass could hide behind conda/embed unexpectedly succeeding instead (which would prove
+# nothing about the venv-specific branch this test exists to cover).
+$venvProviderLog = $combined -match [regex]::Escape('[BOOT] REQ-009: Selected Python provider: Local venv (fallback).')
+
+$warnInstallFired = $combined -match [regex]::Escape('[REPAIR] missing modules detected; installing and rebuilding.')
+$warnRebuildFired = $combined -match [regex]::Escape('[REPAIR] rebuild complete after warnfix.')
+# derived requirement: this is the actual Item 36 assertion -- "the module actually gets
+# installed (not just that the EXE eventually builds)". Before the fix, this line was NEVER
+# emitted under venv mode (the dispatch matched neither the uv nor the conda branch), even
+# though the rebuild-complete line above still fired unconditionally.
+$installedXlrd    = $combined -match [regex]::Escape('[INFO] Installed: xlrd')
+$repairFailed     = $combined -match [regex]::Escape('[WARN] Repair failed:')
+
+$envLeaf  = Split-Path $workDir -Leaf
+$envName  = ($envLeaf -replace '[^A-Za-z0-9_-]', '_')
+if (-not $envName) { $envName = '_warnfix_venv_repair' }
+$distDir  = Join-Path $workDir 'dist'
+$exePath  = Join-Path $distDir "$envName.exe"
+$exeExists = Test-Path -LiteralPath $exePath
+$exeExit   = -1
+$tokenPath = Join-Path $distDir '~warnfix_venv_token.txt'
+$tokenFound = $false
+
+if ($exeExists) {
+    try {
+        Push-Location -LiteralPath $distDir
+        try {
+            cmd /c "`"$exePath`"" *> '~warnfix_venv_repair_exe.log'
+            $exeExit = $LASTEXITCODE
+        } finally {
+            Pop-Location
+        }
+        $tokenFound = Test-Path -LiteralPath $tokenPath
+    } catch {
+        $exeExit = -1
+    }
+}
+
+$exeLogPath    = Join-Path $distDir '~warnfix_venv_repair_exe.log'
+$exeLogContent = if (Test-Path $exeLogPath) { Get-Content -LiteralPath $exeLogPath -Raw -Encoding ASCII } else { '' }
+$infraError    = $exeLogContent -match 'Failed to parse|uv error|pip error'
+
+$pass = $venvProviderLog -and $warnInstallFired -and $warnRebuildFired -and $installedXlrd -and (-not $repairFailed) -and $exeExists -and ($exeExit -eq 0) -and $tokenFound -and (-not $infraError)
+
+Write-NdjsonRow ([ordered]@{
+    id      = $rowId
+    req     = 'REQ-007'
+    pass    = $pass
+    desc    = 'Warnfix repair-install under venv mode genuinely installs the missing module (CLAUDE.md Item 36)'
+    details = [ordered]@{
+        exitCode         = $runExit
+        venvProviderLog  = $venvProviderLog
+        warnInstallFired = $warnInstallFired
+        warnRebuildFired = $warnRebuildFired
+        installedXlrd    = $installedXlrd
+        repairFailed     = $repairFailed
+        exeExists        = $exeExists
+        exeExit          = $exeExit
+        tokenFound       = $tokenFound
+        infraError       = $infraError
+        exePath          = $exePath
+    }
+})
+
+if (-not $pass) { exit 1 }
+exit 0

--- a/tests/selfapps_warnfix_venv_repair.ps1
+++ b/tests/selfapps_warnfix_venv_repair.ps1
@@ -46,8 +46,14 @@ function Write-NdjsonRow {
 $rowId = 'self.exe.warnfix.venv_repair'
 
 # Non-Windows skip
-if (-not $IsWindows) {
-    $platform = [System.Environment]::OSVersion.Platform.ToString()
+# derived requirement: $IsWindows is undefined (reads as $null, so "-not $IsWindows" is always
+# true) under Windows PowerShell 5.1 -- it was only introduced in PowerShell 6+. Already fixed
+# for this exact reason in tests/selfapps_lineending_check.ps1 and tests/selfapps_ux_hardening.ps1
+# (CLAUDE.md Item 44 / PR #434, PR #436) -- applying the same fix here from the start rather than
+# waiting for a future review round to catch it again. [System.Environment]::OSVersion.Platform
+# works identically on 5.1 and 7+.
+$platform = [System.Environment]::OSVersion.Platform.ToString()
+if ($platform -ne 'Win32NT') {
     Write-NdjsonRow ([ordered]@{
         id      = $rowId
         req     = 'REQ-007'

--- a/tests/selfapps_warnfix_venv_repair.ps1
+++ b/tests/selfapps_warnfix_venv_repair.ps1
@@ -43,7 +43,13 @@ function Write-NdjsonRow {
     Add-Content -LiteralPath $ciNd -Value $json -Encoding Ascii
 }
 
-$rowId = 'self.exe.warnfix.venv_repair'
+# derived requirement: docs/agent-lessons-learned.md's "A multi-scenario PowerShell test's
+# NDJSON id must stay a literal string at each Write-NdjsonRow call site, never a shared
+# variable" -- tools/check_ndjson_registry.py's static scan only matches a literal
+# id='...'/id="..." string immediately after the id key, not a variable reference. Every
+# Write-NdjsonRow call below repeats the literal 'self.exe.warnfix.venv_repair' rather than
+# referencing a single shared $rowId, so the registry checker can find this row's own
+# emission site by pure text scan.
 
 # Non-Windows skip
 # derived requirement: $IsWindows is undefined (reads as $null, so "-not $IsWindows" is always
@@ -55,7 +61,7 @@ $rowId = 'self.exe.warnfix.venv_repair'
 $platform = [System.Environment]::OSVersion.Platform.ToString()
 if ($platform -ne 'Win32NT') {
     Write-NdjsonRow ([ordered]@{
-        id      = $rowId
+        id      = 'self.exe.warnfix.venv_repair'
         req     = 'REQ-007'
         pass    = $true
         desc    = 'Warnfix repair-install under venv mode genuinely installs the missing module (skipped on non-Windows)'
@@ -68,7 +74,7 @@ if ($platform -ne 'Win32NT') {
 # unconditionally, so venv mode is unreachable there regardless of what this test forces.
 if ($env:HP_FORCE_CONDA_ONLY -eq '1') {
     Write-NdjsonRow ([ordered]@{
-        id      = $rowId
+        id      = 'self.exe.warnfix.venv_repair'
         req     = 'REQ-007'
         pass    = $true
         desc    = 'Warnfix repair-install under venv mode genuinely installs the missing module (skipped: HP_FORCE_CONDA_ONLY blocks venv fallback)'
@@ -80,7 +86,7 @@ if ($env:HP_FORCE_CONDA_ONLY -eq '1') {
 $batchPath = Join-Path $repo 'run_setup.bat'
 if (-not (Test-Path $batchPath)) {
     Write-NdjsonRow ([ordered]@{
-        id      = $rowId
+        id      = 'self.exe.warnfix.venv_repair'
         req     = 'REQ-007'
         pass    = $false
         desc    = 'Warnfix venv-repair: run_setup.bat not found'
@@ -193,7 +199,7 @@ $infraError    = $exeLogContent -match 'Failed to parse|uv error|pip error'
 $pass = $venvProviderLog -and $warnInstallFired -and $warnRebuildFired -and $installedXlrd -and (-not $repairFailed) -and $exeExists -and ($exeExit -eq 0) -and $tokenFound -and (-not $infraError)
 
 Write-NdjsonRow ([ordered]@{
-    id      = $rowId
+    id      = 'self.exe.warnfix.venv_repair'
     req     = 'REQ-007'
     pass    = $pass
     desc    = 'Warnfix repair-install under venv mode genuinely installs the missing module (CLAUDE.md Item 36)'


### PR DESCRIPTION
## Summary

- The warnfix repair-install dispatch (`run_setup.bat`, inside `:run_entry_smoke`'s `HP_WARNFIX_NEEDED` block) only had `uv` and `conda` branches. Under `venv`, `embed`, or `system` mode, neither branch matched, so the loop silently installed nothing while still logging `[REPAIR] missing modules detected; installing and rebuilding.` / `[REPAIR] rebuild complete after warnfix.` as if the repair had worked. Since no install was even attempted, `~warnfix_repair_failed.flag` was never created either, silently defeating `:warnfix_cascade_detect`'s own cascade-recovery gate for this failure class.
- Adds `venv` and `embed` branches (a plain `"%HP_PY%" -m pip install %%M` per missing module, mirroring the same three-mode pip pathway the main, non-repair dependency-install dispatch already uses a few hundred lines earlier) plus a `system`-mode catch-all that deliberately stays a no-op but now logs `[WARN] System fallback: skipping warnfix repair installation.` instead of silently claiming success.
- Closes CLAUDE.md's Active Backlog Item 36 (moved to `docs/agent-closed-backlog.md`); updates `docs/agent-interconnect.md`'s "Standalone Python-download tier" section (the gap this item cited was already flagged there as "worth a dedicated future fix... its own backlog item") and registers the new NDJSON row in `docs/agent-ndjson.md`.

## Coverage gap closed

Item 36's own text specified the exact gap: "all five `selfapps_warnfix.ps1` scenarios run on `real`/`conda-full`, both of which land in the `uv` or `CONDA_BAT` branch -- the broken branch is unreachable from every existing warnfix test. Add a scenario that forces venv or embed mode with a warnfix-triggering missing import, asserting the module actually gets installed (not just that the EXE eventually builds)."

New `tests/selfapps_warnfix_venv_repair.ps1` (`uv` lane, non-gating for its first landing, matching this repo's established graduation pattern):
- Forces venv mode via `HP_OFFLINE_MODE=1` + `HP_TEST_FORCE_CONDA_FAIL=1` in a fresh scratch directory -- the same established technique `self.venv.fallback` (`selfapps_ux_hardening.ps1`) already uses.
- Uses the same `xlrd`-importing stub app as `selfapps_warnfix.ps1`'s own `real_warnfix` scenario (xlrd isn't heuristic-covered, so warnfix is the only repair path), with the same `HP_SKIP_PIPREQS=1` + `HP_SKIP_AUTOPEP_DISCOVERY=1` isolation flags.
- Asserts the `[BOOT] REQ-009: Selected Python provider: Local venv (fallback).` line (venv genuinely selected), both warnfix phase markers, and -- the core assertion -- `[INFO] Installed: xlrd` (never emitted under venv mode before this fix, even though "rebuild complete" fired unconditionally regardless), plus the absence of `[WARN] Repair failed:` and a clean EXE run.

## Verification

- `python tools/check_delimiters.py run_setup.bat` -- unchanged at the pre-existing 26-finding baseline (CLAUDE.md Item 61's own tracked, out-of-scope follow-up; zero new findings from this change).
- `python tools/check_crlf.py` -- clean.
- `tools/run_sanity_sweep.sh` -- all checks pass except the known pre-existing delimiter baseline above (compileall, pyflakes, CRLF, markdownlint, yamllint, actionlint, ASCII sweep, PowerShell AST parse sweep including the new test file, full pytest suite: 535 passed / 3 skipped).
- `yamllint` + `actionlint` on the updated `batch-check.yml` wiring: clean.

## Test plan

- [ ] CI: full 8-lane matrix green (`real`/`conda-full` gating; new step runs non-gating on `uv`)
- [ ] `self.exe.warnfix.venv_repair` reports `pass:true` on its first real run
- [ ] No regression in the 5 existing `self.exe.warnfix.*` scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017SQ1rvJxDbE71pTXJ4QvLV

---
_Generated by [Claude Code](https://claude.ai/code/session_017SQ1rvJxDbE71pTXJ4QvLV)_