### PR TITLE
Fix misleading --add-data hint for CWD-relative missing data files (Item 38)

### DIFF
--- a/.github/workflows/batch-check.yml
+++ b/.github/workflows/batch-check.yml
@@ -995,6 +995,14 @@ jobs:
         run: |
           & tests\selfapps_exedata_fail.ps1
 
+      - name: "Self-test: EXE smokerun XFAIL missing data file, name coincidentally contains _MEI+digits (real/conda-full only)"
+        if: ${{ !cancelled() && (matrix.mode == 'real' || (matrix.mode == 'conda-full' && steps.conda_avail.outputs.available == 'true')) }}
+        shell: pwsh
+        env:
+          EXEDATA_SCENARIO: mei_substring
+        run: |
+          & tests\selfapps_exedata_fail.ps1
+
       - name: "Self-test: EXE smokerun XFAIL dynamic import not bundled (real/conda-full only)"
         if: ${{ !cancelled() && (matrix.mode == 'real' || (matrix.mode == 'conda-full' && steps.conda_avail.outputs.available == 'true')) }}
         shell: pwsh

--- a/.github/workflows/batch-check.yml
+++ b/.github/workflows/batch-check.yml
@@ -1003,6 +1003,14 @@ jobs:
         run: |
           & tests\selfapps_exedata_fail.ps1
 
+      - name: "Self-test: EXE smokerun XFAIL missing data file under a genuine _MEIxxxxxx extraction path (real/conda-full only)"
+        if: ${{ !cancelled() && (matrix.mode == 'real' || (matrix.mode == 'conda-full' && steps.conda_avail.outputs.available == 'true')) }}
+        shell: pwsh
+        env:
+          EXEDATA_SCENARIO: mei_genuine
+        run: |
+          & tests\selfapps_exedata_fail.ps1
+
       - name: "Self-test: EXE smokerun XFAIL dynamic import not bundled (real/conda-full only)"
         if: ${{ !cancelled() && (matrix.mode == 'real' || (matrix.mode == 'conda-full' && steps.conda_avail.outputs.available == 'true')) }}
         shell: pwsh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -783,17 +783,31 @@ but several represent real gaps worth closing before calling the path fully rele
   case: `--add-data` places the file inside `_MEIPASS` (the onefile extraction dir), which does
   not satisfy a CWD-relative `open()` at all, yet the hint unconditionally suggested it regardless
   of which kind of missing-file path was detected. Fixed by branching on whether the captured
-  missing-file path itself is already under a `_MEIxxxxxx` folder (PyInstaller's own onefile
-  extraction-dir naming, checked via `findstr /i "_MEI"`, quoted per the established "quote a
-  variable before piping into findstr" rule): when it is, `--add-data` genuinely is the fix and the
-  original advice is unchanged; when it is a bare/CWD-relative path (the `report.py`/`config.json`
-  scenario above), the hint now says `--add-data` will not fix it and suggests placing a copy next
-  to the built `.exe` instead, or reading it via a path relative to the script's own file. This is
+  missing-file path itself is already under a genuine `_MEIxxxxxx` folder (PyInstaller's own
+  onefile extraction-dir naming): when it is, `--add-data` genuinely is the fix and the original
+  advice is unchanged; when it is a bare/CWD-relative path (the `report.py`/`config.json` scenario
+  above), the hint now says `--add-data` will not fix it and suggests placing a copy next to the
+  built `.exe` instead, or reading it via a path relative to the script's own file. This is
   independent of, and does not presuppose an answer to, the (a)-vs-(b) CWD-unification question
-  above -- the advice is honest either way that question is eventually resolved. Regression
-  coverage: `tests/selfapps_exedata_fail.ps1` (`self.exe.smokerun.exedata.xfail`, real/conda-full
-  lanes) extended to assert the honest wording fires and the old unconditional `--add-data
-  config.json` suggestion does not, for its own bare-relative-path stub app.
+  above -- the advice is honest either way that question is eventually resolved.
+
+  **First-shipped version used a plain `findstr /i "_MEI"` substring match -- a real false-positive
+  bug found by CodeRabbit's review of this same PR, fixed before landing.** A coincidental filename
+  containing `_MEI` anywhere (e.g. `config_MEI.json`) or a user-named folder called `_MEI` with no
+  digits (e.g. `C:\work\_MEI\data.txt`) would both wrongly match, misclassifying a genuine
+  CWD-relative failure as a bundled-resource one and giving the (still-wrong, for that case)
+  `--add-data` advice. Fixed by matching via PowerShell instead of `findstr`, anchored to the real
+  `_MEIxxxxxx` path-component shape (a path separator, then `_MEI`, then digits, then a path
+  separator) so a bare substring can never match; the value is read from the environment at
+  PowerShell runtime rather than substituted into the `-Command` text, so there is no cmd.exe
+  metacharacter risk either. Verified directly against both of CodeRabbit's own example strings
+  plus the real captured `_MEI41642` extraction path (`docs/demo-bootstrapper-output.md`'s
+  Scenario 31) via a standalone `pwsh` script before landing -- all five cases classify correctly.
+  Regression coverage: `tests/selfapps_exedata_fail.ps1` (`self.exe.smokerun.exedata.xfail`,
+  real/conda-full lanes) gained a second scenario (`EXEDATA_SCENARIO=mei_substring`, a stub app
+  opening `config_MEI99.json` -- CodeRabbit's own example shape) alongside the original `plain`
+  scenario (`config.json`), both asserting the honest wording fires and the corresponding
+  unconditional `--add-data` suggestion does not.
 
   **Still open, NOT part of this fix**: the CWD-mismatch verdict-flip itself (options a/b above)
   remains undecided, and the coverage gap this item originally named -- no test asserts what run 2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -760,8 +760,7 @@ but several represent real gaps worth closing before calling the path fully rele
 
   **Realistic scenario**: `report.py` does `open("config.json")`, with `config.json` sitting next
   to the script. Run 1: CWD = `dist\`, the file isn't there, EXE exits non-zero,
-  `:exe_smokerun_hints` fires `[HINT][DATA_FILE] Consider adding: --add-data config.json;.`, panel
-  reads "SETUP COMPLETE -- WITH A CAVEAT". Run 2: same binary, CWD = app root, file IS found, exit
+  `:exe_smokerun_hints` fires. Run 2: same binary, CWD = app root, file IS found, exit
   0, panel reads clean "SETUP COMPLETE". The user's natural conclusion -- "it fixed itself" -- is
   suspect: per Microsoft's own `ShellExecute`/`CreateProcess` documentation, a launch with no
   explicit working directory supplied defaults to the target EXE's own containing folder as CWD
@@ -770,19 +769,37 @@ but several represent real gaps worth closing before calling the path fully rele
   handed an explicit working directory (e.g. a shortcut's own "Start in" field), which would
   override the default -- and no CI lane launches via an actual double-click or shortcut either
   way, so the real-launch consequence described here is reasoned from documented Windows
-  behavior, not confirmed against a genuine double-click. The hint compounds the problem for the
-  common (no-override) case regardless:
-  `--add-data` places the file inside `_MEIPASS` (the onefile extraction dir), which does not
-  satisfy a CWD-relative `open()` at all -- the one actionable instruction the tool gives doesn't
-  fix the actual problem.
+  behavior, not confirmed against a genuine double-click.
 
-  **Fix options to weigh in this item's own loop** (not pre-decided): (a) unify both verification
-  points to the same CWD (which one is "more correct" needs its own thought -- `dist\` matches a
-  real double-clicked EXE's default CWD, so verifying from the app root may be the actually-wrong
-  choice, not `dist\`); (b) if unification isn't safe (re-verify `selfapps_exedata_fail.ps1`'s own
-  xfail check, which is explicitly load-bearing on the current `pushd dist` behavior per the
-  interconnect doc's own note), at minimum fix `:exe_smokerun_hints`' `--add-data` suggestion to
-  be honest about onefile CWD semantics instead of recommending something that won't work.
+  **Fix options to weigh for the CWD mismatch itself** (still not pre-decided): (a) unify both
+  verification points to the same CWD (which one is "more correct" needs its own thought --
+  `dist\` matches a real double-clicked EXE's default CWD, so verifying from the app root may be
+  the actually-wrong choice, not `dist\`); (b) leave the two CWDs as-is (re-verify
+  `selfapps_exedata_fail.ps1`'s own xfail check, which is explicitly load-bearing on the current
+  `pushd dist` behavior per the interconnect doc's own note, before ever changing this).
+
+  **The hint-honesty half of option (b) is CLOSED 2026-08-23, independently of the CWD-mismatch
+  design decision above.** The hint previously compounded the problem for the common (no-override)
+  case: `--add-data` places the file inside `_MEIPASS` (the onefile extraction dir), which does
+  not satisfy a CWD-relative `open()` at all, yet the hint unconditionally suggested it regardless
+  of which kind of missing-file path was detected. Fixed by branching on whether the captured
+  missing-file path itself is already under a `_MEIxxxxxx` folder (PyInstaller's own onefile
+  extraction-dir naming, checked via `findstr /i "_MEI"`, quoted per the established "quote a
+  variable before piping into findstr" rule): when it is, `--add-data` genuinely is the fix and the
+  original advice is unchanged; when it is a bare/CWD-relative path (the `report.py`/`config.json`
+  scenario above), the hint now says `--add-data` will not fix it and suggests placing a copy next
+  to the built `.exe` instead, or reading it via a path relative to the script's own file. This is
+  independent of, and does not presuppose an answer to, the (a)-vs-(b) CWD-unification question
+  above -- the advice is honest either way that question is eventually resolved. Regression
+  coverage: `tests/selfapps_exedata_fail.ps1` (`self.exe.smokerun.exedata.xfail`, real/conda-full
+  lanes) extended to assert the honest wording fires and the old unconditional `--add-data
+  config.json` suggestion does not, for its own bare-relative-path stub app.
+
+  **Still open, NOT part of this fix**: the CWD-mismatch verdict-flip itself (options a/b above)
+  remains undecided, and the coverage gap this item originally named -- no test asserts what run 2
+  reports for a CWD-sensitive app, since `selfapps_exedata_fail.ps1` invokes `run_setup.bat`
+  exactly once -- is still open. Add a second-run assertion for the same app once the CWD question
+  itself is resolved.
 
   **Coverage gap to close in the same slice**: no test asserts what run 2 reports for a
   CWD-sensitive app. `selfapps_exedata_fail.ps1` invokes `run_setup.bat` exactly once. Add a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -809,6 +809,16 @@ but several represent real gaps worth closing before calling the path fully rele
   scenario (`config.json`), both asserting the honest wording fires and the corresponding
   unconditional `--add-data` suggestion does not.
 
+  **Third scenario added same PR, closing a coverage gap CodeRabbit's review separately flagged:
+  neither scenario above ever exercises the OTHER branch (a genuine `_MEIxxxxxx` path, where
+  `--add-data` remains the correct, unchanged advice) -- nothing in the suite did, before this.**
+  `EXEDATA_SCENARIO=mei_genuine`'s stub app reads a file joined from `sys._MEIPASS` (PyInstaller's
+  own real, randomly-named onefile extraction directory at runtime), never bundled via
+  `--add-data`, so the failure genuinely surfaces a path rooted under a real `_MEIxxxxxx` folder.
+  Since the exact directory name is random per run, the test asserts the stable parts instead
+  (the `--add-data` advice text, the filename it names, and a genuine `_MEI<digits>` path segment
+  actually present in the captured log) rather than the full line verbatim.
+
   **Still open, NOT part of this fix**: the CWD-mismatch verdict-flip itself (options a/b above)
   remains undecided, and the coverage gap this item originally named -- no test asserts what run 2
   reports for a CWD-sensitive app, since `selfapps_exedata_fail.ps1` invokes `run_setup.bat`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -816,7 +816,7 @@ but several represent real gaps worth closing before calling the path fully rele
   own real, randomly-named onefile extraction directory at runtime), never bundled via
   `--add-data`, so the failure genuinely surfaces a path rooted under a real `_MEIxxxxxx` folder.
   Since the exact directory name is random per run, the test asserts the stable parts instead
-  (the `--add-data` advice text, the filename it names, and a genuine `_MEI<digits>` path segment
+  (the `--add-data` advice text, the filename it names, and a genuine `_MEI<suffix>` path segment
   actually present in the captured log) rather than the full line verbatim.
 
   **Real bug this new scenario caught on its first real CI run, fixed same PR: the extraction

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -819,15 +819,23 @@ but several represent real gaps worth closing before calling the path fully rele
   (the `--add-data` advice text, the filename it names, and a genuine `_MEI<digits>` path segment
   actually present in the captured log) rather than the full line verbatim.
 
+  **Real bug this new scenario caught on its first real CI run, fixed same PR: the extraction
+  suffix is NOT always decimal digits.** The regex shipped as `_MEI[0-9]+` (digits only), matching
+  the one reference capture then available (`_MEI41642`, all-decimal). The `mei_genuine` scenario's
+  own first real run captured `_MEI00001a4c2` and `_MEI00001ee42` -- both containing hex letters --
+  so `[0-9]+` never matched, and the fix wrongly gave the CWD-relative advice for a genuine
+  extraction path (the exact failure mode this whole fix exists to prevent, just inverted). Widened
+  to `_MEI[^\\/]+` (any nonempty run of non-separator characters): the structural bounding (a real
+  path separator immediately before AND after `_MEI<suffix>`) is what actually distinguishes a
+  genuine extraction-directory component from a coincidental substring or a no-suffix folder name,
+  not the exact character class of the suffix -- verified via a standalone `pwsh` script against
+  all prior cases plus both newly-captured hex examples before landing.
+
   **Still open, NOT part of this fix**: the CWD-mismatch verdict-flip itself (options a/b above)
   remains undecided, and the coverage gap this item originally named -- no test asserts what run 2
   reports for a CWD-sensitive app, since `selfapps_exedata_fail.ps1` invokes `run_setup.bat`
   exactly once -- is still open. Add a second-run assertion for the same app once the CWD question
   itself is resolved.
-
-  **Coverage gap to close in the same slice**: no test asserts what run 2 reports for a
-  CWD-sensitive app. `selfapps_exedata_fail.ps1` invokes `run_setup.bat` exactly once. Add a
-  second-run assertion for the same app.
 
 - **Item 39: the EXE fast path's freshness check is mtime-only, so timestamp-preserving delivery
   (a ZIP, an xcopy) can silently run stale code with no signal to the user.** Confirmed

--- a/run_setup.bat
+++ b/run_setup.bat
@@ -4988,10 +4988,18 @@ rem derived requirement (CodeRabbit review, PR #458): a plain findstr substring 
 rem false-positives on a coincidental filename (config_MEI.json) or a user-named folder with no
 rem digits (C:\work\_MEI\data.txt) -- neither is a genuine PyInstaller extraction directory.
 rem Matched via PowerShell instead, anchored to the real _MEIxxxxxx path-component shape
-rem (a path separator, then _MEI, then digits, then a path separator) so a bare substring
-rem never matches; the value is read from the environment at PowerShell runtime, never
-rem substituted into the -Command text, so no cmd.exe metacharacter risk either.
-powershell -NoProfile -ExecutionPolicy Bypass -Command "exit [int](-not ($env:HP_HINT_FILE_NAME -match '(?i)[\\/]_MEI[0-9]+[\\/]'))"
+rem (a path separator, then _MEI, then a nonempty suffix, then a path separator) so a bare
+rem substring never matches; the value is read from the environment at PowerShell runtime,
+rem never substituted into the -Command text, so no cmd.exe metacharacter risk either.
+rem derived requirement (real CI failure, PR #458's own mei_genuine test): the suffix is NOT
+rem always decimal digits -- a genuine capture from this same PR's CI run showed
+rem _MEI00001a4c2 (hex characters), not just _MEI41642 (decimal) from the earlier reference
+rem capture. [0-9]+ missed the hex case and wrongly gave the CWD-relative advice for a
+rem genuine extraction path. Widened to [^\\/]+ (any nonempty non-separator run) -- the
+rem structural bounding (a real path separator immediately before AND after) is what
+rem actually distinguishes a genuine extraction-directory component from a coincidental
+rem substring or a no-suffix folder name, not the exact character class of the suffix.
+powershell -NoProfile -ExecutionPolicy Bypass -Command "exit [int](-not ($env:HP_HINT_FILE_NAME -match '(?i)[\\/]_MEI[^\\/]+[\\/]'))"
 if errorlevel 1 (
   call :log "[HINT][DATA_FILE] --add-data will not fix this: it bundles into a temp extraction folder, not the current directory. Place a copy of '%HP_HINT_FILE_NAME%' next to the built .exe instead, or read the file via a path relative to your own script file, not the working directory."
 ) else (

--- a/run_setup.bat
+++ b/run_setup.bat
@@ -4978,7 +4978,18 @@ goto :hint_check_mod
 :hint_data_file
 for /f "usebackq delims=" %%F in (`powershell -NoProfile -ExecutionPolicy Bypass -Command "$t=[IO.File]::ReadAllText('%HP_HINT_FILE%');$m=[regex]::Match($t,'No such file or directory: ''([^'']+)''');if($m.Success){$m.Groups[1].Value}else{'<file>'}"`) do set "HP_HINT_FILE_NAME=%%F"
 call :log "[HINT][DATA_FILE] Missing data file detected: %HP_HINT_FILE_NAME%"
-call :log "[HINT][DATA_FILE] Consider adding: --add-data %HP_HINT_FILE_NAME%;."
+rem derived requirement (CLAUDE.md Active Backlog Item 38): --add-data bundles a file into the
+rem onefile extraction folder (_MEIxxxxxx under TEMP), never the current working directory --
+rem correct advice only when the missing path itself is already under a _MEIxxxxxx folder (the
+rem code reads it via a bundled-resource-style path). For a bare/CWD-relative path, --add-data
+rem would NOT fix the failure at all; give honest advice for that far more common beginner case
+rem instead of a suggestion that cannot work.
+echo "%HP_HINT_FILE_NAME%"| findstr /i "_MEI" >nul 2>&1
+if errorlevel 1 (
+  call :log "[HINT][DATA_FILE] --add-data will not fix this: it bundles into a temp extraction folder, not the current directory. Place a copy of '%HP_HINT_FILE_NAME%' next to the built .exe instead, or read the file via a path relative to your own script file, not the working directory."
+) else (
+  call :log "[HINT][DATA_FILE] Consider adding: --add-data %HP_HINT_FILE_NAME%;."
+)
 if defined HINT_JSON powershell -NoProfile -ExecutionPolicy Bypass -Command "Write-Host ([PSCustomObject]@{hint_type='DATA_FILE';file=$env:HP_HINT_FILE_NAME}|ConvertTo-Json -Compress)"
 :hint_check_mod
 findstr /i /c:"ModuleNotFoundError" /c:"No module named" "%HP_HINT_FILE%" >nul 2>&1

--- a/run_setup.bat
+++ b/run_setup.bat
@@ -4984,7 +4984,14 @@ rem correct advice only when the missing path itself is already under a _MEIxxxx
 rem code reads it via a bundled-resource-style path). For a bare/CWD-relative path, --add-data
 rem would NOT fix the failure at all; give honest advice for that far more common beginner case
 rem instead of a suggestion that cannot work.
-echo "%HP_HINT_FILE_NAME%"| findstr /i "_MEI" >nul 2>&1
+rem derived requirement (CodeRabbit review, PR #458): a plain findstr substring match on "_MEI"
+rem false-positives on a coincidental filename (config_MEI.json) or a user-named folder with no
+rem digits (C:\work\_MEI\data.txt) -- neither is a genuine PyInstaller extraction directory.
+rem Matched via PowerShell instead, anchored to the real _MEIxxxxxx path-component shape
+rem (a path separator, then _MEI, then digits, then a path separator) so a bare substring
+rem never matches; the value is read from the environment at PowerShell runtime, never
+rem substituted into the -Command text, so no cmd.exe metacharacter risk either.
+powershell -NoProfile -ExecutionPolicy Bypass -Command "exit [int](-not ($env:HP_HINT_FILE_NAME -match '(?i)[\\/]_MEI[0-9]+[\\/]'))"
 if errorlevel 1 (
   call :log "[HINT][DATA_FILE] --add-data will not fix this: it bundles into a temp extraction folder, not the current directory. Place a copy of '%HP_HINT_FILE_NAME%' next to the built .exe instead, or read the file via a path relative to your own script file, not the working directory."
 ) else (

--- a/tests/selfapps_exedata_fail.ps1
+++ b/tests/selfapps_exedata_fail.ps1
@@ -96,20 +96,32 @@ $smokerunPassPhrase  = 'EXE smokerun: exited 0 (ok)'
 $smokerunFired  = $combined -match [regex]::Escape($smokerunFiredPhrase)
 $smokerunPassed = $combined -match [regex]::Escape($smokerunPassPhrase)
 
-# xfailPass: smokerun fired AND did NOT report exit 0
-$xfailPass = $smokerunFired -and (-not $smokerunPassed)
+# derived requirement (CLAUDE.md Active Backlog Item 38): entry.py's open("config.json") is a
+# bare, CWD-relative path -- no _MEIxxxxxx marker -- so :exe_smokerun_hints must give the
+# honest "place it next to the .exe" advice, not the misleading unconditional --add-data
+# suggestion (which bundles into a temp extraction folder, never the working directory, so it
+# would not actually fix this failure mode).
+$honestHintFired      = $combined -match [regex]::Escape('will not fix this')
+$misleadingHintAbsent = -not ($combined -match [regex]::Escape('Consider adding: --add-data config.json'))
+$hintCorrect = $honestHintFired -and $misleadingHintAbsent
+
+# xfailPass: smokerun fired AND did NOT report exit 0 AND the hint text is honest for this case
+$xfailPass = $smokerunFired -and (-not $smokerunPassed) -and $hintCorrect
 
 Write-NdjsonRow ([ordered]@{
     id      = 'self.exe.smokerun.exedata.xfail'
     req     = 'REQ-003'
     pass    = $xfailPass
-    desc    = 'EXE smokerun XFAIL: missing data file causes non-zero exit (expected failure)'
+    desc    = 'EXE smokerun XFAIL: missing data file causes non-zero exit (expected failure); hint text is honest about --add-data not fixing a CWD-relative access'
     details = [ordered]@{
-        bootstrapExit  = $runExit
-        smokerunFired  = $smokerunFired
-        smokerunPassed = $smokerunPassed
-        xfailPass      = $xfailPass
-        log            = $bootstrapLog
+        bootstrapExit         = $runExit
+        smokerunFired         = $smokerunFired
+        smokerunPassed        = $smokerunPassed
+        honestHintFired       = $honestHintFired
+        misleadingHintAbsent  = $misleadingHintAbsent
+        hintCorrect           = $hintCorrect
+        xfailPass             = $xfailPass
+        log                   = $bootstrapLog
     }
 })
 

--- a/tests/selfapps_exedata_fail.ps1
+++ b/tests/selfapps_exedata_fail.ps1
@@ -4,16 +4,25 @@
 # built EXE exits non-zero at runtime. Test passes (xfail) when smokerun reports failure.
 # Test fails (xpass) if smokerun unexpectedly reports exit 0.
 #
-# Two scenarios (EXEDATA_SCENARIO env var; unset defaults to 'plain'), both asserting
-# :exe_smokerun_hints' CLAUDE.md Item 38 fix (honest advice for a CWD-relative missing
-# file, real --add-data advice only for a genuine _MEIxxxxxx extraction path):
+# Three scenarios (EXEDATA_SCENARIO env var; unset defaults to 'plain'), covering both
+# branches of :exe_smokerun_hints' CLAUDE.md Item 38 fix (honest advice for a CWD-relative
+# missing file, real --add-data advice only for a genuine _MEIxxxxxx extraction path):
 # - plain: entry.py opens "config.json" -- a bare CWD-relative path, no _MEI anywhere.
+#   Expects the honest CWD-relative advice.
 # - mei_substring (CodeRabbit review, PR #458): entry.py opens "config_MEI99.json" -- a
 #   bare CWD-relative path whose NAME happens to contain "_MEI" followed by digits as a
 #   coincidental substring, with no path separator on either side. Regression test for the
 #   exact false-positive shape CodeRabbit's review flagged in the original plain findstr
-#   substring match (fixed via a path-component-anchored regex instead) -- proves the fix
-#   still gives the honest CWD-relative advice here, not the genuine-extraction-path one.
+#   substring match (fixed via a path-component-anchored regex instead). Expects the honest
+#   CWD-relative advice, NOT the misleading --add-data one.
+# - mei_genuine (CodeRabbit review, PR #458): entry.py reads a file via a path joined from
+#   sys._MEIPASS -- PyInstaller's own real, randomly-named onefile extraction directory at
+#   runtime -- never bundled via --add-data, so the open() genuinely fails with a path
+#   rooted under a real _MEIxxxxxx folder. The only scenario that exercises the OTHER branch
+#   of the fix: --add-data remains the correct, unchanged advice here. Closes the coverage
+#   gap CodeRabbit's review flagged (both new scenarios above only ever exercise the
+#   CWD-relative branch; nothing previously exercised the genuine-extraction-path branch at
+#   all).
 #
 # Lane: real and conda-full only.
 param()
@@ -35,50 +44,30 @@ function Write-NdjsonRow {
 }
 
 $scenario = $env:EXEDATA_SCENARIO
-if (-not $scenario) { $scenario = 'plain' }
+if ($scenario -notin @('mei_substring', 'mei_genuine')) { $scenario = 'plain' }
 
 # Non-Windows skip
 if (-not $IsWindows) {
     $platform = [System.Environment]::OSVersion.Platform.ToString()
-    if ($scenario -eq 'mei_substring') {
-        Write-NdjsonRow ([ordered]@{
-            id      = 'self.exe.smokerun.exedata.xfail'
-            req     = 'REQ-003'
-            pass    = $true
-            desc    = 'EXE smokerun XFAIL: missing data file exits non-zero (skipped on non-Windows)'
-            details = [ordered]@{ skip = $true; platform = $platform; reason = 'non-windows-host'; scenario = $scenario }
-        })
-    } else {
-        Write-NdjsonRow ([ordered]@{
-            id      = 'self.exe.smokerun.exedata.xfail'
-            req     = 'REQ-003'
-            pass    = $true
-            desc    = 'EXE smokerun XFAIL: missing data file exits non-zero (skipped on non-Windows)'
-            details = [ordered]@{ skip = $true; platform = $platform; reason = 'non-windows-host'; scenario = $scenario }
-        })
-    }
+    Write-NdjsonRow ([ordered]@{
+        id      = 'self.exe.smokerun.exedata.xfail'
+        req     = 'REQ-003'
+        pass    = $true
+        desc    = 'EXE smokerun XFAIL: missing data file exits non-zero (skipped on non-Windows)'
+        details = [ordered]@{ skip = $true; platform = $platform; reason = 'non-windows-host'; scenario = $scenario }
+    })
     exit 0
 }
 
 $batchPath = Join-Path $repo 'run_setup.bat'
 if (-not (Test-Path $batchPath)) {
-    if ($scenario -eq 'mei_substring') {
-        Write-NdjsonRow ([ordered]@{
-            id      = 'self.exe.smokerun.exedata.xfail'
-            req     = 'REQ-003'
-            pass    = $false
-            desc    = 'EXE smokerun XFAIL: run_setup.bat not found'
-            details = [ordered]@{ error = 'run_setup.bat not found at ' + $batchPath; scenario = $scenario }
-        })
-    } else {
-        Write-NdjsonRow ([ordered]@{
-            id      = 'self.exe.smokerun.exedata.xfail'
-            req     = 'REQ-003'
-            pass    = $false
-            desc    = 'EXE smokerun XFAIL: run_setup.bat not found'
-            details = [ordered]@{ error = 'run_setup.bat not found at ' + $batchPath; scenario = $scenario }
-        })
-    }
+    Write-NdjsonRow ([ordered]@{
+        id      = 'self.exe.smokerun.exedata.xfail'
+        req     = 'REQ-003'
+        pass    = $false
+        desc    = 'EXE smokerun XFAIL: run_setup.bat not found'
+        details = [ordered]@{ error = 'run_setup.bat not found at ' + $batchPath; scenario = $scenario }
+    })
     exit 1
 }
 
@@ -97,6 +86,17 @@ with open("config_MEI99.json", "r") as f:
     print(f.read())
 '@ -Encoding ASCII
     Set-Content -Path (Join-Path $workDir 'config_MEI99.json') -Value '{"msg": "hello-data"}' -Encoding ASCII
+} elseif ($scenario -eq 'mei_genuine') {
+    # derived requirement: entry.py reads a file joined from sys._MEIPASS, PyInstaller's own
+    # real onefile extraction directory (a genuine, randomly-named _MEIxxxxxx folder at
+    # runtime) -- never bundled via --add-data, so this always fails with a path genuinely
+    # rooted under _MEIxxxxxx. Exercises the branch where --add-data remains correct advice.
+    Set-Content -Path (Join-Path $workDir 'entry.py') -Value @'
+import sys, os
+p = os.path.join(sys._MEIPASS, "bundled_data.json")
+with open(p, "r") as f:
+    print(f.read())
+'@ -Encoding ASCII
 } else {
     # derived requirement: entry.py opens config.json via a relative path. PyInstaller does
     # not bundle arbitrary data files unless explicitly spec'd, so the EXE exits non-zero
@@ -141,59 +141,78 @@ $smokerunPassPhrase  = 'EXE smokerun: exited 0 (ok)'
 $smokerunFired  = $combined -match [regex]::Escape($smokerunFiredPhrase)
 $smokerunPassed = $combined -match [regex]::Escape($smokerunPassPhrase)
 
-# derived requirement (CLAUDE.md Active Backlog Item 38): a bare, CWD-relative path -- no
-# genuine _MEIxxxxxx marker, even if "mei_substring" coincidentally contains that text as a
-# substring -- must get :exe_smokerun_hints' honest "place it next to the .exe" advice, not
-# the misleading --add-data suggestion (which bundles into a temp extraction folder, never
-# the working directory, so it would not actually fix this failure mode).
+# derived requirement (CLAUDE.md Active Backlog Item 38): honest CWD-relative advice for
+# 'plain'/'mei_substring' (neither has a genuine _MEIxxxxxx path component); the original,
+# unchanged --add-data advice for 'mei_genuine' (a real _MEIxxxxxx-rooted path).
 $honestHintFired = $combined -match [regex]::Escape('will not fix this')
-if ($scenario -eq 'mei_substring') {
+if ($scenario -eq 'mei_genuine') {
+    # A random runtime-generated _MEIxxxxxx name means the exact --add-data line can't be
+    # matched verbatim -- assert the stable parts instead: the advice text, the filename it
+    # names, and a genuine _MEI<digits> path segment actually present in the captured log.
+    $addDataHintFired = ($combined -match [regex]::Escape('Consider adding: --add-data')) -and
+                         ($combined -match [regex]::Escape('bundled_data.json'))
+    $genuineMeiPathSeen = $combined -match '_MEI\d+'
+    $hintCorrect = $addDataHintFired -and $genuineMeiPathSeen -and (-not $honestHintFired)
+} elseif ($scenario -eq 'mei_substring') {
     $misleadingHintAbsent = -not ($combined -match [regex]::Escape('Consider adding: --add-data config_MEI99.json'))
+    $hintCorrect = $honestHintFired -and $misleadingHintAbsent
 } else {
     $misleadingHintAbsent = -not ($combined -match [regex]::Escape('Consider adding: --add-data config.json'))
+    $hintCorrect = $honestHintFired -and $misleadingHintAbsent
 }
-$hintCorrect = $honestHintFired -and $misleadingHintAbsent
 
-# xfailPass: smokerun fired AND did NOT report exit 0 AND the hint text is honest for this case
+# xfailPass: smokerun fired AND did NOT report exit 0 AND the hint text is correct for this case
 $xfailPass = $smokerunFired -and (-not $smokerunPassed) -and $hintCorrect
 
-if ($scenario -eq 'mei_substring') {
-    Write-NdjsonRow ([ordered]@{
-        id      = 'self.exe.smokerun.exedata.xfail'
-        req     = 'REQ-003'
-        pass    = $xfailPass
-        desc    = 'EXE smokerun XFAIL: missing data file (name coincidentally contains _MEI+digits) causes non-zero exit (expected failure); hint text stays honest, not misled by the substring'
-        details = [ordered]@{
-            scenario              = $scenario
-            bootstrapExit         = $runExit
-            smokerunFired         = $smokerunFired
-            smokerunPassed        = $smokerunPassed
-            honestHintFired       = $honestHintFired
-            misleadingHintAbsent  = $misleadingHintAbsent
-            hintCorrect           = $hintCorrect
-            xfailPass             = $xfailPass
-            log                   = $bootstrapLog
-        }
-    })
+if ($scenario -eq 'mei_genuine') {
+    $desc = 'EXE smokerun XFAIL: missing data file under a genuine _MEIxxxxxx extraction path causes non-zero exit (expected failure); --add-data advice correctly still fires for this case'
+    $details = [ordered]@{
+        scenario            = $scenario
+        bootstrapExit       = $runExit
+        smokerunFired       = $smokerunFired
+        smokerunPassed      = $smokerunPassed
+        addDataHintFired    = $addDataHintFired
+        genuineMeiPathSeen  = $genuineMeiPathSeen
+        honestHintAbsent    = (-not $honestHintFired)
+        hintCorrect         = $hintCorrect
+        xfailPass           = $xfailPass
+        log                 = $bootstrapLog
+    }
+} elseif ($scenario -eq 'mei_substring') {
+    $desc = 'EXE smokerun XFAIL: missing data file (name coincidentally contains _MEI+digits) causes non-zero exit (expected failure); hint text stays honest, not misled by the substring'
+    $details = [ordered]@{
+        scenario              = $scenario
+        bootstrapExit         = $runExit
+        smokerunFired         = $smokerunFired
+        smokerunPassed        = $smokerunPassed
+        honestHintFired       = $honestHintFired
+        misleadingHintAbsent  = $misleadingHintAbsent
+        hintCorrect           = $hintCorrect
+        xfailPass             = $xfailPass
+        log                   = $bootstrapLog
+    }
 } else {
-    Write-NdjsonRow ([ordered]@{
-        id      = 'self.exe.smokerun.exedata.xfail'
-        req     = 'REQ-003'
-        pass    = $xfailPass
-        desc    = 'EXE smokerun XFAIL: missing data file causes non-zero exit (expected failure); hint text is honest about --add-data not fixing a CWD-relative access'
-        details = [ordered]@{
-            scenario              = $scenario
-            bootstrapExit         = $runExit
-            smokerunFired         = $smokerunFired
-            smokerunPassed        = $smokerunPassed
-            honestHintFired       = $honestHintFired
-            misleadingHintAbsent  = $misleadingHintAbsent
-            hintCorrect           = $hintCorrect
-            xfailPass             = $xfailPass
-            log                   = $bootstrapLog
-        }
-    })
+    $desc = 'EXE smokerun XFAIL: missing data file causes non-zero exit (expected failure); hint text is honest about --add-data not fixing a CWD-relative access'
+    $details = [ordered]@{
+        scenario              = $scenario
+        bootstrapExit         = $runExit
+        smokerunFired         = $smokerunFired
+        smokerunPassed        = $smokerunPassed
+        honestHintFired       = $honestHintFired
+        misleadingHintAbsent  = $misleadingHintAbsent
+        hintCorrect           = $hintCorrect
+        xfailPass             = $xfailPass
+        log                   = $bootstrapLog
+    }
 }
+
+Write-NdjsonRow ([ordered]@{
+    id      = 'self.exe.smokerun.exedata.xfail'
+    req     = 'REQ-003'
+    pass    = $xfailPass
+    desc    = $desc
+    details = $details
+})
 
 if (-not $xfailPass) { exit 1 }
 exit 0

--- a/tests/selfapps_exedata_fail.ps1
+++ b/tests/selfapps_exedata_fail.ps1
@@ -1,8 +1,19 @@
 # ASCII only
 # selfapps_exedata_fail.ps1 - XFAIL test: EXE smokerun expected to fail when entry.py
-# opens a data file (config.json) not bundled by PyInstaller. Bootstrap completes
-# (exitCode=0) but the built EXE exits non-zero at runtime. Test passes (xfail) when
-# smokerun reports failure. Test fails (xpass) if smokerun unexpectedly reports exit 0.
+# opens a data file not bundled by PyInstaller. Bootstrap completes (exitCode=0) but the
+# built EXE exits non-zero at runtime. Test passes (xfail) when smokerun reports failure.
+# Test fails (xpass) if smokerun unexpectedly reports exit 0.
+#
+# Two scenarios (EXEDATA_SCENARIO env var; unset defaults to 'plain'), both asserting
+# :exe_smokerun_hints' CLAUDE.md Item 38 fix (honest advice for a CWD-relative missing
+# file, real --add-data advice only for a genuine _MEIxxxxxx extraction path):
+# - plain: entry.py opens "config.json" -- a bare CWD-relative path, no _MEI anywhere.
+# - mei_substring (CodeRabbit review, PR #458): entry.py opens "config_MEI99.json" -- a
+#   bare CWD-relative path whose NAME happens to contain "_MEI" followed by digits as a
+#   coincidental substring, with no path separator on either side. Regression test for the
+#   exact false-positive shape CodeRabbit's review flagged in the original plain findstr
+#   substring match (fixed via a path-component-anchored regex instead) -- proves the fix
+#   still gives the honest CWD-relative advice here, not the genuine-extraction-path one.
 #
 # Lane: real and conda-full only.
 param()
@@ -23,47 +34,81 @@ function Write-NdjsonRow {
     Add-Content -LiteralPath $ciNd -Value $json -Encoding Ascii
 }
 
+$scenario = $env:EXEDATA_SCENARIO
+if (-not $scenario) { $scenario = 'plain' }
+
 # Non-Windows skip
 if (-not $IsWindows) {
     $platform = [System.Environment]::OSVersion.Platform.ToString()
-    Write-NdjsonRow ([ordered]@{
-        id      = 'self.exe.smokerun.exedata.xfail'
-        req     = 'REQ-003'
-        pass    = $true
-        desc    = 'EXE smokerun XFAIL: missing data file exits non-zero (skipped on non-Windows)'
-        details = [ordered]@{ skip = $true; platform = $platform; reason = 'non-windows-host' }
-    })
+    if ($scenario -eq 'mei_substring') {
+        Write-NdjsonRow ([ordered]@{
+            id      = 'self.exe.smokerun.exedata.xfail'
+            req     = 'REQ-003'
+            pass    = $true
+            desc    = 'EXE smokerun XFAIL: missing data file exits non-zero (skipped on non-Windows)'
+            details = [ordered]@{ skip = $true; platform = $platform; reason = 'non-windows-host'; scenario = $scenario }
+        })
+    } else {
+        Write-NdjsonRow ([ordered]@{
+            id      = 'self.exe.smokerun.exedata.xfail'
+            req     = 'REQ-003'
+            pass    = $true
+            desc    = 'EXE smokerun XFAIL: missing data file exits non-zero (skipped on non-Windows)'
+            details = [ordered]@{ skip = $true; platform = $platform; reason = 'non-windows-host'; scenario = $scenario }
+        })
+    }
     exit 0
 }
 
 $batchPath = Join-Path $repo 'run_setup.bat'
 if (-not (Test-Path $batchPath)) {
-    Write-NdjsonRow ([ordered]@{
-        id      = 'self.exe.smokerun.exedata.xfail'
-        req     = 'REQ-003'
-        pass    = $false
-        desc    = 'EXE smokerun XFAIL: run_setup.bat not found'
-        details = [ordered]@{ error = 'run_setup.bat not found at ' + $batchPath }
-    })
+    if ($scenario -eq 'mei_substring') {
+        Write-NdjsonRow ([ordered]@{
+            id      = 'self.exe.smokerun.exedata.xfail'
+            req     = 'REQ-003'
+            pass    = $false
+            desc    = 'EXE smokerun XFAIL: run_setup.bat not found'
+            details = [ordered]@{ error = 'run_setup.bat not found at ' + $batchPath; scenario = $scenario }
+        })
+    } else {
+        Write-NdjsonRow ([ordered]@{
+            id      = 'self.exe.smokerun.exedata.xfail'
+            req     = 'REQ-003'
+            pass    = $false
+            desc    = 'EXE smokerun XFAIL: run_setup.bat not found'
+            details = [ordered]@{ error = 'run_setup.bat not found at ' + $batchPath; scenario = $scenario }
+        })
+    }
     exit 1
 }
 
-$workDir = Join-Path $here '~selftest_exedata_fail'
+$workDir = Join-Path $here "~selftest_exedata_fail_$scenario"
 if (Test-Path $workDir) { Remove-Item -Recurse -Force $workDir }
 New-Item -ItemType Directory -Force -Path $workDir | Out-Null
 Copy-Item -Path $batchPath -Destination $workDir -Force
 
-# derived requirement: entry.py opens config.json via a relative path. PyInstaller does
-# not bundle arbitrary data files unless explicitly spec'd, so the EXE exits non-zero
-# when config.json is absent from the dist\ directory at runtime.
-Set-Content -Path (Join-Path $workDir 'entry.py') -Value @'
+if ($scenario -eq 'mei_substring') {
+    # derived requirement: entry.py opens config_MEI99.json -- a bare, CWD-relative path whose
+    # name coincidentally contains "_MEI" followed by digits, with no path separator on either
+    # side (matching CodeRabbit's own "config_MEI.json" example shape). Must NOT be misread as
+    # a genuine PyInstaller _MEIxxxxxx extraction-directory path.
+    Set-Content -Path (Join-Path $workDir 'entry.py') -Value @'
+with open("config_MEI99.json", "r") as f:
+    print(f.read())
+'@ -Encoding ASCII
+    Set-Content -Path (Join-Path $workDir 'config_MEI99.json') -Value '{"msg": "hello-data"}' -Encoding ASCII
+} else {
+    # derived requirement: entry.py opens config.json via a relative path. PyInstaller does
+    # not bundle arbitrary data files unless explicitly spec'd, so the EXE exits non-zero
+    # when config.json is absent from the dist\ directory at runtime.
+    Set-Content -Path (Join-Path $workDir 'entry.py') -Value @'
 with open("config.json", "r") as f:
     print(f.read())
 '@ -Encoding ASCII
+    Set-Content -Path (Join-Path $workDir 'config.json') -Value '{"msg": "hello-data"}' -Encoding ASCII
+}
 
-Set-Content -Path (Join-Path $workDir 'config.json') -Value '{"msg": "hello-data"}' -Encoding ASCII
-
-$bootstrapLog = '~exedata_bootstrap.log'
+$bootstrapLog = "~exedata_bootstrap_$scenario.log"
 
 $prev = if (Test-Path Env:HP_SKIP_PIPREQS) { $env:HP_SKIP_PIPREQS } else { $null }
 $env:HP_SKIP_PIPREQS = '1'
@@ -96,34 +141,59 @@ $smokerunPassPhrase  = 'EXE smokerun: exited 0 (ok)'
 $smokerunFired  = $combined -match [regex]::Escape($smokerunFiredPhrase)
 $smokerunPassed = $combined -match [regex]::Escape($smokerunPassPhrase)
 
-# derived requirement (CLAUDE.md Active Backlog Item 38): entry.py's open("config.json") is a
-# bare, CWD-relative path -- no _MEIxxxxxx marker -- so :exe_smokerun_hints must give the
-# honest "place it next to the .exe" advice, not the misleading unconditional --add-data
-# suggestion (which bundles into a temp extraction folder, never the working directory, so it
-# would not actually fix this failure mode).
-$honestHintFired      = $combined -match [regex]::Escape('will not fix this')
-$misleadingHintAbsent = -not ($combined -match [regex]::Escape('Consider adding: --add-data config.json'))
+# derived requirement (CLAUDE.md Active Backlog Item 38): a bare, CWD-relative path -- no
+# genuine _MEIxxxxxx marker, even if "mei_substring" coincidentally contains that text as a
+# substring -- must get :exe_smokerun_hints' honest "place it next to the .exe" advice, not
+# the misleading --add-data suggestion (which bundles into a temp extraction folder, never
+# the working directory, so it would not actually fix this failure mode).
+$honestHintFired = $combined -match [regex]::Escape('will not fix this')
+if ($scenario -eq 'mei_substring') {
+    $misleadingHintAbsent = -not ($combined -match [regex]::Escape('Consider adding: --add-data config_MEI99.json'))
+} else {
+    $misleadingHintAbsent = -not ($combined -match [regex]::Escape('Consider adding: --add-data config.json'))
+}
 $hintCorrect = $honestHintFired -and $misleadingHintAbsent
 
 # xfailPass: smokerun fired AND did NOT report exit 0 AND the hint text is honest for this case
 $xfailPass = $smokerunFired -and (-not $smokerunPassed) -and $hintCorrect
 
-Write-NdjsonRow ([ordered]@{
-    id      = 'self.exe.smokerun.exedata.xfail'
-    req     = 'REQ-003'
-    pass    = $xfailPass
-    desc    = 'EXE smokerun XFAIL: missing data file causes non-zero exit (expected failure); hint text is honest about --add-data not fixing a CWD-relative access'
-    details = [ordered]@{
-        bootstrapExit         = $runExit
-        smokerunFired         = $smokerunFired
-        smokerunPassed        = $smokerunPassed
-        honestHintFired       = $honestHintFired
-        misleadingHintAbsent  = $misleadingHintAbsent
-        hintCorrect           = $hintCorrect
-        xfailPass             = $xfailPass
-        log                   = $bootstrapLog
-    }
-})
+if ($scenario -eq 'mei_substring') {
+    Write-NdjsonRow ([ordered]@{
+        id      = 'self.exe.smokerun.exedata.xfail'
+        req     = 'REQ-003'
+        pass    = $xfailPass
+        desc    = 'EXE smokerun XFAIL: missing data file (name coincidentally contains _MEI+digits) causes non-zero exit (expected failure); hint text stays honest, not misled by the substring'
+        details = [ordered]@{
+            scenario              = $scenario
+            bootstrapExit         = $runExit
+            smokerunFired         = $smokerunFired
+            smokerunPassed        = $smokerunPassed
+            honestHintFired       = $honestHintFired
+            misleadingHintAbsent  = $misleadingHintAbsent
+            hintCorrect           = $hintCorrect
+            xfailPass             = $xfailPass
+            log                   = $bootstrapLog
+        }
+    })
+} else {
+    Write-NdjsonRow ([ordered]@{
+        id      = 'self.exe.smokerun.exedata.xfail'
+        req     = 'REQ-003'
+        pass    = $xfailPass
+        desc    = 'EXE smokerun XFAIL: missing data file causes non-zero exit (expected failure); hint text is honest about --add-data not fixing a CWD-relative access'
+        details = [ordered]@{
+            scenario              = $scenario
+            bootstrapExit         = $runExit
+            smokerunFired         = $smokerunFired
+            smokerunPassed        = $smokerunPassed
+            honestHintFired       = $honestHintFired
+            misleadingHintAbsent  = $misleadingHintAbsent
+            hintCorrect           = $hintCorrect
+            xfailPass             = $xfailPass
+            log                   = $bootstrapLog
+        }
+    })
+}
 
 if (-not $xfailPass) { exit 1 }
 exit 0


### PR DESCRIPTION
## Summary

CLAUDE.md's Active Backlog Item 38 (the run-1-vs-run-2 CWD verification mismatch) named a fix that stands independently of the item's still-undecided CWD-unification design question: `:exe_smokerun_hints`' `DATA_FILE` hint unconditionally suggested `--add-data` for any detected missing-data-file error -- but `--add-data` only bundles a file into the onefile extraction folder (`_MEIxxxxxx` under TEMP), never the current working directory. For the common beginner pattern (a bare `open("config.json")`, CWD-relative), that advice cannot actually fix the failure at all.

- `:exe_smokerun_hints` now branches on whether the captured missing-file path is already under a `_MEIxxxxxx` folder (checked via a quoted `findstr /i "_MEI"`, per the established "quote a variable before piping into findstr" rule): when it is, `--add-data` genuinely is the fix and the original advice is unchanged; when it's a bare/CWD-relative path, the hint now says `--add-data` will not fix it and suggests placing a copy next to the built `.exe` instead, or reading it via a path relative to the script's own file.
- Extends `tests/selfapps_exedata_fail.ps1` (`self.exe.smokerun.exedata.xfail`, real/conda-full lanes) -- its stub app already does exactly the bare-relative-path `open("config.json")` case -- to assert the honest wording fires and the old unconditional `--add-data config.json` suggestion does not.
- Updates CLAUDE.md's Item 38 entry to record this half of the fix as closed, while leaving the CWD-unification design decision (which of the two verification points' CWDs is "correct") and its own coverage gap (a second-run assertion) open and unchanged.

Does not touch or decide the CWD-mismatch question itself -- the advice is honest either way that gets resolved later. Purely additive/corrective to hint text and its branch logic.

## Verification

- `tools/run_sanity_sweep.sh run_setup.bat tests/selfapps_exedata_fail.ps1 CLAUDE.md` -- all checks pass (compileall, pyflakes, delimiter check, CRLF check, markdownlint, yamllint, actionlint, ASCII sweep, PowerShell AST parse sweep, full pytest: 553 passed / 3 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017SQ1rvJxDbE71pTXJ4QvLV

---
_Generated by [Claude Code](https://claude.ai/code/session_017SQ1rvJxDbE71pTXJ4QvLV)_