### PR TITLE
Move NDJSON registry out of auto-load; reword the two fresh-build prompts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,11 +9,13 @@ working in this repository. It summarizes structure, workflows, and conventions.
 - **[CONTRIBUTING.md](./CONTRIBUTING.md)** -- Fork/branch/PR workflow and iteration priorities
 
 **Supplemental context loaded automatically by Claude Code:**
-@docs/agent-ndjson.md
 @docs/agent-interconnect.md
 @docs/agent-lessons-learned.md
 
 **Reference-only, NOT auto-loaded -- read on demand, not every session:**
+- `docs/agent-ndjson.md` -- the NDJSON row registry by lane. Read it when adding/renaming/removing
+  a row, or debugging why a row is missing from a CI artifact. Moved out of auto-load 2026-08-30
+  (~17k tokens of pure registry content with no forward-looking guidance most sessions need).
 - `docs/agent-cold-storage.md` -- shelved ideas gated on a specific, checkable trigger.
 - `docs/agent-closed-backlog.md` -- the full historical record of completed work, plus any
   Active Backlog item below that was later fully closed (see that file's own header).
@@ -24,7 +26,8 @@ appending):
 - `docs/agent-interconnect.md` -- cross-component dependencies ("touch A, must understand B").
 - `docs/agent-lessons-learned.md` -- standalone hazards, rules, budgets, procedures. Most are
   batch/CMD syntax quirks and Windows shell gotchas; record those here.
-- `docs/agent-ndjson.md` -- the NDJSON row registry (add/rename/remove rows here too).
+- `docs/agent-ndjson.md` -- the NDJSON row registry (add/rename/remove rows here too; NOT
+  auto-loaded, read it on demand when touching this).
 - When an Active Backlog item is fully resolved, move it out of this file entirely into
   `docs/agent-closed-backlog.md`'s "Closed Active Backlog Items" section (keep its original
   number). Do not let a closed item linger here -- this file's size is a per-session cost.
@@ -82,7 +85,7 @@ tools/
 docs/
   agent-interconnect.md        Cross-component dependency map (loaded via @ import)
   agent-lessons-learned.md     Standalone hazards/rules/quirks/procedures (loaded via @ import)
-  agent-ndjson.md              NDJSON row registry by lane (loaded via @ import)
+  agent-ndjson.md              NDJSON row registry by lane (NOT auto-loaded)
   agent-closed-backlog.md      Full historical record of completed work (NOT auto-loaded)
   agent-cold-storage.md        Shelved ideas gated on a trigger (NOT auto-loaded)
   agent-scratchlog.md          Internal working notes, freely prunable (NOT auto-loaded)
@@ -638,39 +641,6 @@ but several represent real gaps worth closing before calling the path fully rele
   TWICE with `state:"repaired"` in one run. One confirmed run is not yet the "several consecutive
   runs" Item 35's process requires before considering promotion -- that decision is a live next
   step for a future loop.
-
-- **Item 42: console verbosity (lever 1) is CLOSED (2026-08-24); the two fresh-build Y/N prompts
-  (lever 2) remain open, tracked in `docs/open-questions.md`.** Two independent, separately-
-  implementable levers, deliberately not conflated: (1) tier `:log`'s console output so a beginner
-  isn't shown `[DEBUG]`/`[TRACE]` noise alongside genuinely actionable `[WARN]`/`[ERROR]` text; (2)
-  reduce/reword the two elective Y/N prompts every successful fresh interactive build shows (the
-  post-execution checkpoint, and the optimized-build upsell whose failure hint references "Visual
-  Studio Build Tools" -- meaningless to the target audience).
-
-  **Lever 1, shipped**: `:log` now suppresses `[DEBUG]`/`[TRACE]`/`[INSTALL]` from the LIVE console
-  by default (a substring-slice check inside `:log` itself, not `findstr`/piping -- message text
-  can legally contain `&`); `[INFO]`/`[BOOT]`/`[WARN]`/`[ERROR]`/`[STATUS]`/`[REPAIR]`/`[HINT]`
-  stay visible (`[STATUS]` is the "did my code work" readout; `[REPAIR]` explains why a build is
-  taking longer without looking stuck; `[HINT]` is the most actionable post-failure text in the
-  file). `~setup.log` is untouched -- suppression is console-only. New opt-in `HP_VERBOSE_CONSOLE=1`
-  restores all three suppressed tags (REQ-019-compliant additive opt-in), documented in README.md.
-  A companion `[INFO] Installing dependencies -- this may take a few minutes...` progress line was
-  added for what was previously the single longest silent stretch in a fresh build (no prior
-  `[INFO]`-tier line existed for the dependency-install phase at all).
-  Four test dependencies on the OLD console-redirected-capture behavior were found and fixed in the
-  same change (`tests/selfapps_pvw_overrides.ps1`'s two `PVW_WORKSPACE` scenarios,
-  `tests/selftest.ps1`'s `self.stub.conda_perpkg`/`self.stub.conda_retry`) -- the last one caught
-  only by a real CI failure after an initial grep-for-brackets sweep missed it, since its own
-  assertion matches a bracket-free phrase. A follow-up exhaustive sweep (every real `[DEBUG]`/
-  `[TRACE]`/`[INSTALL]` message body grepped bracket-free against the full `tests/` tree) confirmed
-  no fifth dependency remains -- the correct methodology for this class of check going forward is
-  searching by message body, not by tag string. New regression coverage:
-  `tests/selfapps_console_tiering.ps1` (`self.console.tiering`, `uv` lane, non-gating).
-
-  **Lever 2, still open** -- this is user-facing copy and interaction-flow work needing a
-  maintainer call (reword only vs. also combine the two prompts into one), not a unilaterally-
-  correct technical fix like lever 1 was. See `docs/open-questions.md`'s open item for the two
-  concrete sub-questions still needing an answer before this can move.
 
 - **Item 46: `:die`'s `exit /b` lets most call sites continue executing afterward, producing
   repeated `pause` prompts and further doomed work instead of a single clear stop -- batched,

--- a/docs/agent-closed-backlog.md
+++ b/docs/agent-closed-backlog.md
@@ -1,9 +1,9 @@
 # Agent Closed Backlog -- Python_vs_Windows
 
 **This file is NOT auto-loaded into every session's context** (unlike
-`docs/agent-lessons-learned.md`, `docs/agent-interconnect.md`, and
-`docs/agent-ndjson.md`, which CLAUDE.md's own
-`@import` lines pull in automatically). Read it on demand: when CLAUDE.md's own pointer sends you
+`docs/agent-lessons-learned.md` and `docs/agent-interconnect.md`, which CLAUDE.md's own
+`@import` lines pull in automatically -- `docs/agent-ndjson.md` joined this file in that regard
+2026-08-30). Read it on demand: when CLAUDE.md's own pointer sends you
 here, when you need the full resolution history behind a specific PR/item cited by number, or
 when investigating something that "feels like it was already done" and you want the receipt.
 
@@ -3201,6 +3201,55 @@ subroutine is touched.
 
 Confirmed via PR #470's own green CI run and merge -- `self.exe.smokerun.cwd_consistency` and the
 updated `self.exe.smokerun.exedata.xfail` scenarios both pass for real.
+
+### Item 42 (lever 1 closed 2026-08-24; lever 2 closed 2026-08-30; moved here 2026-08-30)
+
+- **Console verbosity (lever 1) and the two fresh-build Y/N prompts' wording (lever 2) are both
+  CLOSED.** Two independent, separately-implementable levers, deliberately not conflated: (1) tier
+  `:log`'s console output so a beginner isn't shown `[DEBUG]`/`[TRACE]` noise alongside genuinely
+  actionable `[WARN]`/`[ERROR]` text; (2) reduce/reword the two elective Y/N prompts every
+  successful fresh interactive build shows (the post-execution checkpoint, and the optimized-build
+  upsell whose failure hint references "Visual Studio Build Tools" -- meaningless to the target
+  audience).
+
+  **Lever 1, shipped**: `:log` now suppresses `[DEBUG]`/`[TRACE]`/`[INSTALL]` from the LIVE console
+  by default (a substring-slice check inside `:log` itself, not `findstr`/piping -- message text
+  can legally contain `&`); `[INFO]`/`[BOOT]`/`[WARN]`/`[ERROR]`/`[STATUS]`/`[REPAIR]`/`[HINT]`
+  stay visible (`[STATUS]` is the "did my code work" readout; `[REPAIR]` explains why a build is
+  taking longer without looking stuck; `[HINT]` is the most actionable post-failure text in the
+  file). `~setup.log` is untouched -- suppression is console-only. New opt-in `HP_VERBOSE_CONSOLE=1`
+  restores all three suppressed tags (REQ-019-compliant additive opt-in), documented in README.md.
+  A companion `[INFO] Installing dependencies -- this may take a few minutes...` progress line was
+  added for what was previously the single longest silent stretch in a fresh build (no prior
+  `[INFO]`-tier line existed for the dependency-install phase at all).
+  Four test dependencies on the OLD console-redirected-capture behavior were found and fixed in the
+  same change (`tests/selfapps_pvw_overrides.ps1`'s two `PVW_WORKSPACE` scenarios,
+  `tests/selftest.ps1`'s `self.stub.conda_perpkg`/`self.stub.conda_retry`) -- the last one caught
+  only by a real CI failure after an initial grep-for-brackets sweep missed it, since its own
+  assertion matches a bracket-free phrase. A follow-up exhaustive sweep (every real `[DEBUG]`/
+  `[TRACE]`/`[INSTALL]` message body grepped bracket-free against the full `tests/` tree) confirmed
+  no fifth dependency remains -- the correct methodology for this class of check going forward is
+  searching by message body, not by tag string. New regression coverage:
+  `tests/selfapps_console_tiering.ps1` (`self.console.tiering`, `uv` lane, non-gating).
+
+  **Lever 2, shipped (maintainer decision 2026-08-30)**: keep the two prompts SEPARATE (matching
+  each prompt's own distinct consent-gate mechanism and existing test coverage --
+  `self.checkpoint.accept`/`.decline`, `self.optbuild.offer`'s 4 scenarios) rather than combine
+  them into one ask, resolving both of `docs/open-questions.md`'s former sub-questions (entry now
+  removed -- answered, not just re-scoped). The fix was exactly as small as the "is the remaining
+  ask as small as adding an explicit (optional) cue" sub-question floated: `:run_postexec_
+  checkpoint`'s existing one-line rationale now ends "...as an extra diagnostic check. (Optional)";
+  `:offer_optimized_build`'s now ends "...runs faster once it is built. (Optional, safe to skip)".
+  Neither prompt's own Y/N line changed (`Run again via the interpreter now? [Y/N]` /
+  `Build the optimized version now? [Y/N]` were already exactly this wording). `:run_postexec_
+  checkpoint`'s header comment also gained an explanation of WHY this diagnostic is worth offering
+  even after a reported SUCCESS: the first run's exit code 0 is not 100% confirmation the app
+  actually worked correctly -- a frozen EXE can differ from source in bundled resources, DLL
+  binding, etc. (see "Honest ambiguous-exit messaging" in `docs/agent-interconnect.md`) -- so the
+  interpreter path is generally the more reliable one to catch a real problem the EXE's own exit
+  code alone would not surface. No test depended on the exact old wording (only substring matches
+  on `Verification finished...`/`Want to build an optimized version too?`, both untouched by this
+  change); `docs/demo-bootstrapper-output.md`'s transcript excerpts were updated to match.
 
 ## Known Findings (diagnosed, no action warranted)
 

--- a/docs/agent-closed-backlog.md
+++ b/docs/agent-closed-backlog.md
@@ -2,8 +2,8 @@
 
 **This file is NOT auto-loaded into every session's context** (unlike
 `docs/agent-lessons-learned.md` and `docs/agent-interconnect.md`, which CLAUDE.md's own
-`@import` lines pull in automatically -- `docs/agent-ndjson.md` joined this file in that regard
-2026-08-30). Read it on demand: when CLAUDE.md's own pointer sends you
+`@import` lines pull in automatically; `docs/agent-ndjson.md` was removed from auto-load on
+2026-08-30). Read it on demand when CLAUDE.md's own pointer sends you
 here, when you need the full resolution history behind a specific PR/item cited by number, or
 when investigating something that "feels like it was already done" and you want the receipt.
 

--- a/docs/agent-cold-storage.md
+++ b/docs/agent-cold-storage.md
@@ -1,8 +1,7 @@
 # Agent Cold Storage -- Python_vs_Windows
 
 **This file is NOT auto-loaded into every session's context** (unlike
-`docs/agent-lessons-learned.md`, `docs/agent-interconnect.md`, and
-`docs/agent-ndjson.md`, which CLAUDE.md's own
+`docs/agent-lessons-learned.md` and `docs/agent-interconnect.md`, which CLAUDE.md's own
 `@import` lines pull in automatically). Read it on demand: when CLAUDE.md's own pointer below
 sends you here, or when you're about to propose something that might already be a deliberately-
 shelved idea worth checking against first.

--- a/docs/agent-ndjson.md
+++ b/docs/agent-ndjson.md
@@ -1,7 +1,12 @@
 # NDJSON Surface -- Python_vs_Windows
 
-This file is loaded automatically by Claude Code via the `@docs/agent-ndjson.md`
-import in CLAUDE.md. It lists all known NDJSON rows by lane and test source.
+**This file is NOT auto-loaded into every session's context** (unlike
+`docs/agent-lessons-learned.md` and `docs/agent-interconnect.md`, which CLAUDE.md's own `@import`
+lines pull in automatically -- moved out of auto-load 2026-08-30, ~17k tokens of pure registry
+content with no forward-looking guidance most sessions need). Read it on demand: when adding,
+renaming, or removing an NDJSON row, or debugging why a row is missing from a CI artifact.
+
+It lists all known NDJSON rows by lane and test source.
 
 The diagnostics site is the authoritative source of truth for live row counts:
 https://mixmansoundude.github.io/Python_vs_Windows/

--- a/docs/demo-bootstrapper-output.md
+++ b/docs/demo-bootstrapper-output.md
@@ -467,12 +467,12 @@ below is unmodified real capture):
 
 ```
 *** Verification finished -- see the Run Status above. ***
-*** You can run your program again now via the interpreter as an extra diagnostic check. ***
+*** You can run your program again now via the interpreter as an extra diagnostic check. (Optional) ***
 Tue 07/28/2026  4:55:59.91 [INFO] REQ-018: post-execution checkpoint (exe): declined (run footprint stays at one execution).
 
 *** Your app is ready. ***
 *** Want to build an optimized version too? It takes a bit longer to build right now, ***
-*** but it starts up more reliably on Windows and runs faster once it is built. ***
+*** but it starts up more reliably on Windows and runs faster once it is built. (Optional, safe to skip) ***
 Tue 07/28/2026  4:55:59.94 [INFO] Optimized build: declined.
 
 ============================================================
@@ -579,7 +579,7 @@ sees:
 
 ```
 *** Verification finished -- see the Run Status above. ***
-*** You can run your program again now via the interpreter as an extra diagnostic check. ***
+*** You can run your program again now via the interpreter as an extra diagnostic check. (Optional) ***
   Run again via the interpreter now? [Y/N] _
 ```
 
@@ -592,7 +592,7 @@ continues to the second prompt:
 ```
 *** Your app is ready. ***
 *** Want to build an optimized version too? It takes a bit longer to build right now, ***
-*** but it starts up more reliably on Windows and runs faster once it is built. ***
+*** but it starts up more reliably on Windows and runs faster once it is built. (Optional, safe to skip) ***
   Build the optimized version now? [Y/N] _
 ```
 
@@ -2450,7 +2450,7 @@ hello-from-stub
 [STATUS] Run Status: SUCCESS (Exit Code: 0)
 
 *** Verification finished -- see the Run Status above. ***
-*** You can run your program again now via the interpreter as an extra diagnostic check. ***
+*** You can run your program again now via the interpreter as an extra diagnostic check. (Optional) ***
   Run again via the interpreter now? [Y/N] _
 ```
 
@@ -2465,7 +2465,7 @@ the final panel:
 
 *** Your app is ready. ***
 *** Want to build an optimized version too? It takes a bit longer to build right now, ***
-*** but it starts up more reliably on Windows and runs faster once it is built. ***
+*** but it starts up more reliably on Windows and runs faster once it is built. (Optional, safe to skip) ***
 [INFO] Optimized build: declined.
 
 ============================================================
@@ -2599,7 +2599,7 @@ Creating Python environment '<env>' -- this may take several minutes...
 [STATUS] Run Status: SUCCESS (Exit Code: 0)
 
 *** Verification finished -- see the Run Status above. ***
-*** You can run your program again now via the interpreter as an extra diagnostic check. ***
+*** You can run your program again now via the interpreter as an extra diagnostic check. (Optional) ***
   Run again via the interpreter now? [Y/N] _
 ```
 
@@ -2611,7 +2611,7 @@ Branch]` for this specific re-entry, not a separate real capture) reaches the sa
 
 *** Your app is ready. ***
 *** Want to build an optimized version too? It takes a bit longer to build right now, ***
-*** but it starts up more reliably on Windows and runs faster once it is built. ***
+*** but it starts up more reliably on Windows and runs faster once it is built. (Optional, safe to skip) ***
 [INFO] Optimized build: declined.
 
 ============================================================
@@ -2725,7 +2725,7 @@ longer silent on success; everything else in this panel is the original, unmodif
 [STATUS] Run Status: SUCCESS (Exit Code: 0)
 
 *** Verification finished -- see the Run Status above. ***
-*** You can run your program again now via the interpreter as an extra diagnostic check. ***
+*** You can run your program again now via the interpreter as an extra diagnostic check. (Optional) ***
   Run again via the interpreter now? [Y/N] _
 ```
 
@@ -2737,7 +2737,7 @@ final panel:
 
 *** Your app is ready. ***
 *** Want to build an optimized version too? It takes a bit longer to build right now, ***
-*** but it starts up more reliably on Windows and runs faster once it is built. ***
+*** but it starts up more reliably on Windows and runs faster once it is built. (Optional, safe to skip) ***
 [INFO] Optimized build: declined.
 
 ============================================================
@@ -2844,7 +2844,7 @@ print('colorama via importlib ok:', _mod.__name__)
 [STATUS] Run Status: SUCCESS (Exit Code: 0)
 
 *** Verification finished -- see the Run Status above. ***
-*** You can run your program again now via the interpreter as an extra diagnostic check. ***
+*** You can run your program again now via the interpreter as an extra diagnostic check. (Optional) ***
   Run again via the interpreter now? [Y/N] _
 ```
 
@@ -2856,7 +2856,7 @@ Declining (same provider-agnostic building blocks as Scenario 32's own ending, s
 
 *** Your app is ready. ***
 *** Want to build an optimized version too? It takes a bit longer to build right now, ***
-*** but it starts up more reliably on Windows and runs faster once it is built. ***
+*** but it starts up more reliably on Windows and runs faster once it is built. (Optional, safe to skip) ***
 [INFO] Optimized build: declined.
 
 ============================================================
@@ -3028,7 +3028,7 @@ The system cannot find the drive specified.
 [STATUS] Run Status: SUCCESS (Exit Code: 0)
 
 *** Verification finished -- see the Run Status above. ***
-*** You can run your program again now via the interpreter as an extra diagnostic check. ***
+*** You can run your program again now via the interpreter as an extra diagnostic check. (Optional) ***
 [INFO] REQ-018: post-execution checkpoint (exe): declined (run footprint stays at one execution).
 ```
 
@@ -3170,7 +3170,7 @@ code path that announces either one, so both are omitted below (see 38a's note f
 [STATUS] Run Status: SUCCESS (Exit Code: 0)
 
 *** Verification finished -- see the Run Status above. ***
-*** You can run your program again now via the interpreter as an extra diagnostic check. ***
+*** You can run your program again now via the interpreter as an extra diagnostic check. (Optional) ***
 [INFO] REQ-018: post-execution checkpoint (interpreter): declined (run footprint stays at one execution).
 ```
 
@@ -3247,12 +3247,12 @@ The system cannot find the drive specified.
 [STATUS] Run Status: SUCCESS (Exit Code: 0)
 
 *** Verification finished -- see the Run Status above. ***
-*** You can run your program again now via the interpreter as an extra diagnostic check. ***
+*** You can run your program again now via the interpreter as an extra diagnostic check. (Optional) ***
 [INFO] REQ-018: post-execution checkpoint (exe): declined (run footprint stays at one execution).
 
 *** Your app is ready. ***
 *** Want to build an optimized version too? It takes a bit longer to build right now, ***
-*** but it starts up more reliably on Windows and runs faster once it is built. ***
+*** but it starts up more reliably on Windows and runs faster once it is built. (Optional, safe to skip) ***
 [INFO] Optimized build: accepted; building now (this may take a minute or two).
 [INFO] Optimized build succeeded and verified: dist\<env>.exe now uses the fallback build system.
 ```
@@ -3281,7 +3281,7 @@ five failure branches fired; the rest of this capture is real,
 ```
 *** Your app is ready. ***
 *** Want to build an optimized version too? It takes a bit longer to build right now, ***
-*** but it starts up more reliably on Windows and runs faster once it is built. ***
+*** but it starts up more reliably on Windows and runs faster once it is built. (Optional, safe to skip) ***
 [INFO] Optimized build: accepted; building now (this may take a minute or two).
 [WARN] Optimized build did not complete; your app is still ready to use as-is.
 [INFO] REQ-016: Post-flight briefing printed.
@@ -3298,7 +3298,7 @@ since this scenario has passed on every run so far):
 ```
 *** Your app is ready. ***
 *** Want to build an optimized version too? It takes a bit longer to build right now, ***
-*** but it starts up more reliably on Windows and runs faster once it is built. ***
+*** but it starts up more reliably on Windows and runs faster once it is built. (Optional, safe to skip) ***
 [INFO] Optimized build: accepted; building now (this may take a minute or two).
 [WARN] Optimized build verified successfully but could not be swapped into place; your app is still ready to use as-is.
 ```
@@ -3310,7 +3310,7 @@ Real, verbatim console dump (`~selftest_optbuild_decline\~optbuild_decline_boots
 ```
 *** Your app is ready. ***
 *** Want to build an optimized version too? It takes a bit longer to build right now, ***
-*** but it starts up more reliably on Windows and runs faster once it is built. ***
+*** but it starts up more reliably on Windows and runs faster once it is built. (Optional, safe to skip) ***
 [INFO] Optimized build: declined.
 [INFO] REQ-016: Post-flight briefing printed.
 ```
@@ -3689,12 +3689,12 @@ With every gap now resolved, the EXE finally verifies clean and the run complete
 [STATUS] Run Status: SUCCESS (Exit Code: 0)
 
 *** Verification finished -- see the Run Status above. ***
-*** You can run your program again now via the interpreter as an extra diagnostic check. ***
+*** You can run your program again now via the interpreter as an extra diagnostic check. (Optional) ***
 [INFO] REQ-018: post-execution checkpoint (exe): declined (run footprint stays at one execution).
 
 *** Your app is ready. ***
 *** Want to build an optimized version too? It takes a bit longer to build right now, ***
-*** but it starts up more reliably on Windows and runs faster once it is built. ***
+*** but it starts up more reliably on Windows and runs faster once it is built. (Optional, safe to skip) ***
 [INFO] Optimized build: declined.
 
 ============================================================

--- a/docs/open-questions.md
+++ b/docs/open-questions.md
@@ -7,41 +7,5 @@ here and fold the outcome into wherever it actually belongs (CLAUDE.md's Active/
 answered questions accumulate here as history; that's what the other docs' own Closed Backlog /
 changelog-style sections are for.
 
-## 1. CLAUDE.md Active Backlog Item 42, lever 2: is the two-prompt fresh-build flow still worth changing, and if so, reword only or also combine the two prompts?
-
-Lever 1 (console-output tiering) shipped and merged 2026-08-24 (PR #466). Lever 2 -- the two
-elective Y/N prompts every successful fresh interactive build shows (`:run_postexec_checkpoint`'s
-"Run again via the interpreter now?" and `:offer_optimized_build`'s "Want to build an optimized
-version too?") -- remains untouched, per the item's own explicit scoping of lever 1 and lever 2 as
-"two independent, separately-implementable levers -- do not conflate them into one change."
-
-Re-reading both prompts' CURRENT wording directly against source (`run_setup.bat`, `:run_
-postexec_checkpoint`/`:offer_optimized_build`) before filing this: both already carry a plain-
-language one-line rationale before the Y/N line itself (the checkpoint: "You can run your program
-again now via the interpreter as an extra diagnostic check."; the optimized build: "It takes a bit
-longer to build right now, but it starts up more reliably on Windows and runs faster once it is
-built."). This is not the same wording the original 2026-08-14 audit was reacting to -- whether
-that's because it was already improved in an intervening pass, or the audit's own phrasing was
-simply summarizing rather than quoting verbatim, was not tracked down. Neither prompt currently
-uses an explicit "(optional, safe to skip)"-style cue.
-
-**Two open sub-questions, neither pre-decided:**
-- Given the current wording already states a concrete, comprehensible tradeoff for each prompt
-  (not jargon like "Visual Studio Build Tools" -- that phrase only appears in a `[WARN]`-tier
-  post-FAILURE hint, shown to a small subset of users who hit a build error, not in either prompt
-  itself), is there still a real gap to close here, or has this already been substantially
-  addressed by wording that evolved separately from this item? If still worth doing, is the
-  remaining ask as small as adding an explicit "(optional)" cue to both prompts, or something more?
-- Should the two prompts stay separate (matching each prompt's own distinct consent-gate mechanism
-  and existing test coverage -- `self.checkpoint.accept`/`.decline`, `self.optbuild.offer`'s 4
-  scenarios) with wording-only changes, or should they be combined into a single ask as the item's
-  own original text floated ("consider combining them into a single, clearly-optional ask")?
-  Combining is a materially bigger change (restructures which subroutine owns the prompt, how
-  declining one but not the other is expressed, and every test that currently asserts prompt COUNT
-  or exact prompt text) than a pure reword, with real risk of a maintainer having a specific
-  preference on exactly how the combined flow should read.
-
-**Needs the maintainer's call** -- unlike lever 1 (a single, objectively-correct technical
-mechanism: hide diagnostic-tier lines, keep them in the log, add an opt-in flag), lever 2 is
-user-facing copy and interaction flow, where a wrong unilateral guess costs a maintainer real
-rework rather than just being "one valid implementation among several."
+**No open questions right now.** (Last answered: CLAUDE.md Active Backlog Item 42 lever 2's
+prompt-wording question, 2026-08-30 -- see `docs/agent-closed-backlog.md`'s Item 42 entry.)

--- a/run_setup.bat
+++ b/run_setup.bat
@@ -3310,8 +3310,13 @@ exit /b 0
 rem REQ-018 (2b-C): post-execution checkpoint. The FIRST run (EXE smoke or no-EXE interpreter
 rem run) has already happened and its [STATUS] telemetry has already been printed by the time
 rem this is called -- this offers an ELECTIVE second run via the interpreter as a diagnostic
-rem tool, never forced. Declining (the default, and the only outcome in CI/automation) leaves
-rem the run footprint at exactly one execution. Called unconditionally after every verification
+rem tool, never forced. Worth offering even after a reported SUCCESS: the first run's exit code 0
+rem is not 100% confirmation the app actually worked correctly -- a frozen EXE can differ from
+rem source in bundled resources, DLL binding, etc., see "Honest ambiguous-exit messaging" in
+rem docs/agent-interconnect.md. The interpreter path is generally the more reliable one to catch a
+rem real problem the EXE's own exit code alone would not surface. Declining (the default and only
+rem outcome in CI/automation) leaves the run footprint at exactly one execution. Called
+rem unconditionally after every verification
 rem telemetry point (never after :try_fast_exe's fast-path reuse, which stays zero-friction by
 rem design -- see docs/agent-interconnect.md). %1 is a short site tag ('exe'|'interpreter') used
 rem only for the log lines below, so a reader can tell which verification path preceded this.
@@ -3331,7 +3336,7 @@ rem learned.md "Accepted gap"), would hang on set /p with no console input avail
 set "HP_CHECKPOINT_SITE=%~1"
 echo.
 echo *** Verification finished -- see the Run Status above. ***
-echo *** You can run your program again now via the interpreter as an extra diagnostic check. ***
+echo *** You can run your program again now via the interpreter as an extra diagnostic check. (Optional) ***
 set "HP_CHECKPOINT_RAW="
 if defined HP_TEST_CHECKPOINT_ANSWER (
   set "HP_CHECKPOINT_RAW=%HP_TEST_CHECKPOINT_ANSWER%"
@@ -3407,7 +3412,7 @@ if not "%HP_EXE_EXIT%"=="0" exit /b 0
 echo.
 echo *** Your app is ready. ***
 echo *** Want to build an optimized version too? It takes a bit longer to build right now, ***
-echo *** but it starts up more reliably on Windows and runs faster once it is built. ***
+echo *** but it starts up more reliably on Windows and runs faster once it is built. (Optional, safe to skip) ***
 set "HP_OPTBUILD_RAW="
 if defined HP_TEST_OPTBUILD_ANSWER (
   set "HP_OPTBUILD_RAW=%HP_TEST_OPTBUILD_ANSWER%"


### PR DESCRIPTION
## Summary

- `docs/agent-ndjson.md` is pure registry content (row id -> emitting test/lane) with no
  forward-looking guidance most sessions need, at ~17k tokens of the per-session auto-load
  budget. Moved to reference-only (read on demand when touching an NDJSON row), matching the
  existing `docs/agent-cold-storage.md` / `docs/agent-closed-backlog.md` pattern. Updated the
  three other docs that named it as one of the auto-loaded three.
- Resolves `CLAUDE.md` Active Backlog Item 42 lever 2 (`docs/open-questions.md`'s open item):
  keep the two elective post-build Y/N prompts separate, reword only.
  - `:run_postexec_checkpoint`'s rationale line now ends `...as an extra diagnostic check. (Optional)`.
  - `:offer_optimized_build`'s now ends `...runs faster once it is built. (Optional, safe to skip)`.
  - Neither Y/N line itself changed -- both already read exactly `Run again via the interpreter
    now? [Y/N]` / `Build the optimized version now? [Y/N]`.
  - Also documented, in the checkpoint's own header comment, why this diagnostic is worth
    offering even after a reported SUCCESS: exit code 0 alone is not 100% confirmation the app
    actually worked correctly, so the interpreter path is generally the more reliable one to
    catch a real problem the EXE's exit code wouldn't surface.
- Item 42 moved to `docs/agent-closed-backlog.md` now that both levers are shipped; the
  `docs/open-questions.md` entry is answered and removed.
- `docs/demo-bootstrapper-output.md`'s transcript excerpts updated to match the new wording.

## Test plan

- [x] `tools/run_sanity_sweep.sh` -- all checks pass (compileall, pyflakes, delimiter check
      (including the nested-paren-in-echo/rem hazard on the new comment text), CRLF check,
      markdownlint, yamllint, actionlint, ASCII sweep, PowerShell AST parse, `pytest` 582
      passed/3 skipped).
- [x] Confirmed no test asserts the exact old prompt wording (only substring matches on
      `Verification finished...` / `Want to build an optimized version too?`, both untouched).

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_017SQ1rvJxDbE71pTXJ4QvLV

---
_Generated by [Claude Code](https://claude.ai/code/session_017SQ1rvJxDbE71pTXJ4QvLV)_