### PR TITLE
Register Item 42 lever 2 as an open question for the maintainer

### DIFF
--- a/docs/open-questions.md
+++ b/docs/open-questions.md
@@ -103,3 +103,42 @@ Without an answer, Item 35's own soak-then-promote slices can get PREPARED (impl
 several green runs) but never actually CLOSED -- the last step structurally can't happen without
 this.
 
+## 5. CLAUDE.md Active Backlog Item 42, lever 2: is the two-prompt fresh-build flow still worth changing, and if so, reword only or also combine the two prompts?
+
+Lever 1 (console-output tiering) shipped and merged 2026-08-24 (PR #466). Lever 2 -- the two
+elective Y/N prompts every successful fresh interactive build shows (`:run_postexec_checkpoint`'s
+"Run again via the interpreter now?" and `:offer_optimized_build`'s "Want to build an optimized
+version too?") -- remains untouched, per the item's own explicit scoping of lever 1 and lever 2 as
+"two independent, separately-implementable levers -- do not conflate them into one change."
+
+Re-reading both prompts' CURRENT wording directly against source (`run_setup.bat`, `:run_
+postexec_checkpoint`/`:offer_optimized_build`) before filing this: both already carry a plain-
+language one-line rationale before the Y/N line itself (the checkpoint: "You can run your program
+again now via the interpreter as an extra diagnostic check."; the optimized build: "It takes a bit
+longer to build right now, but it starts up more reliably on Windows and runs faster once it is
+built."). This is not the same wording the original 2026-08-14 audit was reacting to -- whether
+that's because it was already improved in an intervening pass, or the audit's own phrasing was
+simply summarizing rather than quoting verbatim, was not tracked down. Neither prompt currently
+uses an explicit "(optional, safe to skip)"-style cue.
+
+**Two open sub-questions, neither pre-decided:**
+- Given the current wording already states a concrete, comprehensible tradeoff for each prompt
+  (not jargon like "Visual Studio Build Tools" -- that phrase only appears in a `[WARN]`-tier
+  post-FAILURE hint, shown to a small subset of users who hit a build error, not in either prompt
+  itself), is there still a real gap to close here, or has this already been substantially
+  addressed by wording that evolved separately from this item? If still worth doing, is the
+  remaining ask as small as adding an explicit "(optional)" cue to both prompts, or something more?
+- Should the two prompts stay separate (matching each prompt's own distinct consent-gate mechanism
+  and existing test coverage -- `self.checkpoint.accept`/`.decline`, `self.optbuild.offer`'s 4
+  scenarios) with wording-only changes, or should they be combined into a single ask as the item's
+  own original text floated ("consider combining them into a single, clearly-optional ask")? 
+  Combining is a materially bigger change (restructures which subroutine owns the prompt, how
+  declining one but not the other is expressed, and every test that currently asserts prompt COUNT
+  or exact prompt text) than a pure reword, with real risk of a maintainer having a specific
+  preference on exactly how the combined flow should read.
+
+**Needs the maintainer's call** -- unlike lever 1 (a single, objectively-correct technical
+mechanism: hide diagnostic-tier lines, keep them in the log, add an opt-in flag), lever 2 is
+user-facing copy and interaction flow, where a wrong unilateral guess costs a maintainer real
+rework rather than just being "one valid implementation among several."
+


### PR DESCRIPTION
## Summary

Pure documentation housekeeping, no functional or test change.

CLAUDE.md Active Backlog Item 42's lever 1 (console-output tiering) shipped and merged in PR #466. Lever 2 (the two elective Y/N prompts a fresh interactive build shows -- `:run_postexec_checkpoint`'s "Run again via the interpreter now?" and `:offer_optimized_build`'s "Want to build an optimized version too?") is the remaining piece.

Re-reading both prompts' current wording directly against `run_setup.bat` before filing this: both already carry a plain-language rationale line before the Y/N prompt itself, and the jargon term the original audit called out ("Visual Studio Build Tools") only appears in a `[WARN]`-tier post-failure hint, not in either prompt. So the remaining question is genuinely open-ended:

- Is there still a real gap here, or has this already been substantially addressed by wording that evolved separately from the item's own filing?
- If something is still worth doing, should it stay a small, additive reword (e.g. an explicit "(optional)" cue) on the two existing, separately-tested prompts, or should the two prompts be combined into one ask (a materially bigger restructuring touching prompt count, existing test coverage, and how declining is expressed)?

Unlike lever 1 (a single, objectively-correct technical mechanism), this is user-facing copy and interaction flow -- the kind of call where a wrong unilateral guess costs the maintainer real rework rather than being one valid implementation among several. Registered as a new numbered question in `docs/open-questions.md`, matching this repo's own "a blocked item needs a registered, traceable question" house rule (see the other 4 entries already there for Items 35/38/46).

## Verification

`tools/run_sanity_sweep.sh` -- all checks pass (compileall, pyflakes, delimiter check, CRLF check, markdownlint, yamllint, actionlint, ASCII sweep, PowerShell AST parse sweep, full pytest: 563 passed / 3 skipped). Diff touches only `docs/open-questions.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_017SQ1rvJxDbE71pTXJ4QvLV)_