### PR TITLE
Item 37: wire HP_NDJSON into selfapps_layered_e2e.ps1's sub-bootstrap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -698,6 +698,21 @@ but several represent real gaps worth closing before calling the path fully rele
   proven stable, promote that one step (or the whole `cache` lane, depending on what Item 35's own
   audit concludes) via Item 35's process.
 
+  **Cheapest-first fix implemented, NOT YET CONFIRMED via a real CI run.**
+  `selfapps_layered_e2e.ps1` now sets `HP_NDJSON` for its own sub-bootstrap (pointing at the same
+  shared `~test-results.ndjson` its own `Write-NdjsonRow` already writes to, restored in its
+  `finally` block) and diffs that file before/after to record, as informational `details` fields
+  on its own `self.layered_e2e.chain` row, whether a `self.dll_bundle.recover` row with
+  `state:"repaired"` actually appeared -- deliberately NOT folded into `chainPass`/`mech4Pass`
+  itself, so a wiring issue in the NDJSON emission specifically cannot turn this already-proven,
+  closely-watched test red on its own first run under the new wiring. See
+  `docs/agent-ndjson.md`'s corresponding entry for the full mechanism. Still open before this
+  slice can be considered done: confirm via the diagnostics site's next real `cache`-lane run
+  that the row genuinely appears with `state:"repaired"` (check `dllBundleRowSeen`/
+  `dllBundleRowRepaired` on that run's `self.layered_e2e.chain` row) -- only then does the
+  "promote that one step... via Item 35's process" half of this fix become a live next step, per
+  Item 35's own "let CI run to completion, several consecutive times" discipline.
+
 - **Item 38: the same EXE is verified from two different working directories across run 1 vs.
   every later run, so a CWD-relative-path app can flip its verdict between two consecutive
   double-clicks.** Confirmed reasoned-from-source; the CWD split itself is already documented as

--- a/docs/agent-ndjson.md
+++ b/docs/agent-ndjson.md
@@ -268,30 +268,37 @@ display-only sanitization exists (see `docs/agent-interconnect.md`'s DLL-bundlin
 a DLL basename can legally contain `&`/`|`, which are metacharacters to cmd.exe's own
 command-line parsing even inside a quoted argument, not just inside `:log`'s unquoted echo.
 
-**Not currently observed in any real CI artifact.** `run_setup.bat`'s own `HP_NDJSON`
-auto-detection (`if not defined HP_NDJSON if exist "%CD%\tests" set "HP_NDJSON=..."`) only fires
-when the bootstrapped app directory has its own `tests\` subfolder -- `tests/selfapps_layered_
-e2e.ps1` (the one test that genuinely triggers the `repaired` state, via `pygrib`/`eccodes.dll`)
-runs its sub-bootstrap from a bare scratch directory with no `tests\` subfolder, and does not
-explicitly set `HP_NDJSON` either, matching this repo's established convention for isolated
-sub-bootstrap tests (see `tests/selfapps_postexec_checkpoint.ps1`, which deliberately `Remove-
-Item Env:HP_NDJSON` around its own sub-bootstrap calls and asserts via log text instead, to avoid
-an isolated scratch run's rows leaking into the shared `~test-results.ndjson` stream). So
-`:emit_dll_bundle_row`'s own `if not defined HP_NDJSON exit /b 0` guard means this row is never
-actually written during that test's run today -- `mech4Pass` continues to rely on the pre-existing
-`[REPAIR][DLL_BUNDLE]` log-text assertions (`docs/agent-interconnect.md`'s DLL-bundling section),
-unaffected by this addition. `batch.dll_bundle.ndjson` (`tests/harness.ps1`, static) is the actual
-coverage for this row: it verifies the `:emit_dll_bundle_row` subroutine exists, the row id string
-is present, and all 7 `call :emit_dll_bundle_row <state>` sites are wired (including the
-`exhausted` state added for CLAUDE.md Item 25) -- the same "static wiring
-guard, not runtime execution" pattern already used for `batch.failfast.probe`/`batch.postexec.
-checkpoint` above. Per-state runtime coverage (deliberately setting `HP_NDJSON` for a sub-bootstrap
-and reading the row back) remains a candidate for a future, dedicated test if ever justified --
-not pursued now, since simulating the other 6 states (Nuitka-used, non-conda provider, a genuine
-PyInstaller rebuild failure, a missing post-rebuild EXE, a detected-but-unlocatable DLL, the
-3-iteration cap hit with a candidate still pending) each needs
-its own scaffolding beyond what `self.layered_e2e.chain`'s real `pygrib` trigger already provides
-for the `repaired` state alone.
+**Now wired for real observation (CLAUDE.md Item 37, not yet confirmed via a real CI run as of
+this edit).** Previously never observed in any real CI artifact: `run_setup.bat`'s own
+`HP_NDJSON` auto-detection (`if not defined HP_NDJSON if exist "%CD%\tests" set "HP_NDJSON=..."`)
+only fires when the bootstrapped app directory has its own `tests\` subfolder, and
+`tests/selfapps_layered_e2e.ps1` (the one test that genuinely triggers the `repaired` state, via
+`pygrib`/`eccodes.dll`) runs its sub-bootstrap from a bare scratch directory with no `tests\`
+subfolder -- so `:emit_dll_bundle_row`'s own `if not defined HP_NDJSON exit /b 0` guard meant
+this row was never actually written. Fixed by having that test explicitly set `HP_NDJSON` to the
+SAME shared file its own `Write-NdjsonRow` already writes to, right before the sub-bootstrap
+call, restored in its `finally` block -- the opposite of `tests/selfapps_postexec_checkpoint.ps1`
+/ `selfapps_failfast_probe.ps1` / `selfapps_exefastpath.ps1`'s established convention of
+deliberately `Remove-Item Env:HP_NDJSON` around an isolated sub-bootstrap to keep its rows OUT of
+the shared stream -- this test's whole Item 37 goal is getting this specific row IN. The test
+also now diffs `~test-results.ndjson` before/after its own sub-bootstrap call and records whether
+a `self.dll_bundle.recover` row with `state:"repaired"` appeared, as informational `details`
+fields (`dllBundleRowSeen`/`dllBundleRowRepaired`) on its own `self.layered_e2e.chain` row --
+deliberately NOT folded into `chainPass`/`mech4Pass` itself, since `mech4Pass`'s existing
+log-text assertions already prove the underlying repair happened; a wiring hiccup in the NDJSON
+emission specifically should not turn this already-proven, closely-watched test red on its first
+real run under the new wiring. Check the diagnostics site's next `cache`-lane run for this row
+before treating it as confirmed. `batch.dll_bundle.ndjson` (`tests/harness.ps1`, static) remains
+the SEPARATE, always-on coverage for this row regardless of the above: it verifies the
+`:emit_dll_bundle_row` subroutine exists, the row id string is present, and all 7
+`call :emit_dll_bundle_row <state>` sites are wired (including the `exhausted` state added for
+CLAUDE.md Item 25) -- the same "static wiring guard, not runtime execution" pattern already used
+for `batch.failfast.probe`/`batch.postexec.checkpoint` above. Runtime coverage for the other 6
+states (Nuitka-used, non-conda provider, a genuine PyInstaller rebuild failure, a missing
+post-rebuild EXE, a detected-but-unlocatable DLL, the 3-iteration cap hit with a candidate still
+pending) each needs its own scaffolding beyond what `self.layered_e2e.chain`'s real `pygrib`
+trigger provides for the `repaired` state alone -- still a candidate for future, dedicated tests,
+not pursued now.
 
 `batch.dll_bundle.pct_sanitizer` (`tests/harness.ps1`, gating) is a SEPARATE static check, not a
 sibling of the above -- it live-executes a real cmd.exe + PowerShell fixture proving the `_SAFE`

--- a/tests/selfapps_layered_e2e.ps1
+++ b/tests/selfapps_layered_e2e.ps1
@@ -179,6 +179,25 @@ Set-Content -Path (Join-Path $workDir 'app.py') -Value $appCode -Encoding ASCII
 $prevCascade = if (Test-Path Env:HP_TEST_CASCADE_ANSWER) { $env:HP_TEST_CASCADE_ANSWER } else { $null }
 $env:HP_TEST_CASCADE_ANSWER = 'Y'
 
+# derived requirement (CLAUDE.md Item 37): point run_setup.bat's own inline HP_NDJSON
+# emission at the SAME shared file this test's own Write-NdjsonRow already writes to ($nd), so
+# self.dll_bundle.recover's "repaired" row -- proven by mech4Pass's log-text checks below to
+# genuinely fire during this exact run, but never previously captured as a queryable NDJSON row
+# anywhere -- lands in the shared stream for the first time. See docs/agent-ndjson.md's
+# "self.dll_bundle.recover... Not currently observed in any real CI artifact" note: the only
+# test reaching the 'repaired' state is THIS one, and it never set HP_NDJSON before now. Unlike
+# selfapps_postexec_checkpoint.ps1 / selfapps_failfast_probe.ps1 / selfapps_exefastpath.ps1
+# (which deliberately UNSET HP_NDJSON around their own sub-bootstraps to keep an isolated
+# scenario's rows OUT of the shared stream), this test's Item 37 goal is the opposite: this
+# sub-bootstrap's inline rows (self.dll_bundle.recover, plus the other already-registered ids
+# it incidentally also emits -- pipreqs.install, env.mode, helper.find_entry.syntax, conda.url,
+# self.warnfix.platform_filter, self.exe.smokerun -- all already-expected occurrences for a
+# real full bootstrap run) belong IN the shared stream.
+$prevNdjson = if (Test-Path Env:HP_NDJSON) { $env:HP_NDJSON } else { $null }
+$env:HP_NDJSON = $nd
+$ndLinesBefore = if (Test-Path -LiteralPath $nd) { @(Get-Content -LiteralPath $nd -Encoding ASCII) } else { @() }
+$ndCountBefore = $ndLinesBefore.Count
+
 $bootstrapLog = '~layered_e2e_bootstrap.log'
 # derived requirement: guard the location push -- under $ErrorActionPreference = 'Continue', a
 # failed Push-Location would otherwise be non-terminating, letting the try block run
@@ -192,6 +211,7 @@ try {
     $runExit = $LASTEXITCODE
 } finally {
     if ($null -eq $prevCascade) { Remove-Item Env:HP_TEST_CASCADE_ANSWER -ErrorAction SilentlyContinue } else { $env:HP_TEST_CASCADE_ANSWER = $prevCascade }
+    if ($null -eq $prevNdjson) { Remove-Item Env:HP_NDJSON -ErrorAction SilentlyContinue } else { $env:HP_NDJSON = $prevNdjson }
     if ($pushedLocation) { Pop-Location }
 }
 
@@ -269,6 +289,18 @@ $hiddenRecovered  = $combined -match [regex]::Escape('[REPAIR][HIDDEN_IMPORT] EX
 $dllWarningSeen    = $setupText -match [regex]::Escape("Library not found: could not resolve 'eccodes.dll'")
 $dllBundling       = $combined -match [regex]::Escape('[REPAIR][DLL_BUNDLE] Bundling native DLL dependency: eccodes.dll')
 $dllBundleComplete = $combined -match [regex]::Escape('[REPAIR][DLL_BUNDLE] Native-DLL bundling complete')
+
+# derived requirement (CLAUDE.md Item 37): informational only, deliberately NOT folded into
+# chainPass/mech4Pass -- mech4Pass above already proves the real repair happened via log text
+# (the same underlying event this NDJSON row records), so a wiring hiccup in the row emission
+# itself must not turn a currently-green, closely-watched test red on its own first real CI
+# run. This is the row's first-ever real-CI observation; once proven stable across several runs
+# it can graduate to a hard assertion via Item 35's own promotion process.
+$ndLinesAfterRun  = if (Test-Path -LiteralPath $nd) { @(Get-Content -LiteralPath $nd -Encoding ASCII) } else { @() }
+$ndNewLines       = if ($ndLinesAfterRun.Count -gt $ndCountBefore) { $ndLinesAfterRun[$ndCountBefore..($ndLinesAfterRun.Count - 1)] } else { @() }
+$ndNewCombined    = $ndNewLines -join "`n"
+$dllBundleRowSeen     = $ndNewCombined -match [regex]::Escape('"id":"self.dll_bundle.recover"')
+$dllBundleRowRepaired = $ndNewCombined -match [regex]::Escape('"state":"repaired"')
 
 $infraError = $combined -match 'Failed to parse|uv error|pip error'
 
@@ -412,6 +444,8 @@ Write-NdjsonRow ([ordered]@{
         dllWarningSeen     = $dllWarningSeen
         dllBundling        = $dllBundling
         dllBundleComplete  = $dllBundleComplete
+        dllBundleRowSeen     = $dllBundleRowSeen
+        dllBundleRowRepaired = $dllBundleRowRepaired
         exePass          = $exePass
         exeExists        = $exeExists
         exeExit          = $exeExit

--- a/tests/selfapps_layered_e2e.ps1
+++ b/tests/selfapps_layered_e2e.ps1
@@ -298,9 +298,26 @@ $dllBundleComplete = $combined -match [regex]::Escape('[REPAIR][DLL_BUNDLE] Nati
 # it can graduate to a hard assertion via Item 35's own promotion process.
 $ndLinesAfterRun  = if (Test-Path -LiteralPath $nd) { @(Get-Content -LiteralPath $nd -Encoding ASCII) } else { @() }
 $ndNewLines       = if ($ndLinesAfterRun.Count -gt $ndCountBefore) { $ndLinesAfterRun[$ndCountBefore..($ndLinesAfterRun.Count - 1)] } else { @() }
-$ndNewCombined    = $ndNewLines -join "`n"
-$dllBundleRowSeen     = $ndNewCombined -match [regex]::Escape('"id":"self.dll_bundle.recover"')
-$dllBundleRowRepaired = $ndNewCombined -match [regex]::Escape('"state":"repaired"')
+# derived requirement (CodeRabbit review, PR #452): parse each new NDJSON line as its own
+# object and require the state check to apply to the SAME row that carries the
+# self.dll_bundle.recover id -- a plain substring match across the whole $ndNewCombined text
+# (the original approach) could not tell "this row's own details.state is repaired" apart from
+# "some OTHER unrelated row emitted during this same run also happens to contain the substring
+# "state":"repaired"" (e.g. a coincidentally identically-shaped field on a different id).
+$dllBundleRowSeen     = $false
+$dllBundleRowRepaired = $false
+foreach ($ndLine in $ndNewLines) {
+    if (-not $ndLine.Trim()) { continue }
+    try {
+        $ndRow = $ndLine | ConvertFrom-Json
+    } catch {
+        continue
+    }
+    if ($ndRow.id -eq 'self.dll_bundle.recover') {
+        $dllBundleRowSeen = $true
+        if ($ndRow.details.state -eq 'repaired') { $dllBundleRowRepaired = $true }
+    }
+}
 
 $infraError = $combined -match 'Failed to parse|uv error|pip error'
 


### PR DESCRIPTION
## Summary

- CLAUDE.md's Active Backlog Item 37: `self.dll_bundle.recover`'s "repaired" row (the conda native-DLL bundling repair loop's own NDJSON emission) has never actually fired in any real CI artifact. `run_setup.bat`'s `HP_NDJSON` auto-detection only triggers when the bootstrapped app directory has its own `tests\` subfolder, and `tests/selfapps_layered_e2e.ps1` — the one test that genuinely triggers the `repaired` state via a real `pygrib`/`eccodes.dll` build — runs its sub-bootstrap from a bare scratch directory with `HP_NDJSON` left unset, so `:emit_dll_bundle_row`'s own `if not defined HP_NDJSON exit /b 0` guard silently skips the row every time.
- Fix (the item's own "cheapest first" suggestion): `selfapps_layered_e2e.ps1` now sets `HP_NDJSON` for its own sub-bootstrap, pointing at the same shared `~test-results.ndjson` file its own `Write-NdjsonRow` already writes to, restored in its `finally` block — the opposite of this repo's usual convention (`selfapps_postexec_checkpoint.ps1`/`selfapps_failfast_probe.ps1`/`selfapps_exefastpath.ps1` deliberately *unset* `HP_NDJSON` to keep an isolated sub-bootstrap's rows out of the shared stream); here the whole point is getting this specific row *in*.
- The test also now diffs `~test-results.ndjson` before/after its own sub-bootstrap call and records whether a `self.dll_bundle.recover` row with `state:"repaired"` actually appeared, as new informational `details` fields (`dllBundleRowSeen`/`dllBundleRowRepaired`) on its own `self.layered_e2e.chain` row.

## Why this is safe / low-risk

- **Deliberately NOT folded into `chainPass`/`mech4Pass`.** `mech4Pass`'s existing log-text assertions already prove the underlying DLL-bundling repair happened for real; a wiring hiccup in the *new* NDJSON emission alone must not turn this already-proven, closely-watched, non-gating test red on its first run under the new wiring.
- **No new/unexpected NDJSON ids.** Every id this sub-bootstrap will now additionally emit inline (`pipreqs.install`, `env.mode`, `helper.find_entry.syntax`, `conda.url`, `self.warnfix.platform_filter`, `self.exe.smokerun`, `self.dll_bundle.recover`) is already registered in `docs/agent-ndjson.md` and already fires many times per CI run from other tests — traced each call site in `run_setup.bat` individually before making this change.
- **Non-gating lane.** `selfapps_layered_e2e.ps1` runs on `cache` only, which is `continue-on-error` at the job level.
- **Not yet claimed as confirmed.** `docs/agent-ndjson.md` and CLAUDE.md's Item 37 entry are both updated to describe the mechanism honestly ("implemented, not yet confirmed via a real CI run") rather than asserting success before a real `cache`-lane run has actually shown the row.

## Verification

- `tools/run_sanity_sweep.sh` — all checks pass (compileall, pyflakes, delimiter check, CRLF check, markdownlint, yamllint, actionlint, ASCII sweep, PowerShell AST parse sweep, full pytest: 535 passed / 3 skipped).
- `[System.Management.Automation.Language.Parser]::ParseFile` confirms the edited test script still parses cleanly.

## Test plan

- [ ] CI: `cache` lane's `self.layered_e2e.chain` row still reports `pass:true` (unaffected — assertion set unchanged)
- [ ] Diagnostics site: confirm the `cache`-lane run's `self.layered_e2e.chain` `details` now shows `dllBundleRowSeen:true, dllBundleRowRepaired:true`
- [ ] Follow-up (separate loop, not this PR): once proven stable across several runs, consider promoting per Item 35's own process

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017SQ1rvJxDbE71pTXJ4QvLV

---
_Generated by [Claude Code](https://claude.ai/code/session_017SQ1rvJxDbE71pTXJ4QvLV)_