### PR TITLE
Item 35: fix selftest-gate's missing-artifact fallback to fail closed per lane

### DIFF
--- a/.github/workflows/batch-check.yml
+++ b/.github/workflows/batch-check.yml
@@ -3416,6 +3416,15 @@ jobs:
     outputs:
       has_failures: ${{ steps.aggregate.outputs.has_failures }}
     steps:
+      # derived requirement (CodeRabbit review, PR #454): this job previously never checked out
+      # the repository at all -- its original "Aggregate verdicts" step was fully self-contained
+      # inline PowerShell with no dependency on any repo file. Extracting that logic to
+      # tools/aggregate_selftest_verdicts.ps1 introduced a genuine new dependency on the repo
+      # being present on this runner that the job never had before; without this step, the
+      # "Aggregate verdicts" step below would fail to find the script on every single run.
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
       - name: Download lane verdicts
         uses: actions/download-artifact@v6
         continue-on-error: true
@@ -3469,6 +3478,20 @@ jobs:
           } else {
             '- No gate summary generated.' | Out-File -Append $env:GITHUB_STEP_SUMMARY
           }
+
+      # derived requirement (CodeRabbit review, PR #454): the report was previously surfaced only
+      # via the job summary above, with no way to download or retain it -- the job summary page
+      # is convenient for a human reading the run live, but is not a durable artifact the way the
+      # per-lane lane_verdict.json files already are. Uploading it here gives future diagnosis
+      # (or a future automated consumer) the same durability the inputs to this step already have.
+      - name: Upload gate report
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: selftest-gate-report-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/selftest-gate.json
+          if-no-files-found: warn
+          retention-days: 7
 
   crlf-check:
     name: CRLF line-ending check (.bat/.cmd)

--- a/.github/workflows/batch-check.yml
+++ b/.github/workflows/batch-check.yml
@@ -283,6 +283,18 @@ jobs:
         run: |
           & tests\test_ci_cache_selfheal.ps1
 
+      # derived requirement: wired into `real` specifically (a GATING lane) for the same reason
+      # as the cache-selfheal self-test immediately above -- so a regression in
+      # tools/aggregate_selftest_verdicts.ps1 (the selftest-gate "Aggregate verdicts" logic,
+      # CLAUDE.md Active Backlog Item 35's "Precondition" caveat) actually fails CI on every run,
+      # independent of whether a real artifact ever goes missing/duplicated/unexpected in this
+      # particular run.
+      - name: "Self-test: selftest-gate verdict aggregation logic (real lane only, GATING)"
+        if: ${{ matrix.mode == 'real' }}
+        shell: pwsh
+        run: |
+          & tests\test_aggregate_selftest_verdicts.ps1
+
       - name: "Pre-bootstrap: ensure Python file exists"
         shell: pwsh
         run: |
@@ -3423,99 +3435,26 @@ jobs:
       - name: Aggregate verdicts
         id: aggregate
         shell: pwsh
+        # derived requirement: the actual aggregation logic now lives in
+        # tools/aggregate_selftest_verdicts.ps1 so tests/test_aggregate_selftest_verdicts.ps1 can
+        # exercise it deterministically against fixture directories on every CI run -- mirrors
+        # tools/ci_cache_selfheal.ps1's own extraction (CLAUDE.md Active Backlog Item 35's
+        # "Precondition" caveat: fix the missing-artifact fallback to fail CLOSED per lane before
+        # this step's own conclusion is ever wired into branch protection). -ExpectedLanes must be
+        # kept in sync with this file's own matrix.include list above (8 modes: cache, real,
+        # conda-full, justme-test, uv, contract-uv, contract-uv-fail, uv-dl-fallback) -- already a
+        # third duplication of that list alongside the matrix include: block and the
+        # continue-on-error: condition, not a new pattern.
         run: |
-          $fallback = '${{ needs.selftest.result }}'
-          $dir = Join-Path $env:RUNNER_TEMP 'selftest-verdicts'
-          $files = @()
-          if (Test-Path $dir) {
-            $files = Get-ChildItem -Path $dir -Filter '*.json' -File -Recurse -ErrorAction SilentlyContinue
-          }
-
-          $has = $false
-          $lanes = @()
-
-          function Convert-ToBooleanOrNull {
-            param(
-              [Parameter(Mandatory = $false)]
-              $Value
-            )
-
-            if ($null -eq $Value) { return $null }
-            if ($Value -is [bool]) { return $Value }
-            if ($Value -is [string]) {
-              $text = $Value.Trim().ToLowerInvariant()
-              switch ($text) {
-                'true' { return $true }
-                't' { return $true }
-                'yes' { return $true }
-                'y' { return $true }
-                '1' { return $true }
-                'false' { return $false }
-                'f' { return $false }
-                'no' { return $false }
-                'n' { return $false }
-                '0' { return $false }
-              }
-              return $null
-            }
-            if ($Value -is [int] -or $Value -is [long]) {
-              if ($Value -eq 0) { return $false }
-              if ($Value -eq 1) { return $true }
-            }
-            return $null
-          }
-
-          foreach ($file in $files) {
-            try {
-              $content = Get-Content -Raw -LiteralPath $file.FullName
-              if ([string]::IsNullOrWhiteSpace($content)) { continue }
-              $data = $content | ConvertFrom-Json -Depth 16
-              if ($null -eq $data) { continue }
-
-              $records = if ($data -is [array]) { $data } else { @($data) }
-              foreach ($record in $records) {
-                if ($null -eq $record) { continue }
-
-                $value = $null
-                if ($record.PSObject.Properties.Name -contains 'has_failures') {
-                  $value = Convert-ToBooleanOrNull -Value $record.has_failures
-                }
-
-                if ($record.PSObject.Properties.Name -notcontains 'source_file') {
-                  $record | Add-Member -NotePropertyName source_file -NotePropertyValue $file.FullName -Force
-                }
-
-                if ($null -eq $value) {
-                  $record | Add-Member -NotePropertyName parse_warning -NotePropertyValue 'has_failures missing or unparseable' -Force
-                } elseif ($value) {
-                  $has = $true
-                }
-
-                $lanes += $record
-              }
-            } catch {
-              $lanes += [ordered]@{
-                lane = $file.BaseName
-                error = $_.Exception.Message
-                source_file = $file.FullName
-              }
-            }
-          }
-
-          if (-not $files -and $fallback -and $fallback -ne 'success') {
-            $has = $true
-          }
-
-          $value = if ($has) { 'true' } else { 'false' }
+          $reportPath = Join-Path $env:RUNNER_TEMP 'selftest-gate.json'
+          & .\tools\aggregate_selftest_verdicts.ps1 `
+            -VerdictsDir (Join-Path $env:RUNNER_TEMP 'selftest-verdicts') `
+            -FallbackResult '${{ needs.selftest.result }}' `
+            -ExpectedLanes @('cache', 'real', 'conda-full', 'justme-test', 'uv', 'contract-uv', 'contract-uv-fail', 'uv-dl-fallback') `
+            -ReportPath $reportPath
+          $rc = $LASTEXITCODE
+          $value = if ($rc -eq 1) { 'true' } else { 'false' }
           "has_failures=$value" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding ascii -Append
-
-          $report = [ordered]@{
-            fallback_result = $fallback
-            has_failures = $has
-            lanes = @($lanes)
-            verdict_files = if ($files) { $files.FullName } else { @() }
-          }
-          $report | ConvertTo-Json -Depth 6 | Out-File -FilePath (Join-Path $env:RUNNER_TEMP 'selftest-gate.json') -Encoding utf8
 
       - name: Append gate summary
         if: ${{ always() }}

--- a/.github/workflows/batch-check.yml
+++ b/.github/workflows/batch-check.yml
@@ -3454,16 +3454,39 @@ jobs:
         # conda-full, justme-test, uv, contract-uv, contract-uv-fail, uv-dl-fallback) -- already a
         # third duplication of that list alongside the matrix include: block and the
         # continue-on-error: condition, not a new pattern.
+        # derived requirement (CodeRabbit review, PR #454, zizmor template-injection warning):
+        # needs.selftest.result is read via env: below instead of interpolated directly into this
+        # run: block -- the value itself is always one of a small fixed GitHub-defined enum
+        # ('success'/'failure'/'cancelled'/'skipped'), never attacker-controlled free text, but
+        # routing it through env: avoids the generic pattern zizmor flags entirely rather than
+        # arguing the specific case is safe.
+        env:
+          HP_SELFTEST_RESULT: ${{ needs.selftest.result }}
         run: |
           $reportPath = Join-Path $env:RUNNER_TEMP 'selftest-gate.json'
           & .\tools\aggregate_selftest_verdicts.ps1 `
             -VerdictsDir (Join-Path $env:RUNNER_TEMP 'selftest-verdicts') `
-            -FallbackResult '${{ needs.selftest.result }}' `
+            -FallbackResult $env:HP_SELFTEST_RESULT `
             -ExpectedLanes @('cache', 'real', 'conda-full', 'justme-test', 'uv', 'contract-uv', 'contract-uv-fail', 'uv-dl-fallback') `
             -ReportPath $reportPath
           $rc = $LASTEXITCODE
           $value = if ($rc -eq 1) { 'true' } else { 'false' }
           "has_failures=$value" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding ascii -Append
+
+          # derived requirement (CodeRabbit review, PR #454): the gate's own verdict was
+          # previously observable only via the job summary/raw report, with no NDJSON row --
+          # this repo's own coding guideline requires "New observable logs, files, artifacts, or
+          # behavior require an NDJSON row." Named to match the ci_test_results-* wildcard
+          # publish_diag's own "Download CI NDJSON artifacts" step already uses (see
+          # ndjson-registry-check's own precedent immediately below in this file), so it lands on
+          # the diagnostics site with zero new download-step wiring.
+          $gateRow = [ordered]@{
+            id      = 'diag.selftest_gate.verdict'
+            pass    = ($rc -ne 1)
+            desc    = 'selftest-gate: aggregate self-test verdict across all matrix lanes'
+            details = [ordered]@{ has_failures = ($rc -eq 1); exit_code = $rc; fallback_result = $env:HP_SELFTEST_RESULT }
+          } | ConvertTo-Json -Compress -Depth 8
+          $gateRow | Out-File -FilePath 'ci_test_results.ndjson' -Encoding ascii -Append
 
       - name: Append gate summary
         if: ${{ always() }}
@@ -3490,6 +3513,21 @@ jobs:
         with:
           name: selftest-gate-report-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ runner.temp }}/selftest-gate.json
+          if-no-files-found: warn
+          retention-days: 7
+
+      # derived requirement (CodeRabbit review, PR #454): uploads the diag.selftest_gate.verdict
+      # NDJSON row (emitted above) as its own artifact -- named to match the ci_test_results-*
+      # wildcard pattern publish_diag's "Download CI NDJSON artifacts" step already uses, so it
+      # lands in _artifacts/batch-check/_ci_artifacts/ alongside the per-lane NDJSON files with
+      # zero new download-step wiring, mirroring ndjson-registry-check's own identical precedent
+      # a few jobs below in this same file.
+      - name: Upload gate NDJSON row
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: ci_test_results-selftest-gate-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ci_test_results.ndjson
           if-no-files-found: warn
           retention-days: 7
 

--- a/.github/workflows/batch-check.yml
+++ b/.github/workflows/batch-check.yml
@@ -3470,7 +3470,18 @@ jobs:
             -ExpectedLanes @('cache', 'real', 'conda-full', 'justme-test', 'uv', 'contract-uv', 'contract-uv-fail', 'uv-dl-fallback') `
             -ReportPath $reportPath
           $rc = $LASTEXITCODE
-          $value = if ($rc -eq 1) { 'true' } else { 'false' }
+          # derived requirement (CodeRabbit review, PR #454): treat anything OTHER than a clean
+          # exit 0 as has_failures=true, not just the script's own documented exit 1. Aggregate_
+          # selftest_verdicts.ps1 only ever exits 0 or 1 by its own contract, but the INVOCATION
+          # itself can fail before that contract even applies -- e.g. a bad path/parameter binding
+          # error from the call operator (&) is typically non-terminating under this shell's
+          # default $ErrorActionPreference, so execution would continue past it with $LASTEXITCODE
+          # left at whatever it was BEFORE this line (commonly $null, since this is the step's
+          # first command) -- the old "-eq 1" check silently classified that as has_failures=false
+          # (fail OPEN: the aggregator never ran, but the gate reported clean). "$rc -ne 0" instead
+          # (with $null -ne 0 evaluating true) fails CLOSED on any anomaly, not just the one
+          # documented failure code.
+          $value = if ($rc -eq 0) { 'false' } else { 'true' }
           "has_failures=$value" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding ascii -Append
 
           # derived requirement (CodeRabbit review, PR #454): the gate's own verdict was
@@ -3482,9 +3493,9 @@ jobs:
           # the diagnostics site with zero new download-step wiring.
           $gateRow = [ordered]@{
             id      = 'diag.selftest_gate.verdict'
-            pass    = ($rc -ne 1)
+            pass    = ($rc -eq 0)
             desc    = 'selftest-gate: aggregate self-test verdict across all matrix lanes'
-            details = [ordered]@{ has_failures = ($rc -eq 1); exit_code = $rc; fallback_result = $env:HP_SELFTEST_RESULT }
+            details = [ordered]@{ has_failures = ($rc -ne 0); exit_code = $rc; fallback_result = $env:HP_SELFTEST_RESULT }
           } | ConvertTo-Json -Compress -Depth 8
           $gateRow | Out-File -FilePath 'ci_test_results.ndjson' -Encoding ascii -Append
 

--- a/.github/workflows/batch-check.yml
+++ b/.github/workflows/batch-check.yml
@@ -3488,6 +3488,22 @@ jobs:
           } | ConvertTo-Json -Compress -Depth 8
           $gateRow | Out-File -FilePath 'ci_test_results.ndjson' -Encoding ascii -Append
 
+          # derived requirement (CodeRabbit review, PR #454): explicitly reset the step's own
+          # exit status. GitHub Actions appends its own "exit $LASTEXITCODE" to every pwsh run:
+          # block; aggregate_selftest_verdicts.ps1 is invoked via the call operator (&), so a
+          # has_failures=true run leaves $LASTEXITCODE at 1 with nothing after it to clear that --
+          # every later line here (string building, Out-File) is pure PowerShell and never
+          # touches $LASTEXITCODE. Without this, the step (and therefore this job's own
+          # conclusion) would silently start failing on real has_failures=true evidence today,
+          # even though CLAUDE.md Active Backlog Item 35's own process discipline is explicit that
+          # making selftest-gate's conclusion fail for real is a SEPARATE, not-yet-taken next
+          # step (its own future "if has_failures: exit 1" addition, only after this mechanism has
+          # soaked and is added to branch protection) -- not an accidental side effect of this
+          # precondition slice. steps.aggregate.outputs.has_failures (set above via
+          # $env:GITHUB_OUTPUT) already carries the real verdict to model-quick-fix regardless of
+          # this step's own exit code.
+          exit 0
+
       - name: Append gate summary
         if: ${{ always() }}
         shell: pwsh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -640,6 +640,29 @@ but several represent real gaps worth closing before calling the path fully rele
      promotion without closing it first would just relocate a false-green risk instead of
      removing one.
 
+     **Implemented, NOT YET CONFIRMED via a real CI run.** The aggregation logic was extracted
+     from `selftest-gate`'s inline "Aggregate verdicts" step into `tools/aggregate_selftest_
+     verdicts.ps1` (mirroring `tools/ci_cache_selfheal.ps1`'s own extraction, Item 19), which now
+     compares the SET of expected lane IDs (hardcoded to match the matrix's own 8-mode `include:`
+     list, alongside its two pre-existing duplications there) against the SET of observed lane
+     IDs (each verdict record's own `lane` field, falling back to the containing artifact
+     directory's name when absent) and flags any missing, unexpected, or duplicate lane as
+     `has_failures=true` -- independent of `needs.selftest.result`, closing the exact blind spot
+     described above. A new regression test, `tests/test_aggregate_selftest_verdicts.ps1`
+     (wired into `real`, a GATING lane, mirroring `test_ci_cache_selfheal.ps1`'s own precedent),
+     exercises all three required shapes plus three more (a genuine per-lane failure still
+     detected, the original healthy case, and the "zero files with a `success` fallback" case
+     that proves the new check no longer depends on the fallback result at all) against fixture
+     directories built to mimic `actions/download-artifact@v6`'s own output layout -- verified
+     directly with a local `pwsh` run before ever reaching real CI (this script has no Windows-
+     specific dependency, unlike its `ci_cache_selfheal.ps1` sibling, so local verification on a
+     non-Windows sandbox was actually possible here). Still open: confirm the new gating test
+     passes on the real `real`-lane run, and re-verify `selftest-gate`'s own "Append gate summary"
+     step still renders correctly with the report's new `lane_check` section. The actual
+     `exit 1`-on-`has_failures` step for `selftest-gate` itself (the change that makes this job's
+     own conclusion fail for real) is a SEPARATE, not-yet-taken next step -- this slice is scoped
+     to the precondition only, per the item's own "one lane or row per slice" discipline.
+
   **Process discipline -- read this before touching anything:**
   1. **One lane or row per slice.** Do not attempt a blanket "flip everything to gating" change.
      Each slice: (a) confirm the underlying mechanism is genuinely real and demonstrably

--- a/docs/agent-lessons-learned.md
+++ b/docs/agent-lessons-learned.md
@@ -1018,6 +1018,43 @@ step without doing this check first.
 
 ---
 
+## A `pwsh` `run:` block's own final `$LASTEXITCODE` becomes the step's exit code, even after later PowerShell-only lines
+
+**Found via CodeRabbit's review of PR #454 (`selftest-gate`'s "Aggregate verdicts" step),
+confirmed with a real local `pwsh` repro before trusting the finding.** GitHub Actions appends
+its own `exit $LASTEXITCODE` to the very end of every `pwsh`-shell `run:` block (documented
+runner behavior, not undocumented cmd.exe-style folklore this repo usually has to reverse
+-engineer). If the block invokes an external script via the call operator (`& .\foo.ps1 ...`)
+that exits non-zero, `$LASTEXITCODE` is set to that value and **stays there** through any number
+of later PURE-PowerShell lines (`Out-File`, string interpolation, `ConvertTo-Json`, etc. never
+touch it) -- so the step (and therefore the job's own conclusion) silently fails on the
+script's exit code even when the block's author only meant to capture and act on that exit code
+programmatically, not propagate it as the step's own result.
+
+Bit `selftest-gate`'s "Aggregate verdicts" step exactly this way: `tools/aggregate_selftest_
+verdicts.ps1` (CLAUDE.md Active Backlog Item 35's own "Precondition" fix) correctly `exit 1`s on
+`has_failures=true` by design (the caller reads `$LASTEXITCODE` to set `steps.aggregate.outputs.
+has_failures`), but with nothing to reset it afterward, the step itself started failing on real
+`has_failures=true` evidence immediately -- even though that PR's own stated scope explicitly
+deferred making `selftest-gate`'s conclusion fail for real to a separate, not-yet-taken future
+step. This is exactly why the "Aggregate self-test verdicts" job appeared to fail on a real PR
+commit before that gating step was ever intentionally added.
+
+**Fix: end the `run:` block with an explicit `exit 0`** (or reset `$LASTEXITCODE` to 0) whenever
+a step captures and acts on an external script's/command's exit code without wanting THAT to
+become the step's own result. Verified locally (not just reasoned about): a script that `exit
+1`s, captured into a variable, followed by unrelated `Out-File` work, followed by an explicit
+`exit 0`, reliably makes the outer process see exit code 0.
+
+**Rule of thumb for any future `run:` block using `pwsh`/`powershell`**: the moment you invoke an
+external script/exe via `&` (or any native command) and capture `$LASTEXITCODE` to branch on
+programmatically -- rather than letting that failure genuinely fail the step -- explicitly
+control the step's own final exit status at the end of the block. Do not assume "the script's
+result is just a variable I read" is enough; GitHub Actions' own runner script generation reads
+`$LASTEXITCODE` at the very end regardless of what happened in between.
+
+---
+
 ## Heuristic dep-augmentation (HP_PREP_REQUIREMENTS): pandas[excel] extras syntax
 
 The `names_lower` list is built from `pip_specs` by splitting at version specifier chars

--- a/docs/agent-ndjson.md
+++ b/docs/agent-ndjson.md
@@ -1052,7 +1052,8 @@ verified locally before ever reaching real CI.
 self.ci.aggregate_selftest_verdicts.healthy, self.ci.aggregate_selftest_verdicts.lane_failed,
 self.ci.aggregate_selftest_verdicts.missing_lane, self.ci.aggregate_selftest_verdicts.unexpected_lane,
 self.ci.aggregate_selftest_verdicts.duplicate_lane, self.ci.aggregate_selftest_verdicts.empty_fallback,
-self.ci.aggregate_selftest_verdicts.malformed_json, self.ci.aggregate_selftest_verdicts.missing_field
+self.ci.aggregate_selftest_verdicts.malformed_json, self.ci.aggregate_selftest_verdicts.missing_field,
+diag.selftest_gate.verdict
 ```
 
 `diag.selftest_gate.verdict` (inline `batch-check.yml`, the `selftest-gate` job's own "Aggregate

--- a/docs/agent-ndjson.md
+++ b/docs/agent-ndjson.md
@@ -1010,6 +1010,44 @@ over time instead of requiring a raw-log dig to notice it happened at all, not t
 
 ---
 
+## selfapps-aggregate-selftest-verdicts NDJSON rows (test_aggregate_selftest_verdicts.ps1, `real` lane only, GATING)
+
+CLAUDE.md Active Backlog Item 35's own "Precondition" caveat: the `selftest-gate` job's
+"Aggregate verdicts" step previously only treated a TOTAL absence of `lane_verdict.json` files
+(zero lanes reporting) as a failure signal -- a single lane's own verdict artifact silently
+missing (upload glitch, artifact-service hiccup) while the other 7 lanes' artifacts landed fine
+was invisible, and an unexpected or duplicate lane landing alongside a genuinely missing one could
+make a raw file-COUNT check pass even with one real lane's evidence absent. The aggregation logic
+was extracted to `tools/aggregate_selftest_verdicts.ps1` (mirroring `tools/ci_cache_selfheal.ps1`'s
+own extraction, see the section directly above) so this test can exercise it deterministically
+against fixture directories built to mimic exactly what `actions/download-artifact@v6` produces
+(each artifact under its own `<VerdictsDir>/selftest-verdict-<lane>/lane_verdict.json`
+subdirectory), with no dependency on a real 8-lane matrix run. Wired into `real` -- a GATING lane
+-- so a regression in the aggregation logic itself fails CI on every run, not just when a real
+artifact happens to go missing/duplicated/unexpected that day.
+
+Six scenarios: `healthy` (all 8 expected lanes present once, none failing -> pass), `lane_failed`
+(a genuine per-lane `has_failures:true` is still detected -- regression guard for the
+pre-existing, unchanged union behavior), `missing_lane` (7 of 8 lanes present -- the actual gap
+this item closes, since the ORIGINAL inline logic had no way to detect a partial miss at all),
+`unexpected_lane` (an extra lane not in the matrix's own mode list), `duplicate_lane` (one lane's
+verdict uploaded twice under two differently-named artifact directories, both claiming the same
+`lane` field inside their JSON), and `empty_fallback` (zero verdict files with
+`FallbackResult='success'` -- proves the new lane-set check fires independent of the fallback
+result, unlike the OLD behavior which only fired here when the fallback result was NOT
+`'success'`). Deliberately NOT gated on `$IsWindows` (unlike `test_ci_cache_selfheal.ps1`'s own
+Windows-only skip) -- the script under test is pure PowerShell (JSON parsing and file I/O only,
+no `cmd.exe`/Windows-specific calls), so it runs identically under `pwsh` on Linux or Windows and
+was directly verified locally before ever reaching real CI.
+
+```
+self.ci.aggregate_selftest_verdicts.healthy, self.ci.aggregate_selftest_verdicts.lane_failed,
+self.ci.aggregate_selftest_verdicts.missing_lane, self.ci.aggregate_selftest_verdicts.unexpected_lane,
+self.ci.aggregate_selftest_verdicts.duplicate_lane, self.ci.aggregate_selftest_verdicts.empty_fallback
+```
+
+---
+
 ## selfapps-lineending-check NDJSON rows (selfapps_lineending_check.ps1, real/conda-full lanes, GATING)
 
 CLAUDE.md Active Backlog Item 44's own "Known gap": the line-ending self-check at the top of

--- a/docs/agent-ndjson.md
+++ b/docs/agent-ndjson.md
@@ -1026,25 +1026,47 @@ subdirectory), with no dependency on a real 8-lane matrix run. Wired into `real`
 -- so a regression in the aggregation logic itself fails CI on every run, not just when a real
 artifact happens to go missing/duplicated/unexpected that day.
 
-Six scenarios: `healthy` (all 8 expected lanes present once, none failing -> pass), `lane_failed`
-(a genuine per-lane `has_failures:true` is still detected -- regression guard for the
-pre-existing, unchanged union behavior), `missing_lane` (7 of 8 lanes present -- the actual gap
-this item closes, since the ORIGINAL inline logic had no way to detect a partial miss at all),
-`unexpected_lane` (an extra lane not in the matrix's own mode list), `duplicate_lane` (one lane's
-verdict uploaded twice under two differently-named artifact directories, both claiming the same
-`lane` field inside their JSON), and `empty_fallback` (zero verdict files with
-`FallbackResult='success'` -- proves the new lane-set check fires independent of the fallback
-result, unlike the OLD behavior which only fired here when the fallback result was NOT
-`'success'`). Deliberately NOT gated on `$IsWindows` (unlike `test_ci_cache_selfheal.ps1`'s own
-Windows-only skip) -- the script under test is pure PowerShell (JSON parsing and file I/O only,
-no `cmd.exe`/Windows-specific calls), so it runs identically under `pwsh` on Linux or Windows and
-was directly verified locally before ever reaching real CI.
+Eight scenarios: `healthy` (all 8 expected lanes present once, none failing -> pass; one lane's
+own record deliberately omits the `lane` field entirely, proving the artifact-directory-name
+fallback path -- added after a CodeRabbit review round on PR #454 pointed out the original 6
+scenarios never exercised that fallback), `lane_failed` (a genuine per-lane `has_failures:true`
+is still detected -- regression guard for the pre-existing, unchanged union behavior),
+`missing_lane` (7 of 8 lanes present -- the actual gap this item closes, since the ORIGINAL
+inline logic had no way to detect a partial miss at all), `unexpected_lane` (an extra lane not in
+the matrix's own mode list), `duplicate_lane` (one lane's verdict uploaded twice under two
+differently-named artifact directories, both claiming the same `lane` field inside their JSON),
+`empty_fallback` (zero verdict files with `FallbackResult='success'` -- proves the new lane-set
+check fires independent of the fallback result, unlike the OLD behavior which only fired here
+when the fallback result was NOT `'success'`), `malformed_json` (one lane's `lane_verdict.json`
+is not valid JSON at all), and `missing_field` (one lane's record is valid JSON but has no
+`has_failures` field). The last two (also added via the same PR #454 review round) close a
+second real gap: a parse failure or a missing `has_failures` value previously only added a
+`parse_warning` annotation without ever setting `has_failures=true` -- silently treated as
+passing evidence instead of "we don't have confirmed-good evidence for this lane." Deliberately
+NOT gated on `$IsWindows` (unlike `test_ci_cache_selfheal.ps1`'s own Windows-only skip) -- the
+script under test is pure PowerShell (JSON parsing and file I/O only, no `cmd.exe`/
+Windows-specific calls), so it runs identically under `pwsh` on Linux or Windows and was directly
+verified locally before ever reaching real CI.
 
 ```
 self.ci.aggregate_selftest_verdicts.healthy, self.ci.aggregate_selftest_verdicts.lane_failed,
 self.ci.aggregate_selftest_verdicts.missing_lane, self.ci.aggregate_selftest_verdicts.unexpected_lane,
-self.ci.aggregate_selftest_verdicts.duplicate_lane, self.ci.aggregate_selftest_verdicts.empty_fallback
+self.ci.aggregate_selftest_verdicts.duplicate_lane, self.ci.aggregate_selftest_verdicts.empty_fallback,
+self.ci.aggregate_selftest_verdicts.malformed_json, self.ci.aggregate_selftest_verdicts.missing_field
 ```
+
+`diag.selftest_gate.verdict` (inline `batch-check.yml`, the `selftest-gate` job's own "Aggregate
+verdicts" step) is the companion VISIBILITY row for the AMBIENT gate's own real outcome each run
+-- unlike the deterministic fixture-based test above, this fires exactly once per real CI run and
+records whether `tools/aggregate_selftest_verdicts.ps1` found `has_failures=true` against that
+run's own genuine 8-lane artifacts (`details.has_failures`/`details.exit_code`/
+`details.fallback_result`). Uploaded as its own artifact
+(`ci_test_results-selftest-gate-<run>-<attempt>`), named to match the `ci_test_results-*`
+wildcard `publish_diag`'s "Download CI NDJSON artifacts" step already uses (see
+`ndjson-registry-check`'s own identical precedent), so it reaches the diagnostics site with no
+new download-step wiring. Added the same PR #454 review round, closing this repo's own coding
+guideline ("New observable logs, files, artifacts, or behavior require an NDJSON row") for the
+gate's own verdict, which previously was observable only via the ephemeral job-summary page.
 
 ---
 

--- a/tests/test_aggregate_selftest_verdicts.ps1
+++ b/tests/test_aggregate_selftest_verdicts.ps1
@@ -14,7 +14,7 @@
 # precedent for tools/ci_cache_selfheal.ps1 (see that file and docs/agent-closed-backlog.md's
 # Item 19 entry).
 #
-# Six scenarios, all against fake lane_verdict.json fixtures (never real matrix-lane output):
+# Eight scenarios, all against fake lane_verdict.json fixtures (never real matrix-lane output):
 #   healthy          - all 8 expected lanes present exactly once, all has_failures:false ->
 #                       exit 0.
 #   lane_failed       - all 8 expected lanes present, but ONE genuinely reports
@@ -32,6 +32,14 @@
 #                       new lane-set check fires independent of the fallback result (a genuine
 #                       improvement over the OLD behavior, which only fired here when
 #                       FallbackResult was NOT 'success') -> exit 1.
+#   malformed_json    - all 8 expected lanes present, but ONE lane's lane_verdict.json is not
+#                       valid JSON at all (a corrupted/truncated write) -> exit 1 (CodeRabbit
+#                       review, PR #454: a parse failure is itself evidence something went wrong
+#                       for that lane and must not silently pass just because the lane was
+#                       technically "observed" via its artifact directory name).
+#   missing_field     - all 8 expected lanes present, valid JSON, but ONE lane's record has no
+#                       has_failures field at all -> exit 1 (CodeRabbit review, PR #454: missing
+#                       or unparseable evidence is not confirmed-good evidence).
 param()
 $ErrorActionPreference = 'Continue'
 $here = $PSScriptRoot
@@ -219,6 +227,59 @@ Write-NdjsonRow ([ordered]@{
     details=[ordered]@{ exitCode=$rc6 }
 })
 if (-not $pass6) { $allPass = $false }
+
+# --- Scenario 7: a lane's verdict file is not valid JSON at all ---
+$dir7 = Join-Path $scratchRoot 'malformed_json'
+$report7 = Join-Path $scratchRoot 'malformed_json_report.json'
+New-VerdictFixture -Dir $dir7
+foreach ($lane in $expectedLanes) {
+    if ($lane -eq 'uv') { continue }
+    Add-VerdictRecord -Dir $dir7 -ArtifactLane $lane -RecordLane $lane -HasFailures $false
+}
+$uvDir7 = Join-Path $dir7 'selftest-verdict-uv'
+New-Item -ItemType Directory -Force -Path $uvDir7 | Out-Null
+Set-Content -LiteralPath (Join-Path $uvDir7 'lane_verdict.json') -Value '{not valid json' -Encoding Ascii
+$rc7 = Invoke-Aggregate -VerdictsDir $dir7 -FallbackResult 'success' -ReportPath $report7
+$pass7 = $false
+if ($rc7 -eq 1 -and (Test-Path -LiteralPath $report7)) {
+    $reportData7 = Get-Content -Raw -LiteralPath $report7 | ConvertFrom-Json
+    # derived requirement: the malformed file's lane ('uv') must still be attributed via its
+    # artifact directory name (not counted as missing -- it WAS observed), while has_failures
+    # must still read true overall because a parse failure is not confirmed-good evidence.
+    $pass7 = ($reportData7.has_failures -eq $true) -and (-not ($reportData7.lane_check.missing_lanes -contains 'uv'))
+}
+Write-NdjsonRow ([ordered]@{
+    id='self.ci.aggregate_selftest_verdicts.malformed_json'; pass=$pass7
+    desc='aggregate_selftest_verdicts.ps1: a lane whose verdict file is not valid JSON is treated as a failure, not silently skipped'
+    details=[ordered]@{ exitCode=$rc7 }
+})
+if (-not $pass7) { $allPass = $false }
+
+# --- Scenario 8: a lane's verdict record has no has_failures field at all ---
+$dir8 = Join-Path $scratchRoot 'missing_field'
+$report8 = Join-Path $scratchRoot 'missing_field_report.json'
+New-VerdictFixture -Dir $dir8
+foreach ($lane in $expectedLanes) {
+    if ($lane -eq 'justme-test') { continue }
+    Add-VerdictRecord -Dir $dir8 -ArtifactLane $lane -RecordLane $lane -HasFailures $false
+}
+$jtDir8 = Join-Path $dir8 'selftest-verdict-justme-test'
+New-Item -ItemType Directory -Force -Path $jtDir8 | Out-Null
+# derived requirement: a genuinely valid JSON record, just missing the has_failures field
+# entirely -- distinct from Scenario 7's totally-unparseable case.
+'{"lane":"justme-test","run_id":"999999"}' | Out-File -FilePath (Join-Path $jtDir8 'lane_verdict.json') -Encoding ascii
+$rc8 = Invoke-Aggregate -VerdictsDir $dir8 -FallbackResult 'success' -ReportPath $report8
+$pass8 = $false
+if ($rc8 -eq 1 -and (Test-Path -LiteralPath $report8)) {
+    $reportData8 = Get-Content -Raw -LiteralPath $report8 | ConvertFrom-Json
+    $pass8 = ($reportData8.has_failures -eq $true) -and (-not ($reportData8.lane_check.missing_lanes -contains 'justme-test'))
+}
+Write-NdjsonRow ([ordered]@{
+    id='self.ci.aggregate_selftest_verdicts.missing_field'; pass=$pass8
+    desc='aggregate_selftest_verdicts.ps1: a lane whose record has no has_failures field is treated as a failure, not silently skipped'
+    details=[ordered]@{ exitCode=$rc8 }
+})
+if (-not $pass8) { $allPass = $false }
 
 Remove-Item -LiteralPath $scratchRoot -Recurse -Force -ErrorAction SilentlyContinue
 

--- a/tests/test_aggregate_selftest_verdicts.ps1
+++ b/tests/test_aggregate_selftest_verdicts.ps1
@@ -1,0 +1,226 @@
+# ASCII only
+# test_aggregate_selftest_verdicts.ps1 - deterministic regression test for
+# tools/aggregate_selftest_verdicts.ps1 (the selftest-gate "Aggregate verdicts" logic,
+# CLAUDE.md Active Backlog Item 35's "Precondition" caveat).
+#
+# Unlike a real batch-check.yml run (which would need all 8 matrix lanes to actually finish and
+# upload their own lane_verdict.json artifacts before the aggregation step ever runs), this test
+# exercises the extracted script directly against fixture directories built to mimic exactly what
+# actions/download-artifact@v6 produces (each artifact under its own
+# <VerdictsDir>/selftest-verdict-<lane>/lane_verdict.json subdirectory, no merge-multiple) -- no
+# dependency on a real CI run or real artifact upload/download round trip. Wired into the `real`
+# lane (a GATING lane, not in the job-level continue-on-error list) so a regression in the
+# aggregation logic itself actually fails CI, mirroring tests/test_ci_cache_selfheal.ps1's own
+# precedent for tools/ci_cache_selfheal.ps1 (see that file and docs/agent-closed-backlog.md's
+# Item 19 entry).
+#
+# Six scenarios, all against fake lane_verdict.json fixtures (never real matrix-lane output):
+#   healthy          - all 8 expected lanes present exactly once, all has_failures:false ->
+#                       exit 0.
+#   lane_failed       - all 8 expected lanes present, but ONE genuinely reports
+#                       has_failures:true -> exit 1 (regression-guard for the pre-existing,
+#                       unchanged per-lane has_failures union behavior).
+#   missing_lane      - only 7 of 8 expected lanes present (one never uploaded) -> exit 1 (the
+#                       actual gap this item's Precondition caveat closes -- the ORIGINAL inline
+#                       logic could not detect this at all, since $files was non-empty).
+#   unexpected_lane   - all 8 expected lanes present PLUS one lane not in the expected set -> exit
+#                       1.
+#   duplicate_lane    - all 8 expected lanes present, but ONE lane's verdict was uploaded twice
+#                       (two separate artifact directories, same "lane" field inside the JSON) ->
+#                       exit 1.
+#   empty_fallback    - no verdict directory at all, with FallbackResult='success' -- proves the
+#                       new lane-set check fires independent of the fallback result (a genuine
+#                       improvement over the OLD behavior, which only fired here when
+#                       FallbackResult was NOT 'success') -> exit 1.
+param()
+$ErrorActionPreference = 'Continue'
+$here = $PSScriptRoot
+$repo = Split-Path -Path $here -Parent
+$script = Join-Path $repo 'tools/aggregate_selftest_verdicts.ps1'
+$nd   = Join-Path $here '~test-results.ndjson'
+$ciNd = Join-Path $repo 'ci_test_results.ndjson'
+if (-not (Test-Path $nd))   { New-Item -ItemType File -Path $nd   -Force | Out-Null }
+if (-not (Test-Path $ciNd)) { New-Item -ItemType File -Path $ciNd -Force | Out-Null }
+
+function Write-NdjsonRow {
+    param([hashtable]$Row)
+    $lane = [Environment]::GetEnvironmentVariable('HP_CI_LANE')
+    if ($lane -and -not $Row.ContainsKey('lane')) { $Row['lane'] = $lane }
+    $json = $Row | ConvertTo-Json -Compress -Depth 8
+    Add-Content -LiteralPath $nd   -Value $json -Encoding Ascii
+    Add-Content -LiteralPath $ciNd -Value $json -Encoding Ascii
+}
+
+# derived requirement: unlike tests/test_ci_cache_selfheal.ps1 (which genuinely shells out to
+# conda.bat via cmd.exe and needs real Windows file-locking semantics), the script under test
+# here is pure PowerShell -- JSON parsing and plain file I/O only, no OS-specific calls. It runs
+# identically under pwsh on Linux or Windows, so this test deliberately does NOT skip on
+# non-Windows -- doing so would only lose local pre-push verification for no real safety benefit
+# (this repo's own CI still only runs Windows runners regardless).
+
+$expectedLanes = @('cache', 'real', 'conda-full', 'justme-test', 'uv', 'contract-uv', 'contract-uv-fail', 'uv-dl-fallback')
+
+function New-VerdictFixture {
+    # derived requirement: build a fresh, empty VerdictsDir for each scenario -- fixtures must
+    # never leak between scenarios, or a missing-lane scenario could accidentally "see" a lane
+    # directory left over from a prior scenario and pass for the wrong reason.
+    param([string]$Dir)
+    if (Test-Path -LiteralPath $Dir) { Remove-Item -LiteralPath $Dir -Recurse -Force -ErrorAction SilentlyContinue }
+    New-Item -ItemType Directory -Force -Path $Dir | Out-Null
+}
+
+function Add-VerdictRecord {
+    # derived requirement: $ArtifactLane names the FOLDER (mimicking the artifact name
+    # download-artifact@v6 creates); $RecordLane is the "lane" field written INSIDE the JSON --
+    # kept as separate parameters (usually equal) so the duplicate_lane scenario can construct
+    # two differently-NAMED folders that both claim the SAME record lane, exactly like a real
+    # double-upload would look once downloaded.
+    param([string]$Dir, [string]$ArtifactLane, [string]$RecordLane, [bool]$HasFailures)
+    $artifactDir = Join-Path $Dir "selftest-verdict-$ArtifactLane"
+    New-Item -ItemType Directory -Force -Path $artifactDir | Out-Null
+    $record = [ordered]@{
+        lane = $RecordLane
+        has_failures = $HasFailures
+        raw = $HasFailures.ToString().ToLowerInvariant()
+        run_id = '999999'
+        run_attempt = '1'
+        sources = @('tests~test-results.ndjson', 'ci_test_results.ndjson')
+    }
+    $record | ConvertTo-Json -Compress -Depth 8 | Out-File -FilePath (Join-Path $artifactDir 'lane_verdict.json') -Encoding ascii
+}
+
+function Invoke-Aggregate {
+    param([string]$VerdictsDir, [string]$FallbackResult, [string]$ReportPath)
+    & $script -VerdictsDir $VerdictsDir -FallbackResult $FallbackResult -ExpectedLanes $expectedLanes -ReportPath $ReportPath
+    return $LASTEXITCODE
+}
+
+$scratchRoot = Join-Path $here '~selftest_aggregate_verdicts'
+if (Test-Path -LiteralPath $scratchRoot) { Remove-Item -LiteralPath $scratchRoot -Recurse -Force }
+New-Item -ItemType Directory -Force -Path $scratchRoot | Out-Null
+
+$allPass = $true
+
+# --- Scenario 1: healthy ---
+$dir1 = Join-Path $scratchRoot 'healthy'
+$report1 = Join-Path $scratchRoot 'healthy_report.json'
+New-VerdictFixture -Dir $dir1
+foreach ($lane in $expectedLanes) { Add-VerdictRecord -Dir $dir1 -ArtifactLane $lane -RecordLane $lane -HasFailures $false }
+$rc1 = Invoke-Aggregate -VerdictsDir $dir1 -FallbackResult 'success' -ReportPath $report1
+$pass1 = ($rc1 -eq 0) -and (Test-Path -LiteralPath $report1)
+Write-NdjsonRow ([ordered]@{
+    id='self.ci.aggregate_selftest_verdicts.healthy'; pass=$pass1
+    desc='aggregate_selftest_verdicts.ps1: all 8 expected lanes present exactly once, none failing -> has_failures false'
+    details=[ordered]@{ exitCode=$rc1 }
+})
+if (-not $pass1) { $allPass = $false }
+
+# --- Scenario 2: one lane genuinely fails ---
+$dir2 = Join-Path $scratchRoot 'lane_failed'
+$report2 = Join-Path $scratchRoot 'lane_failed_report.json'
+New-VerdictFixture -Dir $dir2
+foreach ($lane in $expectedLanes) {
+    $failed = ($lane -eq 'real')
+    Add-VerdictRecord -Dir $dir2 -ArtifactLane $lane -RecordLane $lane -HasFailures $failed
+}
+$rc2 = Invoke-Aggregate -VerdictsDir $dir2 -FallbackResult 'success' -ReportPath $report2
+$pass2 = ($rc2 -eq 1)
+Write-NdjsonRow ([ordered]@{
+    id='self.ci.aggregate_selftest_verdicts.lane_failed'; pass=$pass2
+    desc='aggregate_selftest_verdicts.ps1: a genuine per-lane has_failures:true is still detected (regression guard for the pre-existing behavior)'
+    details=[ordered]@{ exitCode=$rc2 }
+})
+if (-not $pass2) { $allPass = $false }
+
+# --- Scenario 3: a lane never uploaded at all ---
+# derived requirement: this is the actual gap Item 35's Precondition caveat closes -- the
+# ORIGINAL inline aggregation logic had no way to detect this at all, since $files was non-empty
+# (7 of 8 lanes still landed fine) and no individual record reported has_failures:true.
+$dir3 = Join-Path $scratchRoot 'missing_lane'
+$report3 = Join-Path $scratchRoot 'missing_lane_report.json'
+New-VerdictFixture -Dir $dir3
+foreach ($lane in $expectedLanes) {
+    if ($lane -eq 'contract-uv-fail') { continue }
+    Add-VerdictRecord -Dir $dir3 -ArtifactLane $lane -RecordLane $lane -HasFailures $false
+}
+$rc3 = Invoke-Aggregate -VerdictsDir $dir3 -FallbackResult 'success' -ReportPath $report3
+$pass3 = $false
+if ($rc3 -eq 1 -and (Test-Path -LiteralPath $report3)) {
+    $reportData3 = Get-Content -Raw -LiteralPath $report3 | ConvertFrom-Json
+    $pass3 = ($reportData3.lane_check.missing_lanes -contains 'contract-uv-fail')
+}
+Write-NdjsonRow ([ordered]@{
+    id='self.ci.aggregate_selftest_verdicts.missing_lane'; pass=$pass3
+    desc='aggregate_selftest_verdicts.ps1: a single missing lane (7 of 8 present) is detected and named in the report -- the ORIGINAL inline logic could not see this at all'
+    details=[ordered]@{ exitCode=$rc3 }
+})
+if (-not $pass3) { $allPass = $false }
+
+# --- Scenario 4: an unexpected extra lane ---
+$dir4 = Join-Path $scratchRoot 'unexpected_lane'
+$report4 = Join-Path $scratchRoot 'unexpected_lane_report.json'
+New-VerdictFixture -Dir $dir4
+foreach ($lane in $expectedLanes) { Add-VerdictRecord -Dir $dir4 -ArtifactLane $lane -RecordLane $lane -HasFailures $false }
+Add-VerdictRecord -Dir $dir4 -ArtifactLane 'bogus-lane' -RecordLane 'bogus-lane' -HasFailures $false
+$rc4 = Invoke-Aggregate -VerdictsDir $dir4 -FallbackResult 'success' -ReportPath $report4
+$pass4 = $false
+if ($rc4 -eq 1 -and (Test-Path -LiteralPath $report4)) {
+    $reportData4 = Get-Content -Raw -LiteralPath $report4 | ConvertFrom-Json
+    $pass4 = ($reportData4.lane_check.unexpected_lanes -contains 'bogus-lane')
+}
+Write-NdjsonRow ([ordered]@{
+    id='self.ci.aggregate_selftest_verdicts.unexpected_lane'; pass=$pass4
+    desc='aggregate_selftest_verdicts.ps1: an unexpected lane not in the matrix mode list is detected and named in the report'
+    details=[ordered]@{ exitCode=$rc4 }
+})
+if (-not $pass4) { $allPass = $false }
+
+# --- Scenario 5: a lane uploaded twice (duplicate) ---
+$dir5 = Join-Path $scratchRoot 'duplicate_lane'
+$report5 = Join-Path $scratchRoot 'duplicate_lane_report.json'
+New-VerdictFixture -Dir $dir5
+foreach ($lane in $expectedLanes) { Add-VerdictRecord -Dir $dir5 -ArtifactLane $lane -RecordLane $lane -HasFailures $false }
+# derived requirement: a SECOND, differently-named artifact directory whose JSON record still
+# claims lane 'cache' -- simulates a real double-upload (e.g. a retried step re-uploading under a
+# fresh artifact name) surviving the download step, not just a filesystem-level name collision.
+Add-VerdictRecord -Dir $dir5 -ArtifactLane 'cache-retry' -RecordLane 'cache' -HasFailures $false
+$rc5 = Invoke-Aggregate -VerdictsDir $dir5 -FallbackResult 'success' -ReportPath $report5
+$pass5 = $false
+if ($rc5 -eq 1 -and (Test-Path -LiteralPath $report5)) {
+    $reportData5 = Get-Content -Raw -LiteralPath $report5 | ConvertFrom-Json
+    $pass5 = ($reportData5.lane_check.duplicate_lanes -contains 'cache')
+}
+Write-NdjsonRow ([ordered]@{
+    id='self.ci.aggregate_selftest_verdicts.duplicate_lane'; pass=$pass5
+    desc='aggregate_selftest_verdicts.ps1: a lane whose verdict was uploaded twice is detected and named in the report'
+    details=[ordered]@{ exitCode=$rc5 }
+})
+if (-not $pass5) { $allPass = $false }
+
+# --- Scenario 6: no verdict directory at all, fallback result is 'success' ---
+# derived requirement: proves the NEW lane-set check fires regardless of FallbackResult -- the
+# OLD inline logic's own missing-artifact fallback only set has_failures=true here when
+# FallbackResult was NOT 'success'; this scenario deliberately passes 'success' to prove the new
+# check no longer depends on that value for the "zero lanes observed" case.
+$dir6 = Join-Path $scratchRoot 'empty_fallback'
+$report6 = Join-Path $scratchRoot 'empty_fallback_report.json'
+# derived requirement: VerdictsDir itself does not even exist for this scenario (simulates the
+# download step never creating the directory at all, not just an empty one) -- New-VerdictFixture
+# is deliberately NOT called here.
+$rc6 = Invoke-Aggregate -VerdictsDir $dir6 -FallbackResult 'success' -ReportPath $report6
+$pass6 = $false
+if ($rc6 -eq 1 -and (Test-Path -LiteralPath $report6)) {
+    $reportData6 = Get-Content -Raw -LiteralPath $report6 | ConvertFrom-Json
+    $pass6 = ($reportData6.lane_check.missing_lanes.Count -eq $expectedLanes.Count)
+}
+Write-NdjsonRow ([ordered]@{
+    id='self.ci.aggregate_selftest_verdicts.empty_fallback'; pass=$pass6
+    desc='aggregate_selftest_verdicts.ps1: zero verdict files with FallbackResult=success still reports has_failures true (all expected lanes missing), independent of the fallback result'
+    details=[ordered]@{ exitCode=$rc6 }
+})
+if (-not $pass6) { $allPass = $false }
+
+Remove-Item -LiteralPath $scratchRoot -Recurse -Force -ErrorAction SilentlyContinue
+
+if (-not $allPass) { exit 1 }
+exit 0

--- a/tests/test_aggregate_selftest_verdicts.ps1
+++ b/tests/test_aggregate_selftest_verdicts.ps1
@@ -82,18 +82,19 @@ function Add-VerdictRecord {
     # download-artifact@v6 creates); $RecordLane is the "lane" field written INSIDE the JSON --
     # kept as separate parameters (usually equal) so the duplicate_lane scenario can construct
     # two differently-NAMED folders that both claim the SAME record lane, exactly like a real
-    # double-upload would look once downloaded.
-    param([string]$Dir, [string]$ArtifactLane, [string]$RecordLane, [bool]$HasFailures)
+    # double-upload would look once downloaded. -OmitLane (CodeRabbit review, PR #454) drops the
+    # "lane" property from the JSON entirely, so aggregation must fall back to the artifact
+    # directory name alone -- a real gap in coverage the original 8 scenarios never exercised.
+    param([string]$Dir, [string]$ArtifactLane, [string]$RecordLane, [bool]$HasFailures, [switch]$OmitLane)
     $artifactDir = Join-Path $Dir "selftest-verdict-$ArtifactLane"
     New-Item -ItemType Directory -Force -Path $artifactDir | Out-Null
-    $record = [ordered]@{
-        lane = $RecordLane
-        has_failures = $HasFailures
-        raw = $HasFailures.ToString().ToLowerInvariant()
-        run_id = '999999'
-        run_attempt = '1'
-        sources = @('tests~test-results.ndjson', 'ci_test_results.ndjson')
-    }
+    $record = [ordered]@{}
+    if (-not $OmitLane) { $record.lane = $RecordLane }
+    $record.has_failures = $HasFailures
+    $record.raw = $HasFailures.ToString().ToLowerInvariant()
+    $record.run_id = '999999'
+    $record.run_attempt = '1'
+    $record.sources = @('tests~test-results.ndjson', 'ci_test_results.ndjson')
     $record | ConvertTo-Json -Compress -Depth 8 | Out-File -FilePath (Join-Path $artifactDir 'lane_verdict.json') -Encoding ascii
 }
 
@@ -113,12 +114,26 @@ $allPass = $true
 $dir1 = Join-Path $scratchRoot 'healthy'
 $report1 = Join-Path $scratchRoot 'healthy_report.json'
 New-VerdictFixture -Dir $dir1
-foreach ($lane in $expectedLanes) { Add-VerdictRecord -Dir $dir1 -ArtifactLane $lane -RecordLane $lane -HasFailures $false }
+foreach ($lane in $expectedLanes) {
+    if ($lane -eq 'uv-dl-fallback') {
+        # derived requirement (CodeRabbit review, PR #454): one lane's record deliberately omits
+        # the "lane" property entirely, so aggregation must fall back to the artifact directory
+        # name (selftest-verdict-uv-dl-fallback) alone -- a real fallback path the original 8
+        # scenarios never exercised, since every prior fixture always included "lane" explicitly.
+        Add-VerdictRecord -Dir $dir1 -ArtifactLane $lane -RecordLane $lane -HasFailures $false -OmitLane
+    } else {
+        Add-VerdictRecord -Dir $dir1 -ArtifactLane $lane -RecordLane $lane -HasFailures $false
+    }
+}
 $rc1 = Invoke-Aggregate -VerdictsDir $dir1 -FallbackResult 'success' -ReportPath $report1
-$pass1 = ($rc1 -eq 0) -and (Test-Path -LiteralPath $report1)
+$pass1 = $false
+if ($rc1 -eq 0 -and (Test-Path -LiteralPath $report1)) {
+    $reportData1 = Get-Content -Raw -LiteralPath $report1 | ConvertFrom-Json
+    $pass1 = ($reportData1.lane_check.missing_lanes.Count -eq 0) -and ($reportData1.lane_check.observed_lanes.'uv-dl-fallback' -eq 1)
+}
 Write-NdjsonRow ([ordered]@{
     id='self.ci.aggregate_selftest_verdicts.healthy'; pass=$pass1
-    desc='aggregate_selftest_verdicts.ps1: all 8 expected lanes present exactly once, none failing -> has_failures false'
+    desc='aggregate_selftest_verdicts.ps1: all 8 expected lanes present exactly once (one via artifact-directory-name fallback, no lane field in its own JSON), none failing -> has_failures false'
     details=[ordered]@{ exitCode=$rc1 }
 })
 if (-not $pass1) { $allPass = $false }

--- a/tools/aggregate_selftest_verdicts.ps1
+++ b/tools/aggregate_selftest_verdicts.ps1
@@ -108,7 +108,12 @@ foreach ($file in $files) {
             }
 
             if ($null -eq $value) {
+                # derived requirement (CodeRabbit review, PR #454): a record with no usable
+                # has_failures value is NOT confirmed-good evidence for that lane -- it must not
+                # silently count as "this lane passed." Treat it the same as a genuine failure
+                # rather than only annotating it for a human to notice later.
                 $record | Add-Member -NotePropertyName parse_warning -NotePropertyValue 'has_failures missing or unparseable' -Force
+                $has = $true
             } elseif ($value) {
                 $has = $true
             }
@@ -131,6 +136,11 @@ foreach ($file in $files) {
             $lanes += $record
         }
     } catch {
+        # derived requirement (CodeRabbit review, PR #454): a lane_verdict.json that fails to
+        # parse at all is itself evidence something went wrong for that lane (a corrupted or
+        # truncated write, for instance) -- it must not silently pass just because a lane was
+        # technically "observed" via its artifact directory name.
+        $has = $true
         $lanes += [ordered]@{
             lane = $file.BaseName
             error = $_.Exception.Message

--- a/tools/aggregate_selftest_verdicts.ps1
+++ b/tools/aggregate_selftest_verdicts.ps1
@@ -1,0 +1,192 @@
+<#
+ASCII only. Aggregates per-lane lane_verdict.json artifacts (one per matrix.mode, uploaded by
+batch-check.yml's "Upload iterate gate verdict" step) into a single has_failures verdict for the
+"Aggregate self-test verdicts" (selftest-gate) job.
+
+Extracted out of that job's inline "Aggregate verdicts" step so tests/test_aggregate_selftest_
+verdicts.ps1 can exercise it deterministically against fixture directories on every CI run --
+mirrors tools/ci_cache_selfheal.ps1's own extraction (see that file and docs/agent-closed-
+backlog.md's Item 19 entry for the precedent this follows).
+
+CLAUDE.md Active Backlog Item 35's own "Precondition" caveat: the ORIGINAL inline version's
+missing-artifact fallback only set has_failures=true when the downloaded set was EMPTY ACROSS
+ALL LANES -- a single lane's lane_verdict.json silently missing (upload glitch, artifact-service
+hiccup) while other lanes' artifacts landed fine was invisible. This version instead compares the
+SET of expected lane IDs against the SET of observed lane IDs (read from each JSON record's own
+"lane" field, falling back to the containing artifact directory's name when that field is absent)
+and treats any expected lane that's missing -- or any unexpected/duplicate lane present -- as
+has_failures=true, independent of what the overall matrix job's own result was.
+
+Exit codes:
+  0 = has_failures is false (no lane reported a real failure; every expected lane observed
+      exactly once; no unexpected lane present)
+  1 = has_failures is true (see the written report and Write-Host output for exactly why)
+
+Always writes a JSON report to -ReportPath (same shape as the original inline step's
+selftest-gate.json, with an added "lane_check" section covering the new missing/unexpected/
+duplicate detection) for the caller to surface in the job summary.
+#>
+param(
+    [Parameter(Mandatory = $true)][string]$VerdictsDir,
+    [Parameter(Mandatory = $true)][string]$FallbackResult,
+    [Parameter(Mandatory = $true)][string[]]$ExpectedLanes,
+    [Parameter(Mandatory = $true)][string]$ReportPath
+)
+
+function Convert-ToBooleanOrNull {
+    param(
+        [Parameter(Mandatory = $false)]
+        $Value
+    )
+
+    if ($null -eq $Value) { return $null }
+    if ($Value -is [bool]) { return $Value }
+    if ($Value -is [string]) {
+        $text = $Value.Trim().ToLowerInvariant()
+        switch ($text) {
+            'true' { return $true }
+            't' { return $true }
+            'yes' { return $true }
+            'y' { return $true }
+            '1' { return $true }
+            'false' { return $false }
+            'f' { return $false }
+            'no' { return $false }
+            'n' { return $false }
+            '0' { return $false }
+        }
+        return $null
+    }
+    if ($Value -is [int] -or $Value -is [long]) {
+        if ($Value -eq 0) { return $false }
+        if ($Value -eq 1) { return $true }
+    }
+    return $null
+}
+
+$files = @()
+if (Test-Path -LiteralPath $VerdictsDir) {
+    $files = Get-ChildItem -Path $VerdictsDir -Filter '*.json' -File -Recurse -ErrorAction SilentlyContinue
+}
+
+$has = $false
+$lanes = @()
+# derived requirement: a plain string[] (not a hashtable) so a lane appearing 0, 1, or 2+ times
+# is all directly visible in $observedLanes.Count per key -- easier to reason about than a
+# running boolean.
+$observedLanes = [ordered]@{}
+
+foreach ($file in $files) {
+    # derived requirement: download-artifact@v6 (no merge-multiple) places each artifact under
+    # its own <VerdictsDir>/<artifact-name>/ subdirectory -- the artifact name IS
+    # "selftest-verdict-<lane>" (see batch-check.yml's "Upload iterate gate verdict" step), so
+    # the immediate parent directory name is a second, independent source for the lane identity
+    # besides the JSON record's own "lane" field.
+    $dirLane = $null
+    $prefix = 'selftest-verdict-'
+    if ($file.Directory -and $file.Directory.Name -and $file.Directory.Name.StartsWith($prefix)) {
+        $dirLane = $file.Directory.Name.Substring($prefix.Length)
+    }
+
+    try {
+        $content = Get-Content -Raw -LiteralPath $file.FullName
+        if ([string]::IsNullOrWhiteSpace($content)) { continue }
+        $data = $content | ConvertFrom-Json -Depth 16
+        if ($null -eq $data) { continue }
+
+        $records = if ($data -is [array]) { $data } else { @($data) }
+        foreach ($record in $records) {
+            if ($null -eq $record) { continue }
+
+            $value = $null
+            if ($record.PSObject.Properties.Name -contains 'has_failures') {
+                $value = Convert-ToBooleanOrNull -Value $record.has_failures
+            }
+
+            if ($record.PSObject.Properties.Name -notcontains 'source_file') {
+                $record | Add-Member -NotePropertyName source_file -NotePropertyValue $file.FullName -Force
+            }
+
+            if ($null -eq $value) {
+                $record | Add-Member -NotePropertyName parse_warning -NotePropertyValue 'has_failures missing or unparseable' -Force
+            } elseif ($value) {
+                $has = $true
+            }
+
+            $recordLane = $null
+            if ($record.PSObject.Properties.Name -contains 'lane' -and $record.lane) {
+                $recordLane = [string]$record.lane
+            }
+            $lane = if ($recordLane) { $recordLane } elseif ($dirLane) { $dirLane } else { $null }
+            if ($lane) {
+                if ($observedLanes.Contains($lane)) { $observedLanes[$lane] += 1 } else { $observedLanes[$lane] = 1 }
+            } else {
+                # derived requirement: a record with NEITHER a usable "lane" field NOR a
+                # recognizable artifact directory name is itself an anomaly worth flagging --
+                # attribute it to a synthetic '(unattributed)' bucket so it shows up as an
+                # "unexpected lane" below rather than silently vanishing from the lane count.
+                if ($observedLanes.Contains('(unattributed)')) { $observedLanes['(unattributed)'] += 1 } else { $observedLanes['(unattributed)'] = 1 }
+            }
+
+            $lanes += $record
+        }
+    } catch {
+        $lanes += [ordered]@{
+            lane = $file.BaseName
+            error = $_.Exception.Message
+            source_file = $file.FullName
+        }
+        $errLane = if ($dirLane) { $dirLane } else { '(unattributed)' }
+        if ($observedLanes.Contains($errLane)) { $observedLanes[$errLane] += 1 } else { $observedLanes[$errLane] = 1 }
+    }
+}
+
+# derived requirement: kept as an additional, independent safety net alongside the lane-set
+# comparison below (which already catches the "zero lanes observed" case on its own, since every
+# expected lane would show up as missing) -- this one also fires when the download directory
+# itself never materialized for reasons the lane-set check alone would not distinguish, and
+# preserves the original step's own "the matrix job itself did not report success" signal.
+if (-not $files -and $FallbackResult -and $FallbackResult -ne 'success') {
+    $has = $true
+}
+
+$expectedSet = [System.Collections.Generic.HashSet[string]]::new([string[]]$ExpectedLanes)
+$observedSet = [System.Collections.Generic.HashSet[string]]::new([string[]]$observedLanes.Keys)
+
+$missingLanes = @($ExpectedLanes | Where-Object { -not $observedSet.Contains($_) })
+$unexpectedLanes = @($observedLanes.Keys | Where-Object { -not $expectedSet.Contains($_) })
+$duplicateLanes = @($observedLanes.Keys | Where-Object { $observedLanes[$_] -gt 1 })
+
+$laneCheckFailed = ($missingLanes.Count -gt 0) -or ($unexpectedLanes.Count -gt 0) -or ($duplicateLanes.Count -gt 0)
+if ($laneCheckFailed) {
+    $has = $true
+    if ($missingLanes.Count -gt 0) {
+        Write-Host ("::error::selftest-gate: expected lane(s) never reported a verdict: {0}" -f ($missingLanes -join ', '))
+    }
+    if ($unexpectedLanes.Count -gt 0) {
+        Write-Host ("::error::selftest-gate: unexpected lane(s) reported a verdict: {0}" -f ($unexpectedLanes -join ', '))
+    }
+    if ($duplicateLanes.Count -gt 0) {
+        Write-Host ("::error::selftest-gate: lane(s) reported a verdict more than once: {0}" -f ($duplicateLanes -join ', '))
+    }
+}
+
+$report = [ordered]@{
+    fallback_result = $FallbackResult
+    has_failures = $has
+    lanes = @($lanes)
+    verdict_files = if ($files) { $files.FullName } else { @() }
+    lane_check = [ordered]@{
+        expected_lanes = @($ExpectedLanes)
+        observed_lanes = [ordered]@{}
+        missing_lanes = $missingLanes
+        unexpected_lanes = $unexpectedLanes
+        duplicate_lanes = $duplicateLanes
+        failed = $laneCheckFailed
+    }
+}
+foreach ($key in $observedLanes.Keys) { $report.lane_check.observed_lanes[$key] = $observedLanes[$key] }
+$report | ConvertTo-Json -Depth 6 | Out-File -FilePath $ReportPath -Encoding utf8
+
+if ($has) { exit 1 }
+exit 0


### PR DESCRIPTION
## Summary

CLAUDE.md's Active Backlog Item 35 explicitly flags this as a **precondition** that must be fixed before `selftest-gate`'s own job conclusion can ever be trusted as a required check: the "Aggregate verdicts" step only treated a **total** absence of `lane_verdict.json` files (zero lanes reporting) as a failure signal. A single lane's own verdict artifact silently missing — upload glitch, artifact-service hiccup, a step skipped for a reason that doesn't also flip that lane's own job conclusion to failure — while the other 7 lanes' artifacts land fine was completely invisible. A raw file-*count* comparison wouldn't have been sufficient either: an unexpected or duplicate artifact landing alongside a genuinely missing one could make the total count coincidentally match while one real lane's evidence is absent.

- Extracts the aggregation logic out of the inline YAML step into `tools/aggregate_selftest_verdicts.ps1` (mirroring `tools/ci_cache_selfheal.ps1`'s own extraction for Item 19) so it's independently testable.
- The extracted script now compares the **set** of expected lane IDs (the matrix's own 8-mode list) against the **set** of observed lane IDs (each verdict record's own `lane` field, falling back to the containing artifact directory's name when absent) and flags any **missing**, **unexpected**, or **duplicate** lane as `has_failures=true` — independent of what `needs.selftest.result` reports for the run as a whole.
- Adds `tests/test_aggregate_selftest_verdicts.ps1`, wired into the `real` lane (**GATING**, mirroring `test_ci_cache_selfheal.ps1`'s own precedent), covering six scenarios against fixture directories built to mimic `actions/download-artifact@v6`'s own output layout: `healthy`, `lane_failed` (regression guard for the pre-existing per-lane union behavior), `missing_lane` (the actual gap this closes), `unexpected_lane`, `duplicate_lane`, and `empty_fallback` (proves the new check fires independent of the fallback result, unlike the old behavior).

## Scope discipline

Per Item 35's own "one lane or row per slice" process discipline, this PR is scoped to the **precondition only**. The actual `exit 1`-on-`has_failures` step that would make `selftest-gate`'s own job conclusion fail for real (and the eventual branch-protection required-check change) are separate, not-yet-taken next steps — CLAUDE.md's entry is updated to say so explicitly rather than overclaiming.

## Why this is safe / verifiable without a real 8-lane run

- The extracted script has **no Windows-specific dependency** (pure PowerShell JSON parsing and file I/O, unlike its `ci_cache_selfheal.ps1` sibling which genuinely shells out to `conda.bat`) — verified directly with a local `pwsh` run on a non-Windows sandbox before ever reaching real CI, including simulating the exact multi-line invocation the YAML step now uses.
- Doesn't touch the `real`/`conda-full` lanes' own existing per-lane gates, or `publish_diag`'s `needs: [selftest, selftest-gate, model-quick-fix]` / `if: always()` guard.

## Verification

- `tools/run_sanity_sweep.sh` — all checks pass (compileall, pyflakes, delimiter check, CRLF check, markdownlint, yamllint, actionlint, ASCII sweep, PowerShell AST parse sweep, full pytest: 535 passed / 3 skipped).
- `python tools/check_delimiters.py` on both new `.ps1` files — clean.
- `tests/test_aggregate_selftest_verdicts.ps1` run directly via local `pwsh` — all 6 scenarios pass with the exact expected exit codes and report contents.
- The exact multi-line YAML invocation (with its array literal and backtick continuations) simulated locally against a fixture set — produces the identical report shape the original inline step produced, plus the new `lane_check` section.

## Test plan

- [ ] CI: full 8-lane matrix green
- [ ] `real` lane's new "Self-test: selftest-gate verdict aggregation logic" step passes
- [ ] `selftest-gate`'s own "Append gate summary" step still renders the report correctly with the new `lane_check` section

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017SQ1rvJxDbE71pTXJ4QvLV

---
_Generated by [Claude Code](https://claude.ai/code/session_017SQ1rvJxDbE71pTXJ4QvLV)_