### PR TITLE
Item 37: record real-CI confirmation of self.dll_bundle.recover wiring

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -698,20 +698,25 @@ but several represent real gaps worth closing before calling the path fully rele
   proven stable, promote that one step (or the whole `cache` lane, depending on what Item 35's own
   audit concludes) via Item 35's process.
 
-  **Cheapest-first fix implemented, NOT YET CONFIRMED via a real CI run.**
-  `selfapps_layered_e2e.ps1` now sets `HP_NDJSON` for its own sub-bootstrap (pointing at the same
-  shared `~test-results.ndjson` its own `Write-NdjsonRow` already writes to, restored in its
-  `finally` block) and diffs that file before/after to record, as informational `details` fields
-  on its own `self.layered_e2e.chain` row, whether a `self.dll_bundle.recover` row with
-  `state:"repaired"` actually appeared -- deliberately NOT folded into `chainPass`/`mech4Pass`
-  itself, so a wiring issue in the NDJSON emission specifically cannot turn this already-proven,
-  closely-watched test red on its own first run under the new wiring. See
-  `docs/agent-ndjson.md`'s corresponding entry for the full mechanism. Still open before this
-  slice can be considered done: confirm via the diagnostics site's next real `cache`-lane run
-  that the row genuinely appears with `state:"repaired"` (check `dllBundleRowSeen`/
-  `dllBundleRowRepaired` on that run's `self.layered_e2e.chain` row) -- only then does the
-  "promote that one step... via Item 35's process" half of this fix become a live next step, per
-  Item 35's own "let CI run to completion, several consecutive times" discipline.
+  **Cheapest-first fix implemented AND CONFIRMED via real CI (PR #452, merge commit `f50ccd6`,
+  `cache`-lane run `32561652643`).** `selfapps_layered_e2e.ps1` now sets `HP_NDJSON` for its own
+  sub-bootstrap (pointing at the same shared `~test-results.ndjson` its own `Write-NdjsonRow`
+  already writes to, restored in its `finally` block) and diffs that file before/after to record,
+  as informational `details` fields on its own `self.layered_e2e.chain` row, whether a
+  `self.dll_bundle.recover` row with `state:"repaired"` actually appeared -- deliberately NOT
+  folded into `chainPass`/`mech4Pass` itself, so a wiring issue in the NDJSON emission
+  specifically cannot turn this already-proven, closely-watched test red on its own first run
+  under the new wiring. See `docs/agent-ndjson.md`'s corresponding entry for the full mechanism.
+  **Confirmed by pulling the real published diagnostics artifact directly** (`tests/
+  ~test-results.ndjson` from the `cache`-lane job of that run): `self.dll_bundle.recover` fired
+  TWICE with `state:"repaired"` in the same run (`eccodes.dll` and `impi.dll`, both `iteration:1`,
+  `provider:"conda"`), and `self.layered_e2e.chain`'s own `details` show
+  `dllBundleRowSeen:true, dllBundleRowRepaired:true` alongside every other mechanism passing
+  (`mech1Pass`-`mech4Pass` all `true`, `exePass:true`, `statusState:"ok"`, `runExit:0`). This is
+  the row's first-ever real-CI observation, confirming it after ONE run -- not yet the "several
+  consecutive runs" Item 35's own process discipline requires before considering promotion (moving
+  this step, or the whole `cache` lane, out of `continue-on-error`). That promotion decision
+  remains a live next step for a FUTURE loop, not taken here.
 
 - **Item 38: the same EXE is verified from two different working directories across run 1 vs.
   every later run, so a CWD-relative-path app can flip its verdict between two consecutive

--- a/docs/agent-ndjson.md
+++ b/docs/agent-ndjson.md
@@ -268,27 +268,34 @@ display-only sanitization exists (see `docs/agent-interconnect.md`'s DLL-bundlin
 a DLL basename can legally contain `&`/`|`, which are metacharacters to cmd.exe's own
 command-line parsing even inside a quoted argument, not just inside `:log`'s unquoted echo.
 
-**Now wired for real observation (CLAUDE.md Item 37, not yet confirmed via a real CI run as of
-this edit).** Previously never observed in any real CI artifact: `run_setup.bat`'s own
-`HP_NDJSON` auto-detection (`if not defined HP_NDJSON if exist "%CD%\tests" set "HP_NDJSON=..."`)
-only fires when the bootstrapped app directory has its own `tests\` subfolder, and
-`tests/selfapps_layered_e2e.ps1` (the one test that genuinely triggers the `repaired` state, via
-`pygrib`/`eccodes.dll`) runs its sub-bootstrap from a bare scratch directory with no `tests\`
-subfolder -- so `:emit_dll_bundle_row`'s own `if not defined HP_NDJSON exit /b 0` guard meant
-this row was never actually written. Fixed by having that test explicitly set `HP_NDJSON` to the
-SAME shared file its own `Write-NdjsonRow` already writes to, right before the sub-bootstrap
-call, restored in its `finally` block -- the opposite of `tests/selfapps_postexec_checkpoint.ps1`
-/ `selfapps_failfast_probe.ps1` / `selfapps_exefastpath.ps1`'s established convention of
-deliberately `Remove-Item Env:HP_NDJSON` around an isolated sub-bootstrap to keep its rows OUT of
-the shared stream -- this test's whole Item 37 goal is getting this specific row IN. The test
-also now diffs `~test-results.ndjson` before/after its own sub-bootstrap call and records whether
-a `self.dll_bundle.recover` row with `state:"repaired"` appeared, as informational `details`
-fields (`dllBundleRowSeen`/`dllBundleRowRepaired`) on its own `self.layered_e2e.chain` row --
-deliberately NOT folded into `chainPass`/`mech4Pass` itself, since `mech4Pass`'s existing
+**Now wired for real observation AND CONFIRMED via real CI (CLAUDE.md Item 37, PR #452, merge
+commit `f50ccd6`, `cache`-lane run `32561652643`).** Previously never observed in any real CI
+artifact: `run_setup.bat`'s own `HP_NDJSON` auto-detection (`if not defined HP_NDJSON if exist
+"%CD%\tests" set "HP_NDJSON=..."`) only fires when the bootstrapped app directory has its own
+`tests\` subfolder, and `tests/selfapps_layered_e2e.ps1` (the one test that genuinely triggers the
+`repaired` state, via `pygrib`/`eccodes.dll`) runs its sub-bootstrap from a bare scratch directory
+with no `tests\` subfolder -- so `:emit_dll_bundle_row`'s own `if not defined HP_NDJSON exit /b 0`
+guard meant this row was never actually written. Fixed by having that test explicitly set
+`HP_NDJSON` to the SAME shared file its own `Write-NdjsonRow` already writes to, right before the
+sub-bootstrap call, restored in its `finally` block -- the opposite of `tests/selfapps_postexec_
+checkpoint.ps1` / `selfapps_failfast_probe.ps1` / `selfapps_exefastpath.ps1`'s established
+convention of deliberately `Remove-Item Env:HP_NDJSON` around an isolated sub-bootstrap to keep
+its rows OUT of the shared stream -- this test's whole Item 37 goal is getting this specific row
+IN. The test also now diffs `~test-results.ndjson` before/after its own sub-bootstrap call and
+records whether a `self.dll_bundle.recover` row with `state:"repaired"` appeared, as informational
+`details` fields (`dllBundleRowSeen`/`dllBundleRowRepaired`) on its own `self.layered_e2e.chain`
+row -- deliberately NOT folded into `chainPass`/`mech4Pass` itself, since `mech4Pass`'s existing
 log-text assertions already prove the underlying repair happened; a wiring hiccup in the NDJSON
 emission specifically should not turn this already-proven, closely-watched test red on its first
-real run under the new wiring. Check the diagnostics site's next `cache`-lane run for this row
-before treating it as confirmed. `batch.dll_bundle.ndjson` (`tests/harness.ps1`, static) remains
+real run under the new wiring. **Confirmed by pulling the real published diagnostics artifact
+directly** (`tests/~test-results.ndjson` from that run's `cache`-lane job):
+`self.dll_bundle.recover` fired TWICE with `state:"repaired"` (`eccodes.dll` and `impi.dll`, both
+`iteration:1`, `provider:"conda"`), and `self.layered_e2e.chain`'s own `details` show
+`dllBundleRowSeen:true, dllBundleRowRepaired:true` alongside `mech1Pass`-`mech4Pass` all `true`.
+One confirmed run is not yet the "several consecutive runs" Item 35's own process discipline
+requires before considering promotion out of `continue-on-error` -- that decision is still a live
+next step for a future loop, not taken here. `batch.dll_bundle.ndjson` (`tests/harness.ps1`,
+static) remains
 the SEPARATE, always-on coverage for this row regardless of the above: it verifies the
 `:emit_dll_bundle_row` subroutine exists, the row id string is present, and all 7
 `call :emit_dll_bundle_row <state>` sites are wired (including the `exhausted` state added for


### PR DESCRIPTION
## Summary

Docs-only follow-up to PR #452 (which wired `HP_NDJSON` into `selfapps_layered_e2e.ps1`'s sub-bootstrap so `self.dll_bundle.recover`'s "repaired" row could actually fire). That PR shipped with the caveat "not yet confirmed via a real CI run" — this PR records the confirmation now that PR #452's own `cache`-lane run has completed and published.

- Independently verified by pulling the real published diagnostics artifact directly (`tests/~test-results.ndjson` from the `cache`-lane job of run `32561652643`, merge commit `f50ccd6`):
  - `self.dll_bundle.recover` fired **twice** with `state:"repaired"` in the same run (`eccodes.dll` and `impi.dll`, both `iteration:1`, `provider:"conda"`).
  - `self.layered_e2e.chain`'s own `details` show `dllBundleRowSeen:true, dllBundleRowRepaired:true`, alongside `mech1Pass`-`mech4Pass` all `true`, `exePass:true`, `statusState:"ok"`, `runExit:0`.
- Updates CLAUDE.md's Item 37 entry and `docs/agent-ndjson.md`'s corresponding entry to record this as confirmed, while being explicit that **one confirmed run is not the "several consecutive runs" bar Item 35's own process discipline requires** before considering promotion out of `continue-on-error` — that decision stays a separate future step, not taken here.

## Verification

- `tools/run_sanity_sweep.sh` — all checks pass (compileall, pyflakes, delimiter check, CRLF check, markdownlint, yamllint, actionlint, ASCII sweep, PowerShell AST parse sweep, full pytest: 535 passed / 3 skipped).
- Diagnostics artifact fetched and parsed directly (not just taking a third-party summary's word for it) to confirm the exact row content quoted above.

## Test plan

- [ ] CI: full 8-lane matrix green (docs-only change, no functional impact expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017SQ1rvJxDbE71pTXJ4QvLV

---
_Generated by [Claude Code](https://claude.ai/code/session_017SQ1rvJxDbE71pTXJ4QvLV)_